### PR TITLE
fix(jest): exclude integration tests from default npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "test:init": "node -e \"const fs=require('fs'),s='tests/test-config.yaml',t=s+'.template';if(fs.existsSync(s)){console.log(s+' already exists, skipping (use test:reinit to overwrite)')}else{fs.copyFileSync(t,s);console.log('Created '+s+' — edit lines marked CHANGE')}\"",
     "test:reinit": "node -e \"const fs=require('fs'),s='tests/test-config.yaml',t=s+'.template';fs.copyFileSync(t,s);console.log('Recreated '+s+' from template')\"",
     "test": "jest --passWithNoTests",
-    "test:integration": "jest --testPathPatterns=integration --runInBand --passWithNoTests --forceExit",
-    "test:high": "jest --testPathPatterns='integration.*High' --runInBand --passWithNoTests --forceExit",
-    "test:low": "jest --testPathPatterns='integration.*Low' --runInBand --passWithNoTests --forceExit",
+    "test:integration": "jest --testPathPatterns=integration --testPathIgnorePatterns='__tests__/admin/' --runInBand --passWithNoTests --forceExit",
+    "test:high": "jest --testPathPatterns='integration.*High' --testPathIgnorePatterns='__tests__/admin/' --runInBand --passWithNoTests --forceExit",
+    "test:low": "jest --testPathPatterns='integration.*Low' --testPathIgnorePatterns='__tests__/admin/' --runInBand --passWithNoTests --forceExit",
     "test:check": "npx tsc --noEmit -p tsconfig.test.json",
     "shared:setup": "jest --testPathPatterns='admin/shared-deps/setup' --testPathIgnorePatterns='[]' --runInBand --passWithNoTests",
     "shared:teardown": "jest --testPathPatterns='admin/shared-deps/teardown' --testPathIgnorePatterns='[]' --runInBand --passWithNoTests",
@@ -204,7 +204,8 @@
       "!src/**/index.ts"
     ],
     "testPathIgnorePatterns": [
-      "__tests__/admin/"
+      "__tests__/admin/",
+      "__tests__/integration/"
     ],
     "maxWorkers": 1,
     "testTimeout": 600000,


### PR DESCRIPTION
## Summary
Integration tests under `src/__tests__/integration/` require a live SAP system (SAP_URL, auth broker session) and cannot run in CI. Previously they failed in the release workflow but were hidden in the CI workflow by `continue-on-error: true`, so the **v6.4.0 and v6.4.1 tag pushes failed to create GitHub Releases** (release job is gated by `needs: test`).

- Add `__tests__/integration/` to `jest.testPathIgnorePatterns` so default `npm test` runs unit tests only
- Update `test:integration` / `test:high` / `test:low` to override the ignore with an explicit `--testPathIgnorePatterns` so local integration runs still work (same trick already used by `shared:setup`)

## Test plan
- [x] `npm test` now runs 8 suites / 90 tests in ~1.5s — all green, zero integration tests
- [x] `npx jest --testPathPatterns=integration --testPathIgnorePatterns='__tests__/admin/' --listTests` still lists 42 integration test files
- [ ] After merge: re-tag `v6.4.1` on new `main` HEAD so the Release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)