### PR TITLE
feat: per-instance systemType option for EmbeddableMcpServer (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [6.4.0] - 2026-04-20
+
+### Added
+- `EmbeddableMcpServer` accepts a new optional `systemType: 'onprem' | 'cloud' | 'legacy'` option. When set, it overrides the process-global `SAP_SYSTEM_TYPE` env var for the `available_in` tool filter of that server instance only. Enables hosts that serve multiple SAP systems per request (e.g., proxies routing to a mix of on-premise Cloud Connector and cloud-hosted destinations) to register the correct tool set per instance without mutating `process.env`. (#69)
+- `BaseMcpServer` constructor accepts the same `systemType` option for subclasses.
+
+### Changed
+- Filter-skip debug log now reports whether the resolved system type came from the per-instance option or the env var (`source=option` / `source=env`).
+
+### Backward compatibility
+- `systemType` is optional; omitting it preserves the previous behavior (env var fallback, default `cloud`). No consumer changes required.
+
 ## [6.3.1] - 2026-04-19
 
 ### Changed

--- a/docs/user-guide/CLIENT_CONFIGURATION.md
+++ b/docs/user-guide/CLIENT_CONFIGURATION.md
@@ -516,6 +516,22 @@ The `SAP_SYSTEM_TYPE` environment variable controls which tools are available an
 
 You can also set this via CLI: `--system-type=onprem`
 
+#### Per-Instance Override (embedders)
+
+When embedding the server via `EmbeddableMcpServer`, pass `systemType` in the constructor options to bind one server instance to a specific SAP system type, independent of the process-global `SAP_SYSTEM_TYPE` env var:
+
+```ts
+new EmbeddableMcpServer({
+  connection,
+  exposition: ['readonly', 'high'],
+  systemType: 'onprem', // or 'cloud' / 'legacy'
+});
+```
+
+Use this when one host serves multiple SAP systems per request — for example, a proxy that resolves a BTP destination at request time and decides whether it is OnPremise (Cloud Connector) or an internet-facing cloud endpoint. Mutating `process.env.SAP_SYSTEM_TYPE` per request is not safe and is not required.
+
+**Resolution order:** `options.systemType` → `process.env.SAP_SYSTEM_TYPE` → default `cloud`.
+
 ### System Context for On-Premise Systems
 
 When creating or updating ABAP objects on on-premise systems, SAP ADT requires `masterSystem` and `responsible` attributes in the XML request body. These ensure that objects are correctly bound to transport requests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.3.1",
+      "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.3.1",
+  "version": "6.4.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.3.1",
+      "version": "6.4.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/integration/server/EmbeddableMcpServer.systemType.test.ts
+++ b/src/__tests__/integration/server/EmbeddableMcpServer.systemType.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Integration test: verifies that the `systemType` option on
+ * `EmbeddableMcpServer` correctly overrides `process.env.SAP_SYSTEM_TYPE`
+ * at registration time, so tools with `available_in: ['onprem', 'legacy']`
+ * are included or excluded per instance — independent of the process-global
+ * env var.
+ *
+ * Uses a real ABAP connection (from .env / auth broker) to prove the option
+ * works in a realistic embedder scenario, even though the filter itself
+ * doesn't touch the connection.
+ *
+ * Run: npm test -- --testPathPattern=integration/server
+ */
+
+import { EmbeddableMcpServer } from '../../../server/EmbeddableMcpServer';
+import { getTimeout } from '../helpers/configHelpers';
+import { createTestConnectionAndSession } from '../helpers/sessionHelpers';
+
+type RegisteredToolsMap = Record<string, unknown>;
+
+function getRegisteredToolNames(server: EmbeddableMcpServer): Set<string> {
+  const tools = (server as unknown as { _registeredTools: RegisteredToolsMap })
+    ._registeredTools;
+  return new Set(Object.keys(tools || {}));
+}
+
+describe('EmbeddableMcpServer systemType option (real connection)', () => {
+  const ORIGINAL_SAP_SYSTEM_TYPE = process.env.SAP_SYSTEM_TYPE;
+
+  afterEach(() => {
+    if (ORIGINAL_SAP_SYSTEM_TYPE === undefined) {
+      delete process.env.SAP_SYSTEM_TYPE;
+    } else {
+      process.env.SAP_SYSTEM_TYPE = ORIGINAL_SAP_SYSTEM_TYPE;
+    }
+  });
+
+  test(
+    'systemType="onprem" registers onprem-only tools (CreateProgram etc.)',
+    async () => {
+      const { connection } = await createTestConnectionAndSession();
+      process.env.SAP_SYSTEM_TYPE = 'cloud';
+
+      const server = new EmbeddableMcpServer({
+        connection,
+        exposition: ['high'],
+        systemType: 'onprem',
+      });
+
+      const names = getRegisteredToolNames(server);
+
+      expect(names.has('CreateProgram')).toBe(true);
+      expect(names.has('UpdateProgram')).toBe(true);
+      expect(names.has('DeleteProgram')).toBe(true);
+    },
+    getTimeout('default'),
+  );
+
+  test(
+    'systemType="cloud" filters out onprem-only tools despite env=onprem',
+    async () => {
+      const { connection } = await createTestConnectionAndSession();
+      process.env.SAP_SYSTEM_TYPE = 'onprem';
+
+      const server = new EmbeddableMcpServer({
+        connection,
+        exposition: ['high'],
+        systemType: 'cloud',
+      });
+
+      const names = getRegisteredToolNames(server);
+
+      expect(names.has('CreateProgram')).toBe(false);
+      expect(names.has('UpdateProgram')).toBe(false);
+      expect(names.has('DeleteProgram')).toBe(false);
+    },
+    getTimeout('default'),
+  );
+
+  test(
+    'no systemType option → falls back to SAP_SYSTEM_TYPE env var',
+    async () => {
+      const { connection } = await createTestConnectionAndSession();
+      process.env.SAP_SYSTEM_TYPE = 'onprem';
+
+      const server = new EmbeddableMcpServer({
+        connection,
+        exposition: ['high'],
+      });
+
+      const names = getRegisteredToolNames(server);
+
+      expect(names.has('CreateProgram')).toBe(true);
+    },
+    getTimeout('default'),
+  );
+});

--- a/src/server/BaseMcpServer.ts
+++ b/src/server/BaseMcpServer.ts
@@ -41,9 +41,21 @@ export abstract class BaseMcpServer extends McpServer {
    */
   private cachedConnection: AbapConnection | null = null;
 
-  constructor(options: { name: string; version?: string; logger?: Logger }) {
+  /**
+   * Per-instance SAP system type. Overrides process.env.SAP_SYSTEM_TYPE
+   * for `available_in` filtering at handler registration time.
+   */
+  protected readonly systemType?: SapEnvironment;
+
+  constructor(options: {
+    name: string;
+    version?: string;
+    logger?: Logger;
+    systemType?: SapEnvironment;
+  }) {
     super({ name: options.name, version: options.version ?? '1.0.0' });
     this.logger = options.logger ?? getDefaultLogger();
+    this.systemType = options.systemType;
   }
 
   /**
@@ -433,16 +445,17 @@ export abstract class BaseMcpServer extends McpServer {
           // Skip tools not available in the current SAP environment
           const availableIn = entry.toolDefinition.available_in;
           if (availableIn && availableIn.length > 0) {
-            const envType = process.env.SAP_SYSTEM_TYPE?.toLowerCase();
+            const resolvedType =
+              this.systemType ?? process.env.SAP_SYSTEM_TYPE?.toLowerCase();
             const currentEnv: SapEnvironment =
-              envType === 'legacy'
+              resolvedType === 'legacy'
                 ? 'legacy'
-                : envType === 'onprem'
+                : resolvedType === 'onprem'
                   ? 'onprem'
                   : 'cloud';
             if (!availableIn.includes(currentEnv)) {
               this.logger.debug(
-                `[BaseMcpServer] Skipping tool ${entry.toolDefinition.name}: available_in=${JSON.stringify(availableIn)}, currentEnv=${currentEnv}, SAP_SYSTEM_TYPE=${envType || '(not set, default: cloud)'}`,
+                `[BaseMcpServer] Skipping tool ${entry.toolDefinition.name}: available_in=${JSON.stringify(availableIn)}, currentEnv=${currentEnv}, source=${this.systemType ? 'option' : 'env'}, SAP_SYSTEM_TYPE=${process.env.SAP_SYSTEM_TYPE || '(not set)'}`,
               );
               continue;
             }

--- a/src/server/EmbeddableMcpServer.ts
+++ b/src/server/EmbeddableMcpServer.ts
@@ -11,6 +11,7 @@ import { SystemHandlersGroup } from '../lib/handlers/groups/SystemHandlersGroup.
 import type {
   IHandlerGroup,
   IHandlersRegistry,
+  SapEnvironment,
 } from '../lib/handlers/interfaces.js';
 import { CompositeHandlersRegistry } from '../lib/handlers/registry/CompositeHandlersRegistry.js';
 import type { IAdtSystemContext } from '../lib/systemContext.js';
@@ -66,6 +67,18 @@ export interface EmbeddableMcpServerOptions {
    * If not provided, handlers will use whatever is available from env vars.
    */
   systemContext?: Partial<IAdtSystemContext>;
+
+  /**
+   * SAP system type for this server instance. Governs which tools are
+   * registered via the `available_in` filter. Overrides the process-global
+   * `SAP_SYSTEM_TYPE` env var. If omitted, falls back to the env var,
+   * then to `'cloud'`.
+   *
+   * Use this when a single host serves multiple SAP systems (e.g., a proxy
+   * that handles both OnPremise and cloud destinations per request) —
+   * mutating `process.env.SAP_SYSTEM_TYPE` per instance is not safe.
+   */
+  systemType?: SapEnvironment;
 }
 
 /**
@@ -100,6 +113,7 @@ export class EmbeddableMcpServer extends BaseMcpServer {
       name: 'mcp-abap-adt',
       version: options.version ?? DEFAULT_VERSION,
       logger: options.logger,
+      systemType: options.systemType,
     });
 
     this.injectedConnection = options.connection;


### PR DESCRIPTION
## Summary
- Adds optional `systemType: 'onprem' | 'cloud' | 'legacy'` to `EmbeddableMcpServerOptions` / `BaseMcpServer` constructor — overrides process-global `SAP_SYSTEM_TYPE` for the per-instance `available_in` tool filter.
- Lets hosts that serve multiple SAP systems per request (proxies mixing OnPremise Cloud Connector and cloud-hosted destinations) register the correct tool set per instance without mutating `process.env`.
- Resolution order: `options.systemType` → `process.env.SAP_SYSTEM_TYPE` → `'cloud'`. Fully backward compatible.
- Bumps core to **6.4.0**; updates CHANGELOG, `docs/user-guide/CLIENT_CONFIGURATION.md`.

Closes #69.

## Test plan
- [x] Integration test `EmbeddableMcpServer.systemType.test.ts` runs against a real ABAP connection:
  - `systemType: 'onprem'` with `SAP_SYSTEM_TYPE=cloud` → onprem-only tools (`CreateProgram`, `UpdateProgram`, `DeleteProgram`) **are registered**
  - `systemType: 'cloud'` with `SAP_SYSTEM_TYPE=onprem` → onprem-only tools **are excluded**
  - No option → env var fallback still works
- [x] `npm run build` passes (biome + tsc)
- [x] Unit-test suite passes (96/97; 1 pre-existing failure in `admin/shared-deps/teardown`, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)