### PR TITLE
fix: give SAP_AUTH_TYPE priority over SAP_JWT_TOKEN in test helpers

### DIFF
--- a/src/__tests__/integration/helpers/configHelpers.ts
+++ b/src/__tests__/integration/helpers/configHelpers.ts
@@ -408,15 +408,15 @@ export function getSapConfigFromEnv(): SapConfig {
   }
 
   let authType: SapConfig['authType'] = 'basic';
-  if (process.env.SAP_JWT_TOKEN) {
-    authType = 'jwt';
-  } else if (process.env.SAP_AUTH_TYPE) {
+  if (process.env.SAP_AUTH_TYPE) {
     const raw = process.env.SAP_AUTH_TYPE.trim().toLowerCase();
     if (raw === 'xsuaa') {
       authType = 'jwt';
     } else if (raw === 'basic' || raw === 'jwt' || raw === 'saml') {
       authType = raw;
     }
+  } else if (process.env.SAP_JWT_TOKEN) {
+    authType = 'jwt';
   }
 
   const connectionType: SapConfig['connectionType'] =


### PR DESCRIPTION
## Summary

- `getSapConfigFromEnv()` now checks `SAP_AUTH_TYPE` before `SAP_JWT_TOKEN`
- Fixes onprem basic-auth integration tests failing with "JWT token has expired" when OS environment contains a stale BTP JWT token alongside a basic-auth `.env` file

## Root cause

When `SAP_JWT_TOKEN` was set as an OS-level environment variable (leftover from a BTP/cloud session) and the test loaded an onprem `.env` with `SAP_AUTH_TYPE=basic`, the old priority check picked up `SAP_JWT_TOKEN` first and created a `JwtAbapConnection` — which then failed with an expired token error.

## Test plan

- [x] Run `npm test -- --runTestsByPath src/__tests__/integration/high/program/ProgramHighHandlers.test.ts` against E19 (onprem, basic auth) — passes
- [x] Run `npm test -- --testPathPatterns="integration/high/program" --runInBand --forceExit` against E19 — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)