### PR TITLE
docs: decouple RFC connection from legacy system type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ dev.json
 desktop.ini
 .vscode/mcp.json
 .claude/settings.local.json
+.codex
 
 # Superpowers plans (local development artifacts)
 docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ cp tests/test-config.yaml.template tests/test-config.yaml
 **Required changes** (marked `# ← CHANGE`):
 - `environment.env` — session .env file name (`"e19.env"`, `"mdd.env"`) from standard sessions folder
 - `environment.system_type` — `"onprem"`, `"cloud"`, or `"legacy"`
-- `environment.connection_type` — `"http"` (default) or `"rfc"` (legacy)
+- `environment.connection_type` — `"http"` (default) or `"rfc"`
 - `environment.default_package` — dev package (`ZMCP_TEST`, `$TMP`)
 - `environment.default_transport` — transport request or `""` for local packages
 - `shared_dependencies.package` — package for shared test objects
@@ -65,3 +65,7 @@ Values: `'onprem'` | `'cloud'` | `'legacy'`. If omitted, tool is available every
 - Programs are NOT available on ABAP Cloud (`available_in: ['onprem', 'legacy']`)
 - Runtime profiling (class-based) and dumps work on both cloud and onprem
 - `RuntimeRunProgramWithProfiling` is onprem-only (no programs on cloud)
+
+## npm Package Verification
+
+When checking whether an installed npm package contains specific code, always search inside `node_modules/` directly (e.g., `grep -r "pattern" node_modules/@scope/package/`). VS Code search and ripgrep skip `node_modules` by default due to `.gitignore`, which leads to false "not found" conclusions. The code may be there — you're just not looking in the right place.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Why teams use it:**
 - **Full CRUD** (not read-only): create, read, update, and delete ABAP artifacts
-- Works with **On-Premise (ECC/S/4HANA)**, **ABAP Cloud (BTP)**, and **Legacy** systems (BASIS < 7.50 via RFC)
+- Works with **On-Premise (ECC/S/4HANA)**, **ABAP Cloud (BTP)**, and **Legacy** systems (BASIS < 7.50)
 - **JWT/XSUAA**, **service key** (destination-based), and **RFC** authorization
 - Multiple transports: **stdio**, **HTTP**, **SSE**
 - Rich tool surface for ABAP objects, metadata, transports, and search
@@ -282,7 +282,7 @@ SAP_AUTH_TYPE=jwt
 SAP_JWT_TOKEN=your-jwt-token
 ```
 
-For legacy systems (RFC):
+For RFC connection:
 ```bash
 SAP_URL=https://your-legacy-system.com
 SAP_CLIENT=100
@@ -316,7 +316,7 @@ Inline comments are not parsed, so keep comments on separate lines.
 - `--auth-broker` - Force use of auth-broker (service keys), ignore .env file
 - `--auth-broker-path=<path>` - Custom path for auth-broker service keys and sessions
 - `--browser-auth-port=<port>` - Override OAuth browser callback port (default: 5000 for HTTP, 4000 for SSE, 4001 for stdio)
-- `--connection-type=<http|rfc>` - SAP connection transport: `http` (default) or `rfc` (legacy systems)
+- `--connection-type=<http|rfc>` - SAP connection transport: `http` (default) or `rfc`
 - `--unsafe` - Enable file-based session storage (persists tokens to disk). By default, sessions are stored in-memory (secure, lost on restart)
 
 When `--mcp=<destination>` is specified, automatic fallback loading of `./.env` is skipped.

--- a/docs/architecture/TOOLS_ARCHITECTURE.md
+++ b/docs/architecture/TOOLS_ARCHITECTURE.md
@@ -76,7 +76,7 @@ export const TOOL_DEFINITION = {
 **Values:**
 - `'onprem'` — On-premise systems (ECC, S/4HANA)
 - `'cloud'` — ABAP Cloud (SAP BTP)
-- `'legacy'` — Legacy on-premise systems (BASIS < 7.50, connected via RFC)
+- `'legacy'` — Legacy on-premise systems (BASIS < 7.50)
 
 **How filtering works:**
 

--- a/docs/configuration/YAML_CONFIG.md
+++ b/docs/configuration/YAML_CONFIG.md
@@ -47,7 +47,7 @@ env: trial
 # Explicit path to .env file (recommended for file-based config)
 env-path: .env
 
-# SAP connection type: http (default) or rfc (legacy systems with BASIS < 7.50)
+# SAP connection type: http (default) or rfc
 connection-type: http
 
 # Use unsafe mode (file-based session store)
@@ -91,7 +91,7 @@ sse:
 | `mcp` | string | - | Default MCP destination name (uses auth-broker) |
 | `env` | string | - | Destination name resolved from sessions store (`sessions/<name>.env`) |
 | `env-path` | string | - | Explicit path to `.env` file |
-| `connection-type` | string | `http` | SAP connection transport: `http` (default) or `rfc` (legacy systems) |
+| `connection-type` | string | `http` | SAP connection transport: `http` (default) or `rfc` |
 | `unsafe` | boolean | `false` | Use file-based session store (persists to disk) |
 | `auth-broker` | boolean | `false` | Force use of auth-broker (service keys) instead of `.env` |
 | `auth-broker-path` | string | - | Custom path for auth-broker storage |
@@ -189,11 +189,11 @@ Usage:
 mcp-abap-adt --conf=config.yaml
 ```
 
-### Example 6: Legacy System via RFC
+### Example 6: RFC Connection
 
 ```yaml
 transport: stdio
-env-path: legacy.env
+env-path: my-system.env
 connection-type: rfc
 ```
 

--- a/docs/development/TEST_SYSTEM_SETUP.md
+++ b/docs/development/TEST_SYSTEM_SETUP.md
@@ -19,7 +19,7 @@ cp test-config.yaml.template test-config.yaml
 environment:
   env: "e19.env"                # ⚠️ Ім'я .env файлу зі стандартної папки sessions
   system_type: "onprem"         # ⚠️ "onprem" | "cloud" | "legacy"
-  connection_type: "http"       # "http" | "rfc" (rfc для legacy)
+  connection_type: "http"       # "http" | "rfc"
   default_package: "TEST_MCP"   # ⚠️ Оновити на ваш пакет
   default_transport: ""         # ⚠️ Transport request або "" для локальних пакетів
 ```

--- a/docs/development/roadmaps/TRANSPORT_CRUD_ISSUE_11.md
+++ b/docs/development/roadmaps/TRANSPORT_CRUD_ISSUE_11.md
@@ -36,11 +36,10 @@ is bound to the original ABAP session.
 Eclipse ADT avoids this by using `JCoEnqueueSystemSession` (RFC-based locking) — no
 `x-sap-adt-sessiontype` header on the LOCK call.
 
-### 3. SAP_CONNECTION_TYPE=rfc should imply legacy
+### 3. SAP_CONNECTION_TYPE=rfc no longer implies legacy
 
-Currently `SAP_CONNECTION_TYPE=rfc` does not auto-set `SAP_SYSTEM_TYPE=legacy`.
-This could be an improvement: if a user connects via RFC, they're almost certainly
-on a legacy system.
+RFC is now a general-purpose connection transport, not tied to legacy systems.
+`SAP_SYSTEM_TYPE` must be set explicitly regardless of connection type.
 
 ## Reproduction Plan
 
@@ -76,7 +75,7 @@ Cannot run on trial/cloud systems — requires on-prem or legacy with transports
 1. **Skip `x-sap-adt-sessiontype: stateful`** on LOCK for legacy systems
 2. **Use stateless session** for lock/update/unlock cycle on legacy
 3. **Bundle lock + update + unlock** in a single stateful session (CSRF token reuse)
-4. **Auto-detect legacy** from `SAP_CONNECTION_TYPE=rfc`
+4. **Require explicit `SAP_SYSTEM_TYPE`** — RFC no longer implies legacy
 
 ## Status
 
@@ -86,4 +85,4 @@ Cannot run on trial/cloud systems — requires on-prem or legacy with transports
 - [ ] Create package `ZMC_REQUEST_TEST` on SAP (manual)
 - [ ] Run test on legacy system to confirm the 423 error
 - [ ] Implement fix based on test results
-- [ ] Auto-detect `SAP_SYSTEM_TYPE=legacy` from `SAP_CONNECTION_TYPE=rfc`
+- [x] Decouple RFC from legacy — RFC is now a general-purpose connection type (#63)

--- a/docs/installation/RFC_SETUP.md
+++ b/docs/installation/RFC_SETUP.md
@@ -1,6 +1,6 @@
-# RFC Connection Setup (Legacy Systems)
+# RFC Connection Setup
 
-RFC connections are required for legacy SAP systems (BASIS < 7.50) where HTTP stateful sessions are not supported. Without RFC, lock handles are lost between requests, causing update/unlock operations to fail.
+RFC is an alternative connection transport to HTTP. It works with any SAP system supported by the SAP NW RFC SDK. The RFC session is inherently stateful, so lock handles persist across calls without requiring HTTP stateful sessions.
 
 ## Prerequisites
 
@@ -72,7 +72,7 @@ SAP_CONNECTION_TYPE=rfc
 ```
 
 - `SAP_AUTH_TYPE` — authentication method (`basic` or `jwt`). RFC uses basic auth with username/password.
-- `SAP_CONNECTION_TYPE` — transport layer (`http` or `rfc`). Set to `rfc` for legacy systems.
+- `SAP_CONNECTION_TYPE` — transport layer (`http` or `rfc`).
 
 ## How It Works
 

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -2,7 +2,7 @@
 
 Generated from code in `src/handlers/**` (not from docs).
 
-Tools available on legacy SAP systems (BASIS < 7.50) connected via RFC.
+Tools available on legacy SAP systems (BASIS < 7.50).
 Legacy systems support a subset of tools — primarily Class, Interface, View, Program, Function Group/Module, Package (read/update/delete), Include, Unit Test, and common utilities.
 
 - Total tools: 129

--- a/docs/user-guide/CLI_OPTIONS.md
+++ b/docs/user-guide/CLI_OPTIONS.md
@@ -136,14 +136,14 @@ SAP connection transport layer. Determines how the server communicates with the 
 
 Valid values:
 - `http` - HTTP/HTTPS (default, for modern on-premise and cloud systems)
-- `rfc` - RFC via SAP NW RFC SDK (for legacy systems with BASIS < 7.50)
+- `rfc` - RFC via SAP NW RFC SDK (any system supported by NW RFC SDK)
 
 ```bash
 # Default HTTP connection (modern systems)
 mcp-abap-adt --env-path=.env
 
-# RFC connection (legacy systems)
-mcp-abap-adt --connection-type=rfc --env-path=legacy.env
+# RFC connection
+mcp-abap-adt --connection-type=rfc --env-path=my-system.env
 ```
 
 **Note:** RFC requires the SAP NW RFC SDK installed and configured. See [RFC Setup Guide](../installation/RFC_SETUP.md) for prerequisites.
@@ -428,7 +428,7 @@ These are typically set in `.env` file:
 - `SAP_AUTH_TYPE` - Authentication type: `basic` or `jwt` (default: basic)
 - `SAP_USERNAME` - SAP username (for basic auth)
 - `SAP_PASSWORD` - SAP password (for basic auth)
-- `SAP_CONNECTION_TYPE` - Connection transport: `http` (default) or `rfc` (legacy systems)
+- `SAP_CONNECTION_TYPE` - Connection transport: `http` (default) or `rfc`
 - `SAP_LANGUAGE` - SAP language (optional, e.g., EN, DE)
 
 **JWT/OAuth2 Authentication:**
@@ -506,12 +506,12 @@ EOF
 mcp-abap-adt
 ```
 
-### Legacy System Setup (RFC)
+### RFC Connection Setup
 
 ```bash
-# Create legacy environment
-cat > legacy.env << EOF
-SAP_URL=https://legacy.sap.company.com
+# Create RFC environment
+cat > rfc-system.env << EOF
+SAP_URL=https://sap.company.com
 SAP_CLIENT=100
 SAP_AUTH_TYPE=basic
 SAP_USERNAME=developer
@@ -520,7 +520,7 @@ SAP_CONNECTION_TYPE=rfc
 EOF
 
 # Run with RFC connection
-mcp-abap-adt --env-path=legacy.env
+mcp-abap-adt --env-path=rfc-system.env
 
 # Or use CLI flag instead of env var
 mcp-abap-adt --connection-type=rfc --env-path=.env

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -74,7 +74,7 @@ export function getConfig(): SapConfig {
     }
   }
 
-  // Connection type: http (default) or rfc (legacy systems)
+  // Connection type: http (default) or rfc
   const connectionType: SapConfig['connectionType'] =
     process.env.SAP_CONNECTION_TYPE?.trim().toLowerCase() === 'rfc'
       ? 'rfc'

--- a/src/lib/config/ArgumentsParser.ts
+++ b/src/lib/config/ArgumentsParser.ts
@@ -21,7 +21,7 @@ export interface ParsedArguments {
   useAuthBroker: boolean;
   /** Transport type */
   transport?: string;
-  /** SAP connection type: http (default) or rfc (legacy systems) */
+  /** SAP connection type: http (default) or rfc */
   connectionType?: 'http' | 'rfc';
   /** SAP system type override: onprem | cloud | legacy */
   systemType?: 'onprem' | 'cloud' | 'legacy';

--- a/src/lib/config/IServerConfig.ts
+++ b/src/lib/config/IServerConfig.ts
@@ -92,7 +92,7 @@ export interface IServerConfig {
   /** Path to YAML config file */
   configFile?: string;
 
-  /** SAP connection type: http (default) or rfc (legacy systems) */
+  /** SAP connection type: http (default) or rfc */
   connectionType?: 'http' | 'rfc';
 
   /** SAP system type override: onprem | cloud | legacy (overrides auto-detection) */

--- a/src/lib/config/ServerConfigManager.ts
+++ b/src/lib/config/ServerConfigManager.ts
@@ -301,9 +301,9 @@ EXAMPLES:
   # Stdio with explicit env file
   mcp-abap-adt --env-path=.env
 
-  # RFC connection to legacy system (BASIS < 7.50)
-  # Set SAP_CONNECTION_TYPE=rfc in .env file, requires SAP NW RFC SDK
-  mcp-abap-adt --env-path=legacy.env
+  # RFC connection (any system with SAP NW RFC SDK)
+  # Set SAP_CONNECTION_TYPE=rfc in .env file
+  mcp-abap-adt --env-path=my-system.env --connection-type=rfc
 
   # Explicit system type (bypass auto-detection)
   mcp-abap-adt --env-path=e96.env --system-type=onprem

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1906,7 +1906,7 @@ export function getConfig(): SapConfig {
     }
   }
 
-  // Connection type: http (default) or rfc (legacy systems)
+  // Connection type: http (default) or rfc
   const connectionType: SapConfig['connectionType'] =
     process.env.SAP_CONNECTION_TYPE?.trim().toLowerCase() === 'rfc'
       ? 'rfc'

--- a/src/server/launcher.ts
+++ b/src/server/launcher.ts
@@ -140,7 +140,7 @@ SAP CONNECTION (.env file):
     SAP_UAA_CLIENT_ID              UAA Client ID (or UAA_CLIENT_ID)
     SAP_UAA_CLIENT_SECRET          UAA Client Secret (or UAA_CLIENT_SECRET)
 
-  RFC Connection (legacy systems, BASIS < 7.50):
+  RFC Connection (any system with SAP NW RFC SDK):
     SAP_CONNECTION_TYPE=rfc        Enables RFC transport via SADT_REST_RFC_ENDPOINT
     SAP_URL                        SAP system URL (host:port used to derive RFC params)
     SAP_USERNAME                   SAP username

--- a/tests/test-config.yaml.template
+++ b/tests/test-config.yaml.template
@@ -91,7 +91,7 @@ environment:
   env: ""                                    # ← CHANGE: session file name (e.g., "e19.env", "mdd.env")
   # System and connection type (explicit, no auto-detection)
   system_type: ""                            # ← CHANGE: "onprem" | "cloud" | "legacy"
-  connection_type: "http"                    # "http" | "rfc" (rfc for legacy, BASIS < 7.50)
+  connection_type: "http"                    # "http" | "rfc"
   # Test defaults
   default_package: "ZMCP_TEST"              # ← CHANGE: your dev package (Z*/Y*) or "$TMP" for local
   default_transport: ""                       # ← CHANGE: transport request (leave "" for $TMP/local packages)

--- a/tools/generate-tools-docs.js
+++ b/tools/generate-tools-docs.js
@@ -887,7 +887,7 @@ function main() {
       tools,
       'legacy',
       'Legacy System',
-      'Tools available on legacy SAP systems (BASIS < 7.50) connected via RFC.\nLegacy systems support a subset of tools — primarily Class, Interface, View, Program, Function Group/Module, Package (read/update/delete), Include, Unit Test, and common utilities.',
+      'Tools available on legacy SAP systems (BASIS < 7.50).\nLegacy systems support a subset of tools — primarily Class, Interface, View, Program, Function Group/Module, Package (read/update/delete), Include, Unit Test, and common utilities.',
     ),
     'utf8',
   );


### PR DESCRIPTION
## Summary

- RFC is a connection transport, legacy is a system type (BASIS < 7.50) — removed "legacy only" framing from RFC across all docs, help text, and code comments
- RFC now positioned as a general-purpose alternative to HTTP for any on-prem system with SAP NW RFC SDK
- Added `.codex` to `.gitignore`

Closes #63

## Test plan

- [x] TypeScript build passes (`npx tsc --noEmit`)
- [x] Lint/biome checks pass (pre-commit hooks)
- [ ] Verify RFC connection still works on on-prem system

🤖 Generated with [Claude Code](https://claude.com/claude-code)