### PR TITLE
fix: prevent log output from leaking into stdio transport

### DIFF
--- a/src/lib/auth/brokerFactory.ts
+++ b/src/lib/auth/brokerFactory.ts
@@ -30,7 +30,6 @@ import type {
   ITokenProvider,
   ITokenResult,
 } from '@mcp-abap-adt/interfaces';
-import { defaultLogger } from '@mcp-abap-adt/logger';
 import { detectStoreType } from '../stores';
 import { getPlatformPaths } from '../stores/platformPaths';
 import type { IAuthBrokerFactory } from './IAuthBrokerFactory.js';

--- a/src/lib/handlerLogger.ts
+++ b/src/lib/handlerLogger.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module';
 import type { Logger } from '@mcp-abap-adt/logger';
 
 /**
@@ -13,7 +12,7 @@ export function getHandlerLogger(
   if (process.env.HANDLER_LOG_SILENT === 'true') {
     return noopLogger;
   }
-  const resolvedLogger = baseLogger ?? getDefaultLogger();
+  const resolvedLogger = baseLogger ?? noopLogger;
   const prefix = `[${category}]`;
   const wrap = (fn: (msg: string) => void) => (msg: string) =>
     fn(`${prefix} ${msg}`);
@@ -33,9 +32,3 @@ export const noopLogger: Logger = {
   warn: noopFn,
   error: noopFn,
 };
-
-function getDefaultLogger(): Logger {
-  const require = createRequire(__filename);
-  const mod = require('@mcp-abap-adt/logger');
-  return mod.defaultLogger ?? new mod.DefaultLogger();
-}

--- a/src/lib/handlers/HandlerExporter.ts
+++ b/src/lib/handlers/HandlerExporter.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@mcp-abap-adt/logger';
-import { defaultLogger } from '@mcp-abap-adt/logger';
 import type { HandlerContext } from '../../handlers/interfaces.js';
+import { noopLogger } from '../handlerLogger.js';
 import { CompactHandlersGroup } from './groups/CompactHandlersGroup.js';
 import { HighLevelHandlersGroup } from './groups/HighLevelHandlersGroup.js';
 import { LowLevelHandlersGroup } from './groups/LowLevelHandlersGroup.js';
@@ -90,7 +90,7 @@ export class HandlerExporter {
   private readonly handlerGroups: IHandlerGroup[];
 
   constructor(options?: HandlerExporterOptions) {
-    this.logger = options?.logger ?? defaultLogger;
+    this.logger = options?.logger ?? noopLogger;
 
     // Create dummy context for group instantiation
     // Real context is provided by BaseMcpServer.registerHandlers() via getConnection()

--- a/src/server/BaseMcpServer.ts
+++ b/src/server/BaseMcpServer.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module';
 import type { AuthBroker } from '@mcp-abap-adt/auth-broker';
 import {
   type AbapConnection,
@@ -472,7 +471,16 @@ export abstract class BaseMcpServer extends McpServer {
 }
 
 function getDefaultLogger(): Logger {
-  const require = createRequire(__filename);
-  const mod = require('@mcp-abap-adt/logger');
-  return mod.defaultLogger ?? new mod.DefaultLogger();
+  return stderrLogger;
 }
+
+/**
+ * Logger that writes all levels to stderr.
+ * Safe for stdio mode — never writes to stdout (reserved for JSON-RPC protocol).
+ */
+const stderrLogger: Logger = {
+  info: (msg: string) => process.stderr.write(`[INFO] ${msg}\n`),
+  debug: (msg: string) => process.stderr.write(`[DEBUG] ${msg}\n`),
+  warn: (msg: string) => process.stderr.write(`[WARN] ${msg}\n`),
+  error: (msg: string) => process.stderr.write(`[ERROR] ${msg}\n`),
+};

--- a/src/server/EmbeddableMcpServer.ts
+++ b/src/server/EmbeddableMcpServer.ts
@@ -1,7 +1,7 @@
-import { createRequire } from 'node:module';
 import type { AbapConnection } from '@mcp-abap-adt/connection';
 import type { Logger } from '@mcp-abap-adt/logger';
 import type { HandlerContext } from '../handlers/interfaces.js';
+import { noopLogger } from '../lib/handlerLogger.js';
 import { CompactHandlersGroup } from '../lib/handlers/groups/CompactHandlersGroup.js';
 import { HighLevelHandlersGroup } from '../lib/handlers/groups/HighLevelHandlersGroup.js';
 import { LowLevelHandlersGroup } from '../lib/handlers/groups/LowLevelHandlersGroup.js';
@@ -145,7 +145,7 @@ export class EmbeddableMcpServer extends BaseMcpServer {
     // creates wrapper lambdas that call getConnection() for fresh context
     const dummyContext: HandlerContext = {
       connection: null as unknown as AbapConnection,
-      logger: logger ?? getDefaultLogger(),
+      logger: logger ?? noopLogger,
     };
 
     const groups: IHandlerGroup[] = [];
@@ -171,10 +171,4 @@ export class EmbeddableMcpServer extends BaseMcpServer {
 
     return new CompositeHandlersRegistry(groups);
   }
-}
-
-function getDefaultLogger(): Logger {
-  const require = createRequire(__filename);
-  const mod = require('@mcp-abap-adt/logger');
-  return mod.defaultLogger ?? new mod.DefaultLogger();
 }


### PR DESCRIPTION
## Summary
- Replace all `DefaultLogger` fallbacks (stdout for INFO/DEBUG) with `noopLogger` or stderr-only logger
- Remove unused `defaultLogger` import from `brokerFactory.ts`
- `BaseMcpServer` fallback logger now writes to stderr instead of stdout
- `handlerLogger.ts` falls back to `noopLogger` instead of `DefaultLogger`

Closes #46

## Test plan
- [ ] Run unit tests
- [ ] Verify stdio mode: no non-JSON output on stdout
- [ ] Verify SSE/HTTP mode: logging still works via provided logger

🤖 Generated with [Claude Code](https://claude.com/claude-code)