### PR TITLE
release(6.5.1): README dedup note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [6.5.1] - 2026-04-24
+
 ### Documentation
 - README: mention optional `readOnlyDedupStrategy` in the `EmbeddableMcpServer` example and link to the dedup strategies section in `HANDLERS_MANAGEMENT.md`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.5.0",
+      "version": "6.5.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.5.0",
+  "version": "6.5.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.5.0",
+      "version": "6.5.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Docs-only patch release.

- Version bump: \`package.json\`, \`package-lock.json\`, \`server.json\` → 6.5.1.
- CHANGELOG: promote \`[Unreleased]\` Documentation entry to \`[6.5.1] - 2026-04-24\`.

No code changes; picks up PR #75 (README \`readOnlyDedupStrategy\` note) that was merged after v6.5.0 was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)