### PR TITLE
docs(readme): mention readOnlyDedupStrategy option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Documentation
+- README: mention optional `readOnlyDedupStrategy` in the `EmbeddableMcpServer` example and link to the dedup strategies section in `HANDLERS_MANAGEMENT.md`.
+
 ## [6.5.0] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,15 +86,22 @@ mcp-abap-adt --transport=sse           # SSE mode
 ### 2. Embeddable Server (For Integration)
 Embed MCP server into existing applications (e.g., SAP CAP/CDS, Express):
 ```typescript
-import { EmbeddableMcpServer } from '@mcp-abap-adt/core/server';
+import {
+  EmbeddableMcpServer,
+  ReadVsGetDedupStrategy, // optional: hide Read<X> when Get<X> also exposed
+} from '@mcp-abap-adt/core/server';
 
 const server = new EmbeddableMcpServer({
   connection,              // Your AbapConnection instance
   logger,                  // Optional logger
   exposition: ['readonly', 'high'],  // Handler groups to expose
+  // Optional; default: no dedup — existing consumers see no change.
+  readOnlyDedupStrategy: new ReadVsGetDedupStrategy(),
 });
 await server.connect(transport);
 ```
+
+See [Handlers Management → EmbeddableMcpServer dedup strategies](docs/user-guide/HANDLERS_MANAGEMENT.md#embeddablemcpserver-dedup-strategies) for opt-in dedup of readonly tools against high/low/compact, including how to plug a custom `IReadOnlyDedupStrategy` for role-based rules.
 
 ## Quick Start
 


### PR DESCRIPTION
Tiny follow-up to 6.5.0: surface the opt-in \`readOnlyDedupStrategy\` in the top-level README so consumers discover it without having to dive into \`HANDLERS_MANAGEMENT.md\`.

- README \`EmbeddableMcpServer\` example: show import + option with inline comment that dedup is optional.
- Link to \`HANDLERS_MANAGEMENT.md#embeddablemcpserver-dedup-strategies\`.
- CHANGELOG \`[Unreleased] → Documentation\` entry (no version bump).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)