### PR TITLE
fix: add long polling wait before activation in Create/Update handlers

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -706,3 +706,19 @@ For troubleshooting:
 
 @mcp-abap-adt/configurator (independent auxiliary -- no runtime deps on other packages)
 ```
+
+---
+
+## Known Limitations
+
+### Parallel Tool Calls
+
+MCP tool calls that modify SAP objects (Create, Update, Delete) must be executed **sequentially**, not in parallel. Each MCP server instance uses a single ABAP connection with one CSRF token and one HTTP session. Parallel write operations cause:
+
+- **CSRF token conflicts** -- SAP ties CSRF tokens to HTTP sessions; concurrent requests invalidate each other's tokens.
+- **Session type race conditions** -- lock/unlock operations toggle the connection between stateful and stateless modes; concurrent toggles corrupt session state.
+- **Lock conflicts** -- SAP DDIC objects support only one lock per object; parallel locks on the same object will fail.
+
+Read-only operations (Read*, Search*, Get*) are safe to call in any order since they don't require CSRF tokens or session state changes.
+
+**For LLM clients**: configure the MCP client to send write tool calls one at a time. If the client batches multiple Create/Update calls in a single message, they must be serialized before reaching the server.

--- a/src/handlers/behavior_definition/high/handleCreateBehaviorDefinition.ts
+++ b/src/handlers/behavior_definition/high/handleCreateBehaviorDefinition.ts
@@ -132,6 +132,15 @@ export async function handleCreateBehaviorDefinition(
       };
       await client.getBehaviorDefinition().unlock(unlockConfig, lockHandle);
 
+      // Wait for object to be ready after update (long polling)
+      try {
+        await client
+          .getBehaviorDefinition()
+          .read({ name }, 'inactive', { withLongPolling: true });
+      } catch {
+        // Continue anyway — activation will fail explicitly if object isn't ready
+      }
+
       // Activate if requested - using types from adt-clients
       if (shouldActivate) {
         const activateConfig: Pick<IBehaviorDefinitionConfig, 'name'> = {

--- a/src/handlers/behavior_definition/high/handleUpdateBehaviorDefinition.ts
+++ b/src/handlers/behavior_definition/high/handleUpdateBehaviorDefinition.ts
@@ -103,6 +103,15 @@ export async function handleUpdateBehaviorDefinition(
       await client.getBehaviorDefinition().unlock(unlockConfig, lockHandle);
     }
 
+    // Wait for object to be ready after update (long polling)
+    try {
+      await client
+        .getBehaviorDefinition()
+        .read({ name }, 'inactive', { withLongPolling: true });
+    } catch {
+      // Continue anyway — activation will fail explicitly if object isn't ready
+    }
+
     // Activate if requested - using types from adt-clients
     if (shouldActivate) {
       const activateConfig: Pick<IBehaviorDefinitionConfig, 'name'> = {

--- a/src/handlers/data_element/high/handleCreateDataElement.ts
+++ b/src/handlers/data_element/high/handleCreateDataElement.ts
@@ -232,6 +232,15 @@ export async function handleCreateDataElement(
       await client.getDataElement().unlock({ dataElementName }, lockHandle);
       lockHandle = undefined;
 
+      // Wait for object to be ready after update (long polling)
+      try {
+        await client
+          .getDataElement()
+          .read({ dataElementName }, 'inactive', { withLongPolling: true });
+      } catch {
+        // Continue anyway — activation will fail explicitly if object isn't ready
+      }
+
       // Check
       try {
         await safeCheckOperation(

--- a/src/handlers/data_element/high/handleUpdateDataElement.ts
+++ b/src/handlers/data_element/high/handleUpdateDataElement.ts
@@ -293,6 +293,15 @@ export async function handleUpdateDataElement(
         }
       }
 
+      // Wait for object to be ready after update (long polling)
+      try {
+        await client
+          .getDataElement()
+          .read({ dataElementName }, 'inactive', { withLongPolling: true });
+      } catch {
+        // Continue anyway — activation will fail explicitly if object isn't ready
+      }
+
       // Activate if requested
       if (shouldActivate) {
         await client.getDataElement().activate({ dataElementName });

--- a/src/handlers/ddlx/high/handleCreateMetadataExtension.ts
+++ b/src/handlers/ddlx/high/handleCreateMetadataExtension.ts
@@ -89,6 +89,15 @@ export async function handleCreateMetadataExtension(
       // Unlock
       await client.getMetadataExtension().unlock({ name: name }, lockHandle);
 
+      // Wait for object to be ready after update (long polling)
+      try {
+        await client
+          .getMetadataExtension()
+          .read({ name }, 'inactive', { withLongPolling: true });
+      } catch {
+        // Continue anyway — activation will fail explicitly if object isn't ready
+      }
+
       // Activate if requested
       if (shouldActivate) {
         await client.getMetadataExtension().activate({ name: name });

--- a/src/handlers/ddlx/high/handleUpdateMetadataExtension.ts
+++ b/src/handlers/ddlx/high/handleUpdateMetadataExtension.ts
@@ -89,6 +89,15 @@ export async function handleUpdateMetadataExtension(
       await client.getMetadataExtension().unlock({ name: name }, lockHandle);
     }
 
+    // Wait for object to be ready after update (long polling)
+    try {
+      await client
+        .getMetadataExtension()
+        .read({ name }, 'inactive', { withLongPolling: true });
+    } catch {
+      // Continue anyway — activation will fail explicitly if object isn't ready
+    }
+
     // Activate if requested
     if (shouldActivate) {
       await client.getMetadataExtension().activate({ name: name });

--- a/src/handlers/domain/high/handleCreateDomain.ts
+++ b/src/handlers/domain/high/handleCreateDomain.ts
@@ -205,6 +205,15 @@ export async function handleCreateDomain(
       await client.getDomain().unlock({ domainName }, lockHandle);
       lockHandle = undefined;
 
+      // Wait for object to be ready after update (long polling)
+      try {
+        await client
+          .getDomain()
+          .read({ domainName }, 'inactive', { withLongPolling: true });
+      } catch {
+        // Continue anyway — activation will fail explicitly if object isn't ready
+      }
+
       // Check
       try {
         await safeCheckOperation(

--- a/src/handlers/domain/high/handleUpdateDomain.ts
+++ b/src/handlers/domain/high/handleUpdateDomain.ts
@@ -219,6 +219,15 @@ export async function handleUpdateDomain(
         }
       }
 
+      // Wait for object to be ready after update (long polling)
+      try {
+        await client
+          .getDomain()
+          .read({ domainName }, 'inactive', { withLongPolling: true });
+      } catch {
+        // Continue anyway — activation will fail explicitly if object isn't ready
+      }
+
       // Activate if requested
       if (shouldActivate) {
         await client.getDomain().activate({ domainName });

--- a/src/handlers/function/high/handleUpdateFunctionModule.ts
+++ b/src/handlers/function/high/handleUpdateFunctionModule.ts
@@ -136,6 +136,17 @@ export async function handleUpdateFunctionModule(
         }
       }
 
+      // Wait for object to be ready after update (long polling)
+      try {
+        await client
+          .getFunctionModule()
+          .read({ functionModuleName, functionGroupName }, 'inactive', {
+            withLongPolling: true,
+          });
+      } catch {
+        // Continue anyway — activation will fail explicitly if object isn't ready
+      }
+
       // Activate if requested (after unlock)
       if (shouldActivate) {
         await client.getFunctionModule().activate({

--- a/src/handlers/service_definition/high/handleUpdateServiceDefinition.ts
+++ b/src/handlers/service_definition/high/handleUpdateServiceDefinition.ts
@@ -151,6 +151,17 @@ export async function handleUpdateServiceDefinition(
         }
       }
 
+      // Wait for object to be ready after update (long polling)
+      try {
+        await client
+          .getServiceDefinition()
+          .read({ serviceDefinitionName }, 'inactive', {
+            withLongPolling: true,
+          });
+      } catch {
+        // Continue anyway — activation will fail explicitly if object isn't ready
+      }
+
       // Activate if requested
       if (shouldActivate) {
         const activateState = await client


### PR DESCRIPTION
## Summary
- Add `read({ withLongPolling: true })` between unlock and activate in all 10 high-level handlers that were missing it
- Prevents race condition where SAP hasn't finished processing update before activation is called, leaving objects inactive

Affected handlers: CreateDomain, UpdateDomain, CreateDataElement, UpdateDataElement, CreateBehaviorDefinition, UpdateBehaviorDefinition, CreateMetadataExtension, UpdateMetadataExtension, UpdateFunctionModule, UpdateServiceDefinition.

Closes #47

## Test plan
- [ ] Create domain on on-premise — verify it activates
- [ ] Create data element on on-premise — verify it activates
- [ ] Run integration tests (soft mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)