### PR TITLE
feat: add ActivateObjects tool for group/mass activation

### DIFF
--- a/src/handlers/common/high/handleActivateObjects.ts
+++ b/src/handlers/common/high/handleActivateObjects.ts
@@ -1,0 +1,54 @@
+/**
+ * ActivateObjects Handler - Group/mass activation of ABAP repository objects
+ *
+ * Activates one or multiple objects in a single call.
+ * Uses the ADT group activation endpoint (/sap/bc/adt/activation).
+ */
+
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import { handleActivateObject } from '../low/handleActivateObject';
+
+export const TOOL_DEFINITION = {
+  name: 'ActivateObjects',
+  available_in: ['onprem', 'cloud', 'legacy'] as const,
+  description:
+    'Activate one or multiple ABAP repository objects. Use after Create/Update when objects remain inactive, or for group activation of related objects (e.g., domains + data elements + tables together). Works with any object type.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      objects: {
+        type: 'array',
+        description:
+          "Array of objects to activate. Each object must have 'name' and 'type'.",
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description:
+                'Object name in uppercase (e.g., ZOK7_D_MTART, ZCL_MY_CLASS)',
+            },
+            type: {
+              type: 'string',
+              description:
+                'Object type code: DOMA (domain), DTEL (data element), TABL (table), STRU (structure), DDLS (CDS view), CLAS (class), INTF (interface), PROG (program), FUGR (function group), FUGR/FF (function module), TTYP (table type), SRVD (service definition), SRVB (service binding), BDEF (behavior definition), DDLX (metadata extension), DCLS (access control), ENHO (enhancement)',
+            },
+          },
+          required: ['name', 'type'],
+        },
+      },
+      preaudit: {
+        type: 'boolean',
+        description: 'Request pre-audit before activation. Default: true',
+      },
+    },
+    required: ['objects'],
+  },
+} as const;
+
+export async function handleActivateObjects(
+  context: HandlerContext,
+  args: unknown,
+) {
+  return handleActivateObject(context, args as any);
+}

--- a/src/lib/handlers/groups/HighLevelHandlersGroup.ts
+++ b/src/lib/handlers/groups/HighLevelHandlersGroup.ts
@@ -95,6 +95,10 @@ import {
   TOOL_DEFINITION as UpdateLocalTypes_Tool,
 } from '../../../handlers/class/high/handleUpdateLocalTypes';
 import {
+  TOOL_DEFINITION as ActivateObjects_Tool,
+  handleActivateObjects,
+} from '../../../handlers/common/high/handleActivateObjects';
+import {
   TOOL_DEFINITION as CreateDataElement_Tool,
   handleCreateDataElement,
 } from '../../../handlers/data_element/high/handleCreateDataElement';
@@ -381,6 +385,11 @@ export class HighLevelHandlersGroup extends BaseHandlerGroup {
     };
 
     return [
+      // Common
+      {
+        toolDefinition: ActivateObjects_Tool,
+        handler: withContext(handleActivateObjects),
+      },
       {
         toolDefinition: CreatePackage_Tool,
         handler: withContext(handleCreatePackage),

--- a/src/lib/handlers/groups/HighLevelHandlersGroup.ts
+++ b/src/lib/handlers/groups/HighLevelHandlersGroup.ts
@@ -14,6 +14,11 @@ import {
   handleUpdateBehaviorDefinition as handleUpdateBehaviorDefinitionHigh,
   TOOL_DEFINITION as UpdateBdef_Tool,
 } from '../../../handlers/behavior_definition/high/handleUpdateBehaviorDefinition';
+// Per-type activate handlers (reused from low-level)
+import {
+  TOOL_DEFINITION as ActivateBehaviorDefinition_Tool,
+  handleActivateBehaviorDefinition,
+} from '../../../handlers/behavior_definition/low/handleActivateBehaviorDefinition';
 import {
   TOOL_DEFINITION as CreateBehaviorImplementation_Tool,
   handleCreateBehaviorImplementation,
@@ -95,6 +100,10 @@ import {
   TOOL_DEFINITION as UpdateLocalTypes_Tool,
 } from '../../../handlers/class/high/handleUpdateLocalTypes';
 import {
+  TOOL_DEFINITION as ActivateClass_Tool,
+  handleActivateClass,
+} from '../../../handlers/class/low/handleActivateClass';
+import {
   TOOL_DEFINITION as ActivateObjects_Tool,
   handleActivateObjects,
 } from '../../../handlers/common/high/handleActivateObjects';
@@ -115,6 +124,10 @@ import {
   TOOL_DEFINITION as UpdateDataElementHigh_Tool,
 } from '../../../handlers/data_element/high/handleUpdateDataElement';
 import {
+  TOOL_DEFINITION as ActivateDataElement_Tool,
+  handleActivateDataElement,
+} from '../../../handlers/data_element/low/handleActivateDataElement';
+import {
   TOOL_DEFINITION as CreateDdlx_Tool,
   handleCreateMetadataExtension,
 } from '../../../handlers/ddlx/high/handleCreateMetadataExtension';
@@ -122,6 +135,10 @@ import {
   handleUpdateMetadataExtension as handleUpdateMetadataExtensionHigh,
   TOOL_DEFINITION as UpdateDdlx_Tool,
 } from '../../../handlers/ddlx/high/handleUpdateMetadataExtension';
+import {
+  TOOL_DEFINITION as ActivateMetadataExtension_Tool,
+  handleActivateMetadataExtension,
+} from '../../../handlers/ddlx/low/handleActivateMetadataExtension';
 import {
   TOOL_DEFINITION as CreateDomain_Tool,
   handleCreateDomain,
@@ -139,6 +156,10 @@ import {
   TOOL_DEFINITION as UpdateDomainHigh_Tool,
 } from '../../../handlers/domain/high/handleUpdateDomain';
 import {
+  TOOL_DEFINITION as ActivateDomain_Tool,
+  handleActivateDomain,
+} from '../../../handlers/domain/low/handleActivateDomain';
+import {
   TOOL_DEFINITION as CreateFunctionGroup_Tool,
   handleCreateFunctionGroup,
 } from '../../../handlers/function/high/handleCreateFunctionGroup';
@@ -154,6 +175,14 @@ import {
   handleUpdateFunctionModule as handleUpdateFunctionModuleHigh,
   TOOL_DEFINITION as UpdateFunctionModuleHigh_Tool,
 } from '../../../handlers/function/high/handleUpdateFunctionModule';
+import {
+  TOOL_DEFINITION as ActivateFunctionGroup_Tool,
+  handleActivateFunctionGroup,
+} from '../../../handlers/function/low/handleActivateFunctionGroup';
+import {
+  TOOL_DEFINITION as ActivateFunctionModule_Tool,
+  handleActivateFunctionModule,
+} from '../../../handlers/function/low/handleActivateFunctionModule';
 import {
   TOOL_DEFINITION as DeleteFunctionGroup_Tool,
   handleDeleteFunctionGroup,
@@ -186,6 +215,10 @@ import {
   handleUpdateInterface as handleUpdateInterfaceHigh,
   TOOL_DEFINITION as UpdateInterfaceHigh_Tool,
 } from '../../../handlers/interface/high/handleUpdateInterface';
+import {
+  TOOL_DEFINITION as ActivateInterface_Tool,
+  handleActivateInterface,
+} from '../../../handlers/interface/low/handleActivateInterface';
 import {
   TOOL_DEFINITION as DeleteMetadataExtension_Tool,
   handleDeleteMetadataExtension,
@@ -220,6 +253,10 @@ import {
   handleUpdateProgram as handleUpdateProgramHigh,
   TOOL_DEFINITION as UpdateProgramHigh_Tool,
 } from '../../../handlers/program/high/handleUpdateProgram';
+import {
+  TOOL_DEFINITION as ActivateProgram_Tool,
+  handleActivateProgram,
+} from '../../../handlers/program/low/handleActivateProgram';
 import {
   TOOL_DEFINITION as CreateServiceBinding_Tool,
   handleCreateServiceBinding,
@@ -277,6 +314,10 @@ import {
   TOOL_DEFINITION as UpdateStructureHigh_Tool,
 } from '../../../handlers/structure/high/handleUpdateStructure';
 import {
+  TOOL_DEFINITION as ActivateStructure_Tool,
+  handleActivateStructure,
+} from '../../../handlers/structure/low/handleActivateStructure';
+import {
   TOOL_DEFINITION as CreateTable_Tool,
   handleCreateTable,
 } from '../../../handlers/table/high/handleCreateTable';
@@ -292,6 +333,10 @@ import {
   handleUpdateTable as handleUpdateTableHigh,
   TOOL_DEFINITION as UpdateTableHigh_Tool,
 } from '../../../handlers/table/high/handleUpdateTable';
+import {
+  TOOL_DEFINITION as ActivateTable_Tool,
+  handleActivateTable,
+} from '../../../handlers/table/low/handleActivateTable';
 import {
   TOOL_DEFINITION as CreateTransport_Tool,
   handleCreateTransport,
@@ -364,6 +409,10 @@ import {
   handleUpdateView as handleUpdateViewHigh,
   TOOL_DEFINITION as UpdateViewHigh_Tool,
 } from '../../../handlers/view/high/handleUpdateView';
+import {
+  TOOL_DEFINITION as ActivateView_Tool,
+  handleActivateView,
+} from '../../../handlers/view/low/handleActivateView';
 import { BaseHandlerGroup } from '../base/BaseHandlerGroup.js';
 import type { HandlerEntry } from '../interfaces.js';
 
@@ -385,10 +434,59 @@ export class HighLevelHandlersGroup extends BaseHandlerGroup {
     };
 
     return [
-      // Common
+      // Common — group activation
       {
         toolDefinition: ActivateObjects_Tool,
         handler: withContext(handleActivateObjects),
+      },
+      // Per-type activation
+      {
+        toolDefinition: ActivateDomain_Tool,
+        handler: withContext(handleActivateDomain),
+      },
+      {
+        toolDefinition: ActivateDataElement_Tool,
+        handler: withContext(handleActivateDataElement),
+      },
+      {
+        toolDefinition: ActivateTable_Tool,
+        handler: withContext(handleActivateTable),
+      },
+      {
+        toolDefinition: ActivateStructure_Tool,
+        handler: withContext(handleActivateStructure),
+      },
+      {
+        toolDefinition: ActivateView_Tool,
+        handler: withContext(handleActivateView),
+      },
+      {
+        toolDefinition: ActivateClass_Tool,
+        handler: withContext(handleActivateClass),
+      },
+      {
+        toolDefinition: ActivateInterface_Tool,
+        handler: withContext(handleActivateInterface),
+      },
+      {
+        toolDefinition: ActivateProgram_Tool,
+        handler: withContext(handleActivateProgram),
+      },
+      {
+        toolDefinition: ActivateFunctionModule_Tool,
+        handler: withContext(handleActivateFunctionModule),
+      },
+      {
+        toolDefinition: ActivateFunctionGroup_Tool,
+        handler: withContext(handleActivateFunctionGroup),
+      },
+      {
+        toolDefinition: ActivateBehaviorDefinition_Tool,
+        handler: withContext(handleActivateBehaviorDefinition),
+      },
+      {
+        toolDefinition: ActivateMetadataExtension_Tool,
+        handler: withContext(handleActivateMetadataExtension),
       },
       {
         toolDefinition: CreatePackage_Tool,

--- a/src/lib/handlers/groups/LowLevelHandlersGroup.ts
+++ b/src/lib/handlers/groups/LowLevelHandlersGroup.ts
@@ -1,8 +1,7 @@
+// Import common low-level handlers
+import { handleActivateObject } from '../../../handlers/common/low/handleActivateObject';
 import { BaseHandlerGroup } from '../base/BaseHandlerGroup.js';
 import type { HandlerEntry } from '../interfaces.js';
-
-// // Import common low-level handlers
-// import { handleActivateObject } from "../../../handlers/common/low/handleActivateObject";
 // import { handleDeleteObject } from "../../../handlers/common/low/handleDeleteObject";
 // import { handleCheckObject } from "../../../handlers/common/low/handleCheckObject";
 // import { handleValidateObject } from "../../../handlers/common/low/handleValidateObject";
@@ -38,6 +37,8 @@ import { handleUnlockClassTestClasses } from '../../../handlers/class/low/handle
 import { handleUpdateClass as handleUpdateClassLow } from '../../../handlers/class/low/handleUpdateClass';
 import { handleUpdateClassTestClasses } from '../../../handlers/class/low/handleUpdateClassTestClasses';
 import { handleValidateClass } from '../../../handlers/class/low/handleValidateClass';
+// Import TOOL_DEFINITION from common low handlers
+import { TOOL_DEFINITION as ActivateObject_Tool } from '../../../handlers/common/low/handleActivateObject';
 import { handleActivateDataElement } from '../../../handlers/data_element/low/handleActivateDataElement';
 import { handleCheckDataElement } from '../../../handlers/data_element/low/handleCheckDataElement';
 import { handleCreateDataElement as handleCreateDataElementLow } from '../../../handlers/data_element/low/handleCreateDataElement';
@@ -136,9 +137,6 @@ import { handleUnlockView } from '../../../handlers/view/low/handleUnlockView';
 // Import low-level handlers - View
 import { handleUpdateView as handleUpdateViewLow } from '../../../handlers/view/low/handleUpdateView';
 import { handleValidateView } from '../../../handlers/view/low/handleValidateView';
-
-// // Import TOOL_DEFINITION from common low handlers
-// import { TOOL_DEFINITION as ActivateObject_Tool } from "../../../handlers/common/low/handleActivateObject";
 // import { TOOL_DEFINITION as DeleteObject_Tool } from "../../../handlers/common/low/handleDeleteObject";
 // import { TOOL_DEFINITION as CheckObject_Tool } from "../../../handlers/common/low/handleCheckObject";
 // import { TOOL_DEFINITION as ValidateObject_Tool } from "../../../handlers/common/low/handleValidateObject";
@@ -285,15 +283,18 @@ export class LowLevelHandlersGroup extends BaseHandlerGroup {
    */
   getHandlers(): HandlerEntry[] {
     return [
-      // // Common low-level handlers
-      // {
-      //   toolDefinition: {
-      //     name: ActivateObject_Tool.name,
-      //     description: ActivateObject_Tool.description,
-      //     inputSchema: ActivateObject_Tool.inputSchema,
-      //   },
-      //   handler: (args: any) => { return handleActivateObject(this.context, args) },
-      // },
+      // Common low-level handlers
+      {
+        toolDefinition: {
+          name: ActivateObject_Tool.name,
+          description: ActivateObject_Tool.description,
+          inputSchema: ActivateObject_Tool.inputSchema,
+          available_in: ActivateObject_Tool.available_in,
+        },
+        handler: (args: any) => {
+          return handleActivateObject(this.context, args);
+        },
+      },
       // {
       //   toolDefinition: {
       //     name: CheckObject_Tool.name,


### PR DESCRIPTION
## Summary
- Add `ActivateObjects` high-level handler for group/mass activation of any ABAP object types
- Uncomment `ActivateObjectLow` in LowLevelHandlersGroup
- Both delegate to `activateObjectsGroup` from ADT client library

Closes #49

## Test plan
- [ ] Verify ActivateObjects appears in tool list
- [ ] Activate a single domain via ActivateObjects
- [ ] Activate multiple objects (domains + data elements) in one call

🤖 Generated with [Claude Code](https://claude.com/claude-code)