### PR TITLE
release(6.4.1): fix Dockerfile for HTTP mode with header-based connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [6.4.1] - 2026-04-21
+
+### Fixed
+- `docker/Dockerfile`: switch default `MCP_TRANSPORT` from `stdio` to `http` so the image runs as an HTTP MCP server out of the box
+- `docker/Dockerfile`: correct launcher path (`dist/server/v2/launcher.js` → `dist/server/launcher.js`) — previous path did not exist and prevented the container from starting
+- `docker/Dockerfile`: pass `--allow-destination-header` so callers can supply SAP connection parameters via request headers (no default SAP connection baked into the image)
+- `docker/Dockerfile`: fix healthcheck endpoint (`/health` → `/mcp/health`) to match the actual route exposed by `StreamableHttpServer`
+- `docker/Dockerfile`: use `npm run build:fast` in the builder stage — the full `build` runs Biome which requires `.gitignore`, but `.dockerignore` excludes it
+
 ## [6.4.0] - 2026-04-20
 
 ### Added

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN npm ci
 COPY . .
 
 # Build TypeScript to JavaScript
-RUN npm run build
+RUN npm run build:fast
 
 # Remove dev dependencies
 RUN npm prune --omit=dev
@@ -36,7 +36,7 @@ WORKDIR /app
 ENV NODE_ENV=production \
     MCP_HTTP_PORT=3000 \
     MCP_HTTP_HOST=0.0.0.0 \
-    MCP_TRANSPORT=stdio
+    MCP_TRANSPORT=http
 
 # Copy built application
 COPY --from=builder /app/dist ./dist
@@ -51,8 +51,8 @@ EXPOSE 3000 9229
 
 # Healthcheck - only relevant for sse/http transports
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD if [ "$MCP_TRANSPORT" = "stdio" ]; then exit 0; else node -e "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})" || exit 1; fi
+  CMD if [ "$MCP_TRANSPORT" = "stdio" ]; then exit 0; else node -e "require('http').get('http://localhost:3000/mcp/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})" || exit 1; fi
 
 # Start server with v2 launcher
 # Transport will be taken from MCP_TRANSPORT env var (defaults to stdio)
-CMD ["node", "--inspect=0.0.0.0:9229", "./dist/server/v2/launcher.js"]
+CMD ["node", "--inspect=0.0.0.0:9229", "./dist/server/launcher.js", "--allow-destination-header"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.4.0",
+  "version": "6.4.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.4.0",
+      "version": "6.4.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Switch `MCP_TRANSPORT` default from `stdio` to `http` so the image runs as an HTTP MCP server out of the box
- Fix launcher path — was `dist/server/v2/launcher.js` (non-existent), corrected to `dist/server/launcher.js`
- Add `--allow-destination-header` so callers can pass connection parameters via request headers (no default SAP connection baked into the image)
- Fix healthcheck endpoint: `/health` → `/mcp/health` (actual route registered by `StreamableHttpServer`)
- Use `npm run build:fast` in the builder stage — the full `build` runs Biome which requires `.gitignore`, but `.dockerignore` excludes it

## Test plan
- [x] `docker build -f docker/Dockerfile -t mcp-abap-adt:test .` succeeds
- [x] `docker run -p 3000:3000 mcp-abap-adt:test` starts `StreamableHttpServer` on `0.0.0.0:3000`
- [x] `GET /mcp/health` returns `200 {"status":"ok",...,"transport":"http"}`
- [x] `docker inspect --format '{{.State.Health.Status}}'` reports `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)