### PR TITLE
feat(handlers): dedup strategy + FM group validation

### DIFF
--- a/scripts/probe-fm.ts
+++ b/scripts/probe-fm.ts
@@ -1,0 +1,85 @@
+/**
+ * Probe an FM via ADT search + direct GETs. Helps diagnose when a handler
+ * claims "does not exist" but Eclipse shows the FM.
+ */
+import * as path from 'node:path';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import * as dotenv from 'dotenv';
+import { getSapConfigFromEnv } from '../src/__tests__/integration/helpers/configHelpers';
+
+async function tryGet(conn: any, url: string) {
+  try {
+    const res = await conn.makeAdtRequest({ url, method: 'GET' });
+    return {
+      ok: true,
+      status: res?.status ?? 200,
+      len: (res?.data ?? '').length ?? 0,
+      head: String(res?.data ?? '').slice(0, 500),
+    };
+  } catch (e: any) {
+    return {
+      ok: false,
+      status: e?.response?.status,
+      message: e?.message,
+      body: String(e?.response?.data ?? '').slice(0, 500),
+    };
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const get = (f: string) => {
+    const i = args.indexOf(f);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  const fm = get('--fm') ?? 'XPG_COMMAND_EXECUTE';
+  const group = get('--group') ?? 'SXPT';
+  const envFile = path.resolve(
+    get('--env') || path.join(__dirname, '..', 'trial.env'),
+  );
+  dotenv.config({ path: envFile, override: true });
+  console.log(`env: ${envFile}`);
+
+  const conn = createAbapConnection(getSapConfigFromEnv()) as any;
+
+  const probes: { label: string; url: string }[] = [
+    {
+      label: 'search quickSearch',
+      url: `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${encodeURIComponent(
+        fm,
+      )}&maxResults=5`,
+    },
+    {
+      label: 'nodestructure by FM name',
+      url: `/sap/bc/adt/repository/nodestructure?parent_name=${encodeURIComponent(
+        fm,
+      )}&parent_type=FUGR/FF`,
+    },
+    {
+      label: 'metadata via group URL',
+      url: `/sap/bc/adt/functions/groups/${group.toLowerCase()}/fmodules/${fm.toLowerCase()}`,
+    },
+    {
+      label: 'source via group URL',
+      url: `/sap/bc/adt/functions/groups/${group.toLowerCase()}/fmodules/${fm.toLowerCase()}/source/main`,
+    },
+    {
+      label: 'metadata via FUGR/FF ref',
+      url: `/sap/bc/adt/vit/wb/object_type/fugrff/object_name/${encodeURIComponent(
+        fm,
+      )}`,
+    },
+  ];
+
+  for (const p of probes) {
+    const r = await tryGet(conn, p.url);
+    console.log(`\n--- ${p.label} ---`);
+    console.log(`URL: ${p.url}`);
+    console.log(JSON.stringify(r, null, 2));
+  }
+}
+
+main().catch((e) => {
+  console.error('Fatal:', e);
+  process.exit(1);
+});

--- a/scripts/read-fm.ts
+++ b/scripts/read-fm.ts
@@ -1,0 +1,110 @@
+/**
+ * Read a function module via handleReadFunctionModule and dump the raw
+ * response (source + metadata XML). Useful for debugging cases where the
+ * ADT backend is permissive about the function group in the URL.
+ */
+import * as path from 'node:path';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import * as dotenv from 'dotenv';
+import { getSapConfigFromEnv } from '../src/__tests__/integration/helpers/configHelpers';
+import { handleReadFunctionModule } from '../src/handlers/function_module/readonly/handleReadFunctionModule';
+
+function printHelp() {
+  console.log(`Usage:
+  npx tsx scripts/read-fm.ts --fm <NAME> --group <GROUP> [--version active|inactive] [--env <path>]
+
+By default loads ./.env (same as 'npm run dev'). Override with --env <path>.
+
+Examples:
+  npx tsx scripts/read-fm.ts --fm XPG_COMMAND_EXECUTE --group SXPT
+  npx tsx scripts/read-fm.ts --fm XPG_COMMAND_EXECUTE --group SXPG  # wrong on purpose
+  npx tsx scripts/read-fm.ts --fm FOO --group BAR --env ./trial.env`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help')) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const get = (flag: string) => {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+
+  const fm = get('--fm');
+  const group = get('--group');
+  const version = (get('--version') as 'active' | 'inactive') || 'active';
+
+  if (!fm || !group) {
+    console.error('Error: --fm and --group are required.\n');
+    printHelp();
+    process.exit(1);
+  }
+
+  const envArg = get('--env');
+  const envPath = path.resolve(envArg || path.join(__dirname, '..', '.env'));
+  console.log(`Loading env from: ${envPath}`);
+  dotenv.config({ path: envPath, override: true });
+
+  const config = getSapConfigFromEnv();
+  console.log(
+    `Connection: url=${config.url ? 'set' : 'missing'}, jwt=${(config as any).jwtToken ? 'set' : 'missing'}`,
+  );
+  const connection = createAbapConnection(config);
+  const logger = {
+    info: (...a: any[]) => console.error('[info]', ...a),
+    warn: (...a: any[]) => console.error('[warn]', ...a),
+    error: (...a: any[]) => console.error('[error]', ...a),
+    debug: (...a: any[]) => console.error('[debug]', ...a),
+  };
+  const context = { connection, logger } as any;
+
+  console.log(
+    `\nReading FM="${fm}" via group="${group}" version="${version}"...\n`,
+  );
+
+  const result = await handleReadFunctionModule(context, {
+    function_module_name: fm,
+    function_group_name: group,
+    version,
+  });
+
+  if (result.isError) {
+    console.error('Handler returned error:');
+    console.error(JSON.stringify(result, null, 2));
+    process.exit(2);
+  }
+
+  const text = result.content?.[0]?.text ?? '';
+  let parsed: any = null;
+  try {
+    const outer = JSON.parse(text);
+    parsed = outer?.data ? JSON.parse(outer.data) : outer;
+  } catch {
+    console.log(text);
+    return;
+  }
+
+  console.log('=== Response shape ===');
+  console.log({
+    success: parsed.success,
+    echoed_group: parsed.function_group_name,
+    fm: parsed.function_module_name,
+    version: parsed.version,
+    source_len: parsed.source_code?.length ?? 0,
+    metadata_len: parsed.metadata?.length ?? 0,
+  });
+
+  console.log('\n=== Source (first 400 chars) ===');
+  console.log((parsed.source_code ?? '').slice(0, 400));
+
+  console.log('\n=== Metadata XML ===');
+  console.log(parsed.metadata ?? '(none)');
+}
+
+main().catch((e) => {
+  console.error('Unhandled error:', e);
+  process.exit(3);
+});

--- a/src/__tests__/unit/parseContainerGroup.test.ts
+++ b/src/__tests__/unit/parseContainerGroup.test.ts
@@ -1,0 +1,60 @@
+import {
+  assertFunctionGroupMatches,
+  parseContainerGroupName,
+} from '../../handlers/function_module/shared/parseContainerGroup';
+
+const META_SXPT = `<?xml version="1.0"?><fmodule:abapFunctionModule xmlns:adtcore="http://www.sap.com/adt/core" xmlns:fmodule="x"><adtcore:containerRef adtcore:uri="/sap/bc/adt/functions/groups/sxpt" adtcore:type="FUGR/F" adtcore:name="SXPT" adtcore:packageName="SBTC"/></fmodule:abapFunctionModule>`;
+const META_NAME_FIRST = `<adtcore:containerRef adtcore:name="SXPT" adtcore:type="FUGR/F"/>`;
+const META_NO_REF = `<?xml version="1.0"?><fmodule:abapFunctionModule/>`;
+
+describe('parseContainerGroupName', () => {
+  it('extracts group name when type precedes name', () => {
+    expect(parseContainerGroupName(META_SXPT)).toBe('SXPT');
+  });
+
+  it('extracts group name when name precedes type', () => {
+    expect(parseContainerGroupName(META_NAME_FIRST)).toBe('SXPT');
+  });
+
+  it('returns null when containerRef is missing', () => {
+    expect(parseContainerGroupName(META_NO_REF)).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseContainerGroupName('')).toBeNull();
+    expect(parseContainerGroupName(null)).toBeNull();
+    expect(parseContainerGroupName(undefined)).toBeNull();
+  });
+});
+
+describe('assertFunctionGroupMatches', () => {
+  it('returns real group on exact match', () => {
+    expect(
+      assertFunctionGroupMatches(META_SXPT, 'SXPT', 'SXPG_COMMAND_EXECUTE'),
+    ).toBe('SXPT');
+  });
+
+  it('matches case-insensitively', () => {
+    expect(
+      assertFunctionGroupMatches(META_SXPT, 'sxpt', 'SXPG_COMMAND_EXECUTE'),
+    ).toBe('SXPT');
+  });
+
+  it('throws when real group differs', () => {
+    expect(() =>
+      assertFunctionGroupMatches(META_SXPT, 'SXPG', 'SXPG_COMMAND_EXECUTE'),
+    ).toThrow(/belongs to group SXPT, not SXPG/);
+  });
+
+  it('throws when metadata lacks containerRef', () => {
+    expect(() =>
+      assertFunctionGroupMatches(META_NO_REF, 'SXPT', 'SXPG_COMMAND_EXECUTE'),
+    ).toThrow(/Could not determine owning function group/);
+  });
+
+  it('throws on empty metadata', () => {
+    expect(() =>
+      assertFunctionGroupMatches('', 'SXPT', 'SXPG_COMMAND_EXECUTE'),
+    ).toThrow(/Could not determine owning function group/);
+  });
+});

--- a/src/__tests__/unit/readVsGetDedupStrategy.test.ts
+++ b/src/__tests__/unit/readVsGetDedupStrategy.test.ts
@@ -1,0 +1,82 @@
+import {
+  NoDedupStrategy,
+  ReadVsGetDedupStrategy,
+} from '../../lib/handlers/groups/strategies';
+import type { HandlerEntry } from '../../lib/handlers/interfaces';
+
+const makeEntry = (name: string): HandlerEntry =>
+  ({
+    toolDefinition: { name, description: '', inputSchema: {} },
+    handler: async () => ({ content: [] }),
+  }) as any;
+
+describe('ReadVsGetDedupStrategy', () => {
+  const strategy = new ReadVsGetDedupStrategy();
+
+  it('excludes Read<X> when Get<X> is in overriding set', () => {
+    const overriding = new Set(['GetFunctionModule']);
+    expect(
+      strategy.shouldExclude(makeEntry('ReadFunctionModule'), overriding),
+    ).toBe(true);
+  });
+
+  it('keeps Read<X> when Get<X> is not in overriding set', () => {
+    const overriding = new Set(['GetPackage']);
+    expect(
+      strategy.shouldExclude(makeEntry('ReadFunctionModule'), overriding),
+    ).toBe(false);
+  });
+
+  it('never excludes non-Read* entries', () => {
+    const overriding = new Set(['GetEnhancements']);
+    expect(
+      strategy.shouldExclude(makeEntry('GetEnhancements'), overriding),
+    ).toBe(false);
+    expect(
+      strategy.shouldExclude(makeEntry('ListTransports'), overriding),
+    ).toBe(false);
+  });
+
+  it('keeps Read<X> when overriding set is empty', () => {
+    expect(strategy.shouldExclude(makeEntry('ReadClass'), new Set())).toBe(
+      false,
+    );
+  });
+
+  it('handles all 16 known duplicate pairs', () => {
+    const suffixes = [
+      'BehaviorDefinition',
+      'BehaviorImplementation',
+      'Class',
+      'DataElement',
+      'Domain',
+      'FunctionGroup',
+      'FunctionModule',
+      'Interface',
+      'MetadataExtension',
+      'Package',
+      'Program',
+      'ServiceBinding',
+      'ServiceDefinition',
+      'Structure',
+      'Table',
+      'View',
+    ];
+    const overriding = new Set(suffixes.map((s) => 'Get' + s));
+    for (const s of suffixes) {
+      expect(strategy.shouldExclude(makeEntry('Read' + s), overriding)).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe('NoDedupStrategy', () => {
+  it('never excludes anything', () => {
+    const strategy = new NoDedupStrategy();
+    const overriding = new Set(['GetFunctionModule', 'GetClass']);
+    expect(
+      strategy.shouldExclude(makeEntry('ReadFunctionModule'), overriding),
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/unit/validateExposition.test.ts
+++ b/src/__tests__/unit/validateExposition.test.ts
@@ -1,0 +1,49 @@
+import { validateExposition } from '../../lib/config/validateExposition';
+
+describe('validateExposition', () => {
+  it('accepts default [readonly, high]', () => {
+    expect(() => validateExposition(['readonly', 'high'])).not.toThrow();
+  });
+
+  it('accepts [readonly, low]', () => {
+    expect(() => validateExposition(['readonly', 'low'])).not.toThrow();
+  });
+
+  it('accepts [readonly]', () => {
+    expect(() => validateExposition(['readonly'])).not.toThrow();
+  });
+
+  it('accepts [high] alone', () => {
+    expect(() => validateExposition(['high'])).not.toThrow();
+  });
+
+  it('accepts [low] alone', () => {
+    expect(() => validateExposition(['low'])).not.toThrow();
+  });
+
+  it('accepts [compact] alone', () => {
+    expect(() => validateExposition(['compact'])).not.toThrow();
+  });
+
+  it('accepts empty array', () => {
+    expect(() => validateExposition([])).not.toThrow();
+  });
+
+  it('rejects high + low as mutually exclusive', () => {
+    expect(() => validateExposition(['high', 'low'])).toThrow(
+      /mutually exclusive/i,
+    );
+  });
+
+  it('rejects compact combined with readonly', () => {
+    expect(() => validateExposition(['compact', 'readonly'])).toThrow(/alone/i);
+  });
+
+  it('rejects compact combined with high', () => {
+    expect(() => validateExposition(['compact', 'high'])).toThrow(/alone/i);
+  });
+
+  it('rejects compact combined with low', () => {
+    expect(() => validateExposition(['compact', 'low'])).toThrow(/alone/i);
+  });
+});

--- a/src/handlers/function_module/high/handleGetFunctionModule.ts
+++ b/src/handlers/function_module/high/handleGetFunctionModule.ts
@@ -12,6 +12,7 @@ import {
   return_error,
   return_response,
 } from '../../../lib/utils';
+import { assertFunctionGroupMatches } from '../shared/parseContainerGroup';
 
 export const TOOL_DEFINITION = {
   name: 'GetFunctionModule',
@@ -81,10 +82,26 @@ export async function handleGetFunctionModule(
     );
 
     try {
-      // Read function module using AdtClient
       const functionModuleObject = client.getFunctionModule();
+
+      // Verify ownership first — ADT resolves FM by name regardless of group
+      // segment in URL, so we reject mismatches before returning source.
+      const metaResult = await functionModuleObject.readMetadata({
+        functionModuleName,
+        functionGroupName,
+      });
+      const metadataXml =
+        typeof metaResult?.metadataResult?.data === 'string'
+          ? metaResult.metadataResult.data
+          : null;
+      const realGroup = assertFunctionGroupMatches(
+        metadataXml,
+        functionGroupName,
+        functionModuleName,
+      );
+
       const readResult = await functionModuleObject.read(
-        { functionModuleName, functionGroupName },
+        { functionModuleName, functionGroupName: realGroup },
         version as 'active' | 'inactive',
       );
 
@@ -106,7 +123,7 @@ export async function handleGetFunctionModule(
       }
 
       logger?.info(
-        `✅ GetFunctionModule completed successfully: ${functionModuleName}`,
+        `GetFunctionModule completed successfully: ${functionModuleName} in ${realGroup}`,
       );
 
       return return_response({
@@ -114,7 +131,7 @@ export async function handleGetFunctionModule(
           {
             success: true,
             function_module_name: functionModuleName,
-            function_group_name: functionGroupName,
+            function_group_name: realGroup,
             version,
             function_module_data: functionModuleData,
             status: readResult.readResult.status,

--- a/src/handlers/function_module/readonly/handleReadFunctionModule.ts
+++ b/src/handlers/function_module/readonly/handleReadFunctionModule.ts
@@ -5,6 +5,7 @@ import {
   return_error,
   return_response,
 } from '../../../lib/utils';
+import { assertFunctionGroupMatches } from '../shared/parseContainerGroup';
 
 export const TOOL_DEFINITION = {
   name: 'ReadFunctionModule',
@@ -59,10 +60,39 @@ export async function handleReadFunctionModule(
     const functionGroupName = function_group_name.toUpperCase();
     const obj = client.getFunctionModule();
 
+    // Read metadata FIRST — the ADT backend resolves FM by name regardless of
+    // the group segment in the URL, so we must verify ownership from metadata
+    // (<adtcore:containerRef/>) before trusting any source payload.
+    let metadata: string | null = null;
+    try {
+      const metaResult = await obj.readMetadata({
+        functionModuleName,
+        functionGroupName,
+      });
+      if (metaResult?.metadataResult?.data) {
+        metadata =
+          typeof metaResult.metadataResult.data === 'string'
+            ? metaResult.metadataResult.data
+            : safeStringify(metaResult.metadataResult.data);
+      }
+    } catch (e: any) {
+      return return_error(
+        new Error(
+          `Could not read metadata for ${functionModuleName} in group ${functionGroupName}: ${e?.message ?? e}`,
+        ),
+      );
+    }
+
+    const realGroup = assertFunctionGroupMatches(
+      metadata,
+      functionGroupName,
+      functionModuleName,
+    );
+
     let source_code: string | null = null;
     try {
       const readResult = await obj.read(
-        { functionModuleName, functionGroupName },
+        { functionModuleName, functionGroupName: realGroup },
         version as 'active' | 'inactive',
       );
       if (readResult?.readResult?.data) {
@@ -77,30 +107,12 @@ export async function handleReadFunctionModule(
       );
     }
 
-    let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({
-        functionModuleName,
-        functionGroupName,
-      });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${functionModuleName}: ${e?.message}`,
-      );
-    }
-
     return return_response({
       data: JSON.stringify(
         {
           success: true,
           function_module_name: functionModuleName,
-          function_group_name: functionGroupName,
+          function_group_name: realGroup,
           version,
           source_code,
           metadata,

--- a/src/handlers/function_module/shared/parseContainerGroup.ts
+++ b/src/handlers/function_module/shared/parseContainerGroup.ts
@@ -1,0 +1,55 @@
+/**
+ * Parse the owning function group from ADT function module metadata XML.
+ *
+ * The relevant element is:
+ *   <adtcore:containerRef
+ *      adtcore:uri="/sap/bc/adt/functions/groups/sxpt"
+ *      adtcore:type="FUGR/F"
+ *      adtcore:name="SXPT" .../>
+ *
+ * The ADT backend resolves function modules by name alone and happily returns
+ * source/metadata even when the group segment of the URL is wrong. The only
+ * reliable indicator of the real owning group is the `containerRef` element
+ * above. Callers compare it with the caller-supplied group to reject
+ * mismatched inputs instead of silently returning code from a different
+ * group than requested.
+ */
+export function parseContainerGroupName(
+  metadataXml: string | null | undefined,
+): string | null {
+  if (!metadataXml) return null;
+  const match = metadataXml.match(
+    /<adtcore:containerRef\b[^>]*\badtcore:type="FUGR\/F"[^>]*\badtcore:name="([^"]+)"/,
+  );
+  if (match) return match[1];
+  // Attribute order is not guaranteed — try with name before type.
+  const alt = metadataXml.match(
+    /<adtcore:containerRef\b[^>]*\badtcore:name="([^"]+)"[^>]*\badtcore:type="FUGR\/F"/,
+  );
+  return alt ? alt[1] : null;
+}
+
+/**
+ * Validate that the FM belongs to the expected group and return the real
+ * group name from metadata. Throws when the metadata does not contain a
+ * `containerRef` (so we never return unverified source) or when the real
+ * group does not match the expected one (case-insensitive).
+ */
+export function assertFunctionGroupMatches(
+  metadataXml: string | null | undefined,
+  expectedGroupName: string,
+  functionModuleName: string,
+): string {
+  const real = parseContainerGroupName(metadataXml);
+  if (!real) {
+    throw new Error(
+      `Could not determine owning function group for ${functionModuleName} from ADT metadata. Refusing to return unverified source.`,
+    );
+  }
+  if (real.toUpperCase() !== expectedGroupName.toUpperCase()) {
+    throw new Error(
+      `Function module ${functionModuleName} belongs to group ${real}, not ${expectedGroupName}.`,
+    );
+  }
+  return real;
+}

--- a/src/lib/config/validateExposition.ts
+++ b/src/lib/config/validateExposition.ts
@@ -1,0 +1,25 @@
+import type { HandlerSet } from './IServerConfig.js';
+
+/**
+ * Validates an exposition array and throws on disallowed combinations.
+ *
+ * Rules:
+ * - `compact` is exposed only by itself. It cannot be combined with any other set.
+ * - `high` and `low` are mutually exclusive.
+ */
+export function validateExposition(exposition: readonly HandlerSet[]): void {
+  const set = new Set(exposition);
+
+  if (set.has('compact') && set.size > 1) {
+    const others = [...set].filter((s) => s !== 'compact').join(', ');
+    throw new Error(
+      `Invalid exposition: 'compact' must be exposed alone, but also found: ${others}`,
+    );
+  }
+
+  if (set.has('high') && set.has('low')) {
+    throw new Error(
+      `Invalid exposition: 'high' and 'low' are mutually exclusive`,
+    );
+  }
+}

--- a/src/lib/handlers/groups/ReadOnlyHandlersGroup.ts
+++ b/src/lib/handlers/groups/ReadOnlyHandlersGroup.ts
@@ -103,19 +103,47 @@ import {
   TOOL_DEFINITION as ReadView_Tool,
 } from '../../../handlers/view/readonly/handleReadView';
 import { BaseHandlerGroup } from '../base/BaseHandlerGroup.js';
-import type { HandlerEntry } from '../interfaces.js';
+import type { HandlerContext, HandlerEntry } from '../interfaces.js';
+import {
+  type IReadOnlyDedupStrategy,
+  NoDedupStrategy,
+} from './strategies/index.js';
 
 /**
  * Handler group for all readonly (read-only) handlers.
  * Contains handlers that only read data without modifying the ABAP system.
+ *
+ * When other groups (HighLevel / LowLevel / Compact) are also exposed, some
+ * readonly handlers semantically duplicate tools from those groups
+ * (e.g. ReadFunctionModule vs GetFunctionModule). The group hides such
+ * duplicates based on the injected override strategy and the set of tool
+ * names contributed by the other groups.
  */
 export class ReadOnlyHandlersGroup extends BaseHandlerGroup {
   protected groupName = 'ReadOnlyHandlers';
+  private readonly overridingToolNames: ReadonlySet<string>;
+  private readonly dedupStrategy: IReadOnlyDedupStrategy;
+
+  constructor(
+    context: HandlerContext,
+    overridingToolNames: ReadonlySet<string> = new Set(),
+    dedupStrategy: IReadOnlyDedupStrategy = new NoDedupStrategy(),
+  ) {
+    super(context);
+    this.overridingToolNames = overridingToolNames;
+    this.dedupStrategy = dedupStrategy;
+  }
 
   /**
-   * Gets all readonly handler entries
+   * Gets all readonly handler entries, filtered by the dedup strategy.
    */
   getHandlers(): HandlerEntry[] {
+    return this.getAllEntries().filter(
+      (e) => !this.dedupStrategy.shouldExclude(e, this.overridingToolNames),
+    );
+  }
+
+  private getAllEntries(): HandlerEntry[] {
     return [
       // Existing readonly handlers
       {

--- a/src/lib/handlers/groups/index.ts
+++ b/src/lib/handlers/groups/index.ts
@@ -12,3 +12,8 @@ export { LowLevelHandlersGroup } from './LowLevelHandlersGroup.js';
 export { ReadOnlyHandlersGroup } from './ReadOnlyHandlersGroup.js';
 export { SearchHandlersGroup } from './SearchHandlersGroup.js';
 export { SystemHandlersGroup } from './SystemHandlersGroup.js';
+export {
+  type IReadOnlyDedupStrategy,
+  NoDedupStrategy,
+  ReadVsGetDedupStrategy,
+} from './strategies/index.js';

--- a/src/lib/handlers/groups/strategies/IReadOnlyDedupStrategy.ts
+++ b/src/lib/handlers/groups/strategies/IReadOnlyDedupStrategy.ts
@@ -1,0 +1,18 @@
+import type { HandlerEntry } from '../../interfaces.js';
+
+/**
+ * Strategy that decides whether a readonly handler entry should be deduped
+ * (excluded) from the ReadOnly group when overriding handler groups
+ * (high / low / compact) are also exposed.
+ */
+export interface IReadOnlyDedupStrategy {
+  /**
+   * @param entry readonly handler entry being considered
+   * @param overridingToolNames tool names contributed by non-readonly groups
+   * @returns true if the entry should be excluded from the readonly group
+   */
+  shouldExclude(
+    entry: HandlerEntry,
+    overridingToolNames: ReadonlySet<string>,
+  ): boolean;
+}

--- a/src/lib/handlers/groups/strategies/NoDedupStrategy.ts
+++ b/src/lib/handlers/groups/strategies/NoDedupStrategy.ts
@@ -1,0 +1,15 @@
+import type { HandlerEntry } from '../../interfaces.js';
+import type { IReadOnlyDedupStrategy } from './IReadOnlyDedupStrategy.js';
+
+/**
+ * Null strategy — never excludes anything. Useful when the caller wants to
+ * expose the readonly group as-is regardless of other groups present.
+ */
+export class NoDedupStrategy implements IReadOnlyDedupStrategy {
+  shouldExclude(
+    _entry: HandlerEntry,
+    _overridingToolNames: ReadonlySet<string>,
+  ): boolean {
+    return false;
+  }
+}

--- a/src/lib/handlers/groups/strategies/ReadVsGetDedupStrategy.ts
+++ b/src/lib/handlers/groups/strategies/ReadVsGetDedupStrategy.ts
@@ -1,0 +1,22 @@
+import type { HandlerEntry } from '../../interfaces.js';
+import type { IReadOnlyDedupStrategy } from './IReadOnlyDedupStrategy.js';
+
+/**
+ * Excludes a readonly `Read<X>` handler when a corresponding `Get<X>` handler
+ * is contributed by another group (HighLevel) or when the HighLevel/LowLevel
+ * groups otherwise provide a semantic replacement.
+ *
+ * Standalone `Get*` / `List*` readonly handlers (e.g. GetEnhancements,
+ * ListTransports) are never excluded — they have no pair in other groups.
+ */
+export class ReadVsGetDedupStrategy implements IReadOnlyDedupStrategy {
+  shouldExclude(
+    entry: HandlerEntry,
+    overridingToolNames: ReadonlySet<string>,
+  ): boolean {
+    const name = entry.toolDefinition.name;
+    if (!name.startsWith('Read')) return false;
+    const getName = 'Get' + name.slice('Read'.length);
+    return overridingToolNames.has(getName);
+  }
+}

--- a/src/lib/handlers/groups/strategies/index.ts
+++ b/src/lib/handlers/groups/strategies/index.ts
@@ -1,0 +1,3 @@
+export type { IReadOnlyDedupStrategy } from './IReadOnlyDedupStrategy.js';
+export { NoDedupStrategy } from './NoDedupStrategy.js';
+export { ReadVsGetDedupStrategy } from './ReadVsGetDedupStrategy.js';

--- a/src/server/EmbeddableMcpServer.ts
+++ b/src/server/EmbeddableMcpServer.ts
@@ -8,6 +8,7 @@ import { LowLevelHandlersGroup } from '../lib/handlers/groups/LowLevelHandlersGr
 import { ReadOnlyHandlersGroup } from '../lib/handlers/groups/ReadOnlyHandlersGroup.js';
 import { SearchHandlersGroup } from '../lib/handlers/groups/SearchHandlersGroup.js';
 import { SystemHandlersGroup } from '../lib/handlers/groups/SystemHandlersGroup.js';
+import type { IReadOnlyDedupStrategy } from '../lib/handlers/groups/strategies/index.js';
 import type {
   IHandlerGroup,
   IHandlersRegistry,
@@ -79,6 +80,18 @@ export interface EmbeddableMcpServerOptions {
    * mutating `process.env.SAP_SYSTEM_TYPE` per instance is not safe.
    */
   systemType?: SapEnvironment;
+
+  /**
+   * Optional strategy that decides which readonly handlers to dedup (hide)
+   * when overriding groups (high / low / compact) are also exposed.
+   *
+   * Default: no dedup — readonly handlers are exposed verbatim, preserving
+   * prior behavior for existing consumers. Pass `new ReadVsGetDedupStrategy()`
+   * (exported from this package) to hide `Read<X>` when a corresponding
+   * `Get<X>` is contributed by another group, or supply a custom
+   * implementation for bespoke role-based rules.
+   */
+  readOnlyDedupStrategy?: IReadOnlyDedupStrategy;
 }
 
 /**
@@ -128,6 +141,7 @@ export class EmbeddableMcpServer extends BaseMcpServer {
       this.createDefaultRegistry(
         options.exposition ?? ['readonly', 'high'],
         options.logger,
+        options.readOnlyDedupStrategy,
       );
 
     this.registerHandlers(registry);
@@ -154,6 +168,7 @@ export class EmbeddableMcpServer extends BaseMcpServer {
       | 'search'
     )[],
     logger?: Logger,
+    readOnlyDedupStrategy?: IReadOnlyDedupStrategy,
   ): IHandlersRegistry {
     // Dummy context - not actually used because BaseMcpServer.registerHandlers()
     // creates wrapper lambdas that call getConnection() for fresh context
@@ -162,20 +177,39 @@ export class EmbeddableMcpServer extends BaseMcpServer {
       logger: logger ?? noopLogger,
     };
 
-    const groups: IHandlerGroup[] = [];
-
-    if (exposition.includes('readonly')) {
-      groups.push(new ReadOnlyHandlersGroup(dummyContext));
-    }
+    // Build non-readonly groups first so their tool names can feed the
+    // readonly dedup strategy (when one is provided by the consumer).
+    const overridingGroups: IHandlerGroup[] = [];
     if (exposition.includes('high')) {
-      groups.push(new HighLevelHandlersGroup(dummyContext));
-    }
-    if (exposition.includes('compact')) {
-      groups.push(new CompactHandlersGroup(dummyContext));
+      overridingGroups.push(new HighLevelHandlersGroup(dummyContext));
     }
     if (exposition.includes('low')) {
-      groups.push(new LowLevelHandlersGroup(dummyContext));
+      overridingGroups.push(new LowLevelHandlersGroup(dummyContext));
     }
+    if (exposition.includes('compact')) {
+      overridingGroups.push(new CompactHandlersGroup(dummyContext));
+    }
+
+    const overridingToolNames = new Set<string>();
+    if (readOnlyDedupStrategy) {
+      for (const g of overridingGroups) {
+        for (const e of g.getHandlers()) {
+          overridingToolNames.add(e.toolDefinition.name);
+        }
+      }
+    }
+
+    const groups: IHandlerGroup[] = [];
+    if (exposition.includes('readonly')) {
+      groups.push(
+        new ReadOnlyHandlersGroup(
+          dummyContext,
+          overridingToolNames,
+          readOnlyDedupStrategy,
+        ),
+      );
+    }
+    groups.push(...overridingGroups);
     if (exposition.includes('system')) {
       groups.push(new SystemHandlersGroup(dummyContext));
     }

--- a/src/server/launcher.ts
+++ b/src/server/launcher.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import * as dotenv from 'dotenv';
 import { AuthBrokerFactory } from '../lib/auth/index.js';
 import { ServerConfigManager } from '../lib/config/index.js';
+import { validateExposition } from '../lib/config/validateExposition.js';
 import {
   CompactHandlersGroup,
   HighLevelHandlersGroup,
@@ -11,7 +12,11 @@ import {
   SearchHandlersGroup,
   SystemHandlersGroup,
 } from '../lib/handlers/groups/index.js';
-import type { HandlerContext } from '../lib/handlers/interfaces.js';
+import { ReadVsGetDedupStrategy } from '../lib/handlers/groups/strategies/index.js';
+import type {
+  HandlerContext,
+  IHandlerGroup,
+} from '../lib/handlers/interfaces.js';
 import { CompositeHandlersRegistry } from '../lib/handlers/registry/CompositeHandlersRegistry.js';
 import {
   type AuthDisplayConfig,
@@ -196,20 +201,41 @@ async function main() {
 
   // Build handlers based on exposition config (default to readonly,high)
   const exposition = config.exposition || ['readonly', 'high'];
-  const handlerGroups: any[] = [];
-  if (exposition.includes('readonly')) {
-    handlerGroups.push(new ReadOnlyHandlersGroup(baseContext));
-    handlerGroups.push(new SystemHandlersGroup(baseContext));
-  }
+  validateExposition(exposition);
+
+  // Non-readonly groups are built first so that their tool names can be fed
+  // into ReadOnlyHandlersGroup for duplicate suppression (e.g. hide
+  // ReadFunctionModule when GetFunctionModule is also exposed).
+  const overridingGroups: IHandlerGroup[] = [];
   if (exposition.includes('high')) {
-    handlerGroups.push(new HighLevelHandlersGroup(baseContext));
-  }
-  if (exposition.includes('compact')) {
-    handlerGroups.push(new CompactHandlersGroup(baseContext));
+    overridingGroups.push(new HighLevelHandlersGroup(baseContext));
   }
   if (exposition.includes('low')) {
-    handlerGroups.push(new LowLevelHandlersGroup(baseContext));
+    overridingGroups.push(new LowLevelHandlersGroup(baseContext));
   }
+  if (exposition.includes('compact')) {
+    overridingGroups.push(new CompactHandlersGroup(baseContext));
+  }
+
+  const overridingToolNames = new Set<string>();
+  for (const g of overridingGroups) {
+    for (const e of g.getHandlers()) {
+      overridingToolNames.add(e.toolDefinition.name);
+    }
+  }
+
+  const handlerGroups: IHandlerGroup[] = [];
+  if (exposition.includes('readonly')) {
+    handlerGroups.push(
+      new ReadOnlyHandlersGroup(
+        baseContext,
+        overridingToolNames,
+        new ReadVsGetDedupStrategy(),
+      ),
+    );
+    handlerGroups.push(new SystemHandlersGroup(baseContext));
+  }
+  handlerGroups.push(...overridingGroups);
   // SearchHandlersGroup is always included
   handlerGroups.push(new SearchHandlersGroup(baseContext));
 


### PR DESCRIPTION
## Summary

Two separate fixes in one branch (both surfaced from the same UI session):

1. **Pluggable dedup strategy for ReadOnly group.** Consumers can now hide readonly `Read<X>` handlers when another group contributes an equivalent (e.g. `Get<X>` from HighLevel). Default behavior is unchanged — no dedup — so embedder consumers are unaffected until they opt in. The CLI launcher opts in and also validates that `compact` is exposed alone and `high` / `low` are mutually exclusive.
2. **Function module group validation.** ADT silently returns source for the correct FM even when the caller-supplied group is wrong, and the handler was echoing the wrong group back in the response. Now we read metadata first, parse `<adtcore:containerRef adtcore:name="..." adtcore:type="FUGR/F"/>`, reject mismatches with an explicit error, and echo the real group from metadata.

Adds `scripts/read-fm.ts` and `scripts/probe-fm.ts` as diagnostic tools for FM endpoint quirks.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx jest src/__tests__/unit/` — 51/51 green (26 new across both fixes)
- [x] Manual reproduction against trial system: correct group returns source; wrong group now errors with `Function module X belongs to group Y, not Z`.
- [ ] UI smoke via `npm run dev` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)