### PR TITLE
Replace node-rfc with @mcp-abap-adt/sap-rfc-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
-    "node-rfc": "^3.3.1"
+    "@mcp-abap-adt/sap-rfc-lite": "^0.1.0"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/src/lib/config/ServerConfigManager.ts
+++ b/src/lib/config/ServerConfigManager.ts
@@ -263,7 +263,7 @@ AUTHENTICATION:
   --mcp=<destination>              Default MCP destination name (for auth-broker mode)
                                    Example: --mcp=TRIAL
   --connection-type=<type>         SAP connection type: http (default) or rfc
-                                   RFC requires SAP NW RFC SDK + node-rfc installed
+                                   RFC requires SAP NW RFC SDK + @mcp-abap-adt/sap-rfc-lite installed
                                    Alternative: SAP_CONNECTION_TYPE env var in .env
   --system-type=<type>             SAP system type: cloud (default) | onprem | legacy
                                    Controls which tools are available

--- a/src/server/launcher.ts
+++ b/src/server/launcher.ts
@@ -146,7 +146,7 @@ SAP CONNECTION (.env file):
     SAP_USERNAME                   SAP username
     SAP_PASSWORD                   SAP password
     SAP_CLIENT                     SAP client number
-    Requires: SAP NW RFC SDK + node-rfc package installed
+    Requires: SAP NW RFC SDK + @mcp-abap-adt/sap-rfc-lite package installed
 
   System Context (on-premise):
     SAP_MASTER_SYSTEM              SAP system ID (e.g., DEV, QAS). Required for on-prem


### PR DESCRIPTION
## Summary
- Replace `node-rfc` with `@mcp-abap-adt/sap-rfc-lite` in `optionalDependencies`
- Update help text in `launcher.ts` and `ServerConfigManager.ts`

Closes #27

## Test plan
- [ ] Verify RFC connection works with `@mcp-abap-adt/sap-rfc-lite` installed
- [ ] Verify `--help` output shows correct package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)