### PR TITLE
chore(deps): bump adt-clients 5.4.2 + connection 1.8.1 (stale-CSRF 401 fix), release 6.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [6.5.2] - 2026-05-13
+
+### Fixed
+- Bump `@mcp-abap-adt/adt-clients` to `^5.4.2` and `@mcp-abap-adt/connection` to `^1.8.1` to pick up the stale-CSRF 401 recovery fix (fr0ster/mcp-abap-connection#7, originally reported as #78). On on-prem SAP with basic auth, a cached-but-stale CSRF token caused POST/PUT/DELETE to fail permanently with `401 + login HTML`; the connection layer now detects this case, clears the token/cookies, and retries.
+
 ## [6.5.1] - 2026-04-24
 
 ### Documentation

--- a/backups/shared-ZADT_BLD_PKG03.yaml
+++ b/backups/shared-ZADT_BLD_PKG03.yaml
@@ -1,0 +1,373 @@
+schemaVersion: 2
+generatedAt: 2026-05-13T11:46:30.006Z
+package: ZADT_BLD_PKG03
+root:
+  name: ZADT_BLD_PKG03
+  adtType: DEVC/K
+  type: package
+  is_package: true
+  codeFormat: xml
+  children:
+    - name: ZMCP_SHR_PKG
+      adtType: DEVC/K
+      type: package
+      is_package: true
+      codeFormat: xml
+      children:
+        - name: ZMCP_SHR_I_ROOT
+          adtType: BDEF/BDO
+          type: behaviorDefinition
+          description: Shared BDEF for BehaviorDefinition and BehaviorImplementatio
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            name: ZMCP_SHR_I_ROOT
+            description: Shared BDEF for BehaviorDefinition and BehaviorImplementatio
+            packageName: ZMCP_SHR_PKG
+            implementationType: Managed
+            rootEntity: ZMCP_SHR_I_ROOT
+          codeBase64: bWFuYWdlZCBpbXBsZW1lbnRhdGlvbiBpbiBjbGFzcyB6YnBfbWNwX3Nocl9pX3Jvb3QgdW5pcXVlOwpzdHJpY3QgKCAyICk7CgpkZWZpbmUgYmVoYXZpb3IgZm9yIFpNQ1BfU0hSX0lfUk9PVApwZXJzaXN0ZW50IHRhYmxlIHptY3Bfc2hyX3J0YWJsCmxvY2sgbWFzdGVyCmF1dGhvcml6YXRpb24gbWFzdGVyICggaW5zdGFuY2UgKQp7CiAgY3JlYXRlICggYXV0aG9yaXphdGlvbiA6IGdsb2JhbCApOwogIHVwZGF0ZTsKICBkZWxldGU7CiAgZmllbGQgKCByZWFkb25seSApIEZsZDE7CiAgYXNzb2NpYXRpb24gX2NoaWxkcmVuIHsgY3JlYXRlOyB9Cn0KCmRlZmluZSBiZWhhdmlvciBmb3IgWk1DUF9TSFJfSV9DSExECnBlcnNpc3RlbnQgdGFibGUgem1jcF9zaHJfY3RhYmwKbG9jayBkZXBlbmRlbnQgYnkgX3BhcmVudAphdXRob3JpemF0aW9uIGRlcGVuZGVudCBieSBfcGFyZW50CnsKICB1cGRhdGU7CiAgZGVsZXRlOwogIGZpZWxkICggcmVhZG9ubHk6dXBkYXRlICkgQ2hsZElkLCBQYXJlbnRJZDsKICBhc3NvY2lhdGlvbiBfcGFyZW50Owp9
+          codeChecksum: 11caf7909c75774af786d658f8f55d9a41de639a2fae311d1fd690170b17ac0a
+        - name: ZBP_MCP_SHR_I_ROOT
+          adtType: CLAS/OC
+          type: class
+          description: Shared BDEF implementation class for ZMCP_SHR_I_ROOT
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            className: ZBP_MCP_SHR_I_ROOT
+            description: Shared BDEF implementation class for ZMCP_SHR_I_ROOT
+            packageName: ZMCP_SHR_PKG
+            responsible: CB9980008038
+            masterSystem: TRL
+          codeBase64: Q0xBU1MgemJwX21jcF9zaHJfaV9yb290IERFRklOSVRJT04NCiAgUFVCTElDDQogIENSRUFURSBQVUJMSUMgLg0KDQogIFBVQkxJQyBTRUNUSU9OLg0KICBQUk9URUNURUQgU0VDVElPTi4NCiAgUFJJVkFURSBTRUNUSU9OLg0KRU5EQ0xBU1MuDQoNCg0KDQpDTEFTUyB6YnBfbWNwX3Nocl9pX3Jvb3QgSU1QTEVNRU5UQVRJT04uDQpFTkRDTEFTUy4=
+          usedBy:
+            - behaviorDefinition:ZMCP_SHR_I_ROOT
+          codeChecksum: 77fec5c7d174c4646999e88abbcf8dc4adf25f6dff2509bbd53da8f2e7575964
+        - name: ZMCP_BLD_CLSUT_L1
+          adtType: CLAS/OC
+          type: class
+          description: Shared container class for unit test integration tests
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            className: ZMCP_BLD_CLSUT_L1
+            description: Shared container class for unit test integration tests
+            packageName: ZMCP_SHR_PKG
+            responsible: CB9980008038
+            masterSystem: TRL
+          codeBase64: Q0xBU1Mgem1jcF9ibGRfY2xzdXRfbDEgREVGSU5JVElPTg0KICBQVUJMSUMNCiAgQ1JFQVRFIFBVQkxJQyAuDQoNCiAgUFVCTElDIFNFQ1RJT04uDQogIFBST1RFQ1RFRCBTRUNUSU9OLg0KICBQUklWQVRFIFNFQ1RJT04uDQpFTkRDTEFTUy4NCg0KDQoNCkNMQVNTIHptY3BfYmxkX2Nsc3V0X2wxIElNUExFTUVOVEFUSU9OLg0KRU5EQ0xBU1Mu
+          codeChecksum: b48c55f32b862f640743864d1f0d2a7ea8ed4b41d31990b0d5c3be8867d54aa2
+        - name: ZMCP_BLD_CDSV_H1
+          adtType: DDLS/DF
+          type: view
+          description: Shared CDS view for CDS unit test
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared CDS view for CDS unit test
+            packageName: ZMCP_SHR_PKG
+            viewName: ZMCP_BLD_CDSV_H1
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBDRFMgdmlldyBmb3IgQ0RTIHVuaXQgdGVzdCcKQEFjY2Vzc0NvbnRyb2wuYXV0aG9yaXphdGlvbkNoZWNrIDogI05PVF9SRVFVSVJFRApkZWZpbmUgdmlldyBlbnRpdHkgWk1DUF9CTERfQ0RTVl9IMQogIGFzIHNlbGVjdCBmcm9tIHptY3BfY2RzX3RibDAyCnsKICBrZXkgaWQsCiAgbmFtZSwKICB2YWx1ZSwKICBjcmVhdGVkX2F0Cn0K
+          codeChecksum: 23d9d5ac506108b476d9bd391b37c196e8245658a34e666dc7b3b8c0ca58e7fb
+        - name: ZMCP_SHR_C_ROOT
+          adtType: DDLS/DF
+          type: view
+          description: Shared consumption projection CDS view
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared consumption projection CDS view
+            packageName: ZMCP_SHR_PKG
+            viewName: ZMCP_SHR_C_ROOT
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBjb25zdW1wdGlvbiBwcm9qZWN0aW9uJwpAQWNjZXNzQ29udHJvbC5hdXRob3JpemF0aW9uQ2hlY2sgOiAjTk9UX1JFUVVJUkVECmRlZmluZSByb290IHZpZXcgZW50aXR5IFpNQ1BfU0hSX0NfUk9PVAogIHByb3ZpZGVyIGNvbnRyYWN0IHRyYW5zYWN0aW9uYWxfcXVlcnkKICBhcyBwcm9qZWN0aW9uIG9uIFpNQ1BfU0hSX0lfUk9PVAp7CiAga2V5IEZsZDEsCiAgRmxkMiwKICBGbGQzLAogIEZsZDQKfQo=
+          usedBy:
+            - serviceDefinition:ZMCP_SHR_SRVD01
+          codeChecksum: 44b7c1b9ba746a4b263c6d0ef1c015b06131aa69fc10ea50fa4eb3e95fca5d61
+        - name: ZMCP_SHR_I_BCHD
+          adtType: DDLS/DF
+          type: view
+          description: Shared child CDS view for BDEF HIGH test
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared child CDS view for BDEF HIGH test
+            packageName: ZMCP_SHR_PKG
+            viewName: ZMCP_SHR_I_BCHD
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBjaGlsZCBDRFMgdmlldyBmb3IgQkRFRiBISUdIIHRlc3QnCkBBY2Nlc3NDb250cm9sLmF1dGhvcml6YXRpb25DaGVjayA6ICNOT1RfUkVRVUlSRUQKZGVmaW5lIHZpZXcgZW50aXR5IFpNQ1BfU0hSX0lfQkNIRAogIGFzIHNlbGVjdCBmcm9tIHptY3Bfc2hyX2JjdGJsCiAgYXNzb2NpYXRpb24gdG8gcGFyZW50IFpNQ1BfU0hSX0lfQkRFRiBhcyBfcGFyZW50CiAgICBvbiAkcHJvamVjdGlvbi5QYXJlbnRJZCA9IF9wYXJlbnQuRmxkMQp7CiAga2V5IGNobGRfaWQgYXMgQ2hsZElkLAogIHBhcmVudF9pZCBhcyBQYXJlbnRJZCwKICBmbGQyIGFzIEZsZDIsCiAgX3BhcmVudAp9Cg==
+          usedBy:
+            - view:ZMCP_SHR_I_BDEF
+          codeChecksum: a31e95cd3d1935073ffd50ece0b3d33e9f64702993508f7612d35c67132a569d
+        - name: ZMCP_SHR_I_BCHL
+          adtType: DDLS/DF
+          type: view
+          description: Shared child CDS view for BDEF LOW test
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared child CDS view for BDEF LOW test
+            packageName: ZMCP_SHR_PKG
+            viewName: ZMCP_SHR_I_BCHL
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBjaGlsZCBDRFMgdmlldyBmb3IgQkRFRiBMT1cgdGVzdCcKQEFjY2Vzc0NvbnRyb2wuYXV0aG9yaXphdGlvbkNoZWNrIDogI05PVF9SRVFVSVJFRApkZWZpbmUgdmlldyBlbnRpdHkgWk1DUF9TSFJfSV9CQ0hMCiAgYXMgc2VsZWN0IGZyb20gem1jcF9zaHJfYmxjdGwKICBhc3NvY2lhdGlvbiB0byBwYXJlbnQgWk1DUF9TSFJfSV9CREZMIGFzIF9wYXJlbnQKICAgIG9uICRwcm9qZWN0aW9uLlBhcmVudElkID0gX3BhcmVudC5GbGQxCnsKICBrZXkgY2hsZF9pZCBhcyBDaGxkSWQsCiAgcGFyZW50X2lkIGFzIFBhcmVudElkLAogIGZsZDIgYXMgRmxkMiwKICBfcGFyZW50Cn0K
+          usedBy:
+            - view:ZMCP_SHR_I_BDFL
+          codeChecksum: 910875b102cd91cf9a1608e2be5452c687ecd27022a44d818a1b55bc0fb3a4a9
+        - name: ZMCP_SHR_I_BDEF
+          adtType: DDLS/DF
+          type: view
+          description: Shared root CDS view for BDEF HIGH test
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared root CDS view for BDEF HIGH test
+            packageName: ZMCP_SHR_PKG
+            viewName: ZMCP_SHR_I_BDEF
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCByb290IENEUyB2aWV3IGZvciBCREVGIEhJR0ggdGVzdCcKQEFjY2Vzc0NvbnRyb2wuYXV0aG9yaXphdGlvbkNoZWNrIDogI05PVF9SRVFVSVJFRApkZWZpbmUgcm9vdCB2aWV3IGVudGl0eSBaTUNQX1NIUl9JX0JERUYKICBhcyBzZWxlY3QgZnJvbSB6bWNwX3Nocl9idGFibAogIGNvbXBvc2l0aW9uIFswLi4qXSBvZiBaTUNQX1NIUl9JX0JDSEQgYXMgX2NoaWxkcmVuCnsKICBrZXkgZmxkMSBhcyBGbGQxLAogIGZsZDIgYXMgRmxkMiwKICBmbGQzIGFzIEZsZDMsCiAgZmxkNCBhcyBGbGQ0LAogIF9jaGlsZHJlbgp9Cg==
+          usedBy:
+            - view:ZMCP_SHR_I_BCHD
+          codeChecksum: e14e33247655b1a21891418119e74b985c0a85048f0b1a0db8fed0809ff91f94
+        - name: ZMCP_SHR_I_BDFL
+          adtType: DDLS/DF
+          type: view
+          description: Shared root CDS view for BDEF LOW test
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared root CDS view for BDEF LOW test
+            packageName: ZMCP_SHR_PKG
+            viewName: ZMCP_SHR_I_BDFL
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCByb290IENEUyB2aWV3IGZvciBCREVGIExPVyB0ZXN0JwpAQWNjZXNzQ29udHJvbC5hdXRob3JpemF0aW9uQ2hlY2sgOiAjTk9UX1JFUVVJUkVECmRlZmluZSByb290IHZpZXcgZW50aXR5IFpNQ1BfU0hSX0lfQkRGTAogIGFzIHNlbGVjdCBmcm9tIHptY3Bfc2hyX2JsdGJsCiAgY29tcG9zaXRpb24gWzAuLipdIG9mIFpNQ1BfU0hSX0lfQkNITCBhcyBfY2hpbGRyZW4KewogIGtleSBmbGQxIGFzIEZsZDEsCiAgZmxkMiBhcyBGbGQyLAogIGZsZDMgYXMgRmxkMywKICBmbGQ0IGFzIEZsZDQsCiAgX2NoaWxkcmVuCn0K
+          usedBy:
+            - view:ZMCP_SHR_I_BCHL
+          codeChecksum: 575578237d816e4a68c177007864e6412f22fbe72bb3ce6629e2128acee7c3a9
+        - name: ZMCP_SHR_I_CHLD
+          adtType: DDLS/DF
+          type: view
+          description: Shared child CDS view entity
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared child CDS view entity
+            packageName: ZMCP_SHR_PKG
+            viewName: ZMCP_SHR_I_CHLD
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBjaGlsZCBDRFMgdmlldyBlbnRpdHknCkBBY2Nlc3NDb250cm9sLmF1dGhvcml6YXRpb25DaGVjayA6ICNOT1RfUkVRVUlSRUQKZGVmaW5lIHZpZXcgZW50aXR5IFpNQ1BfU0hSX0lfQ0hMRAogIGFzIHNlbGVjdCBmcm9tIHptY3Bfc2hyX2N0YWJsCiAgYXNzb2NpYXRpb24gdG8gcGFyZW50IFpNQ1BfU0hSX0lfUk9PVCBhcyBfcGFyZW50CiAgICBvbiAkcHJvamVjdGlvbi5QYXJlbnRJZCA9IF9wYXJlbnQuRmxkMQp7CiAga2V5IGNobGRfaWQgYXMgQ2hsZElkLAogIHBhcmVudF9pZCBhcyBQYXJlbnRJZCwKICBmbGQyIGFzIEZsZDIsCiAgX3BhcmVudAp9Cg==
+          usedBy:
+            - behaviorDefinition:ZMCP_SHR_I_ROOT
+            - view:ZMCP_SHR_I_ROOT
+          codeChecksum: 09a94d5fbdc7e662e23062a352f668dc0902460815aaa02dcff420282cf5aad2
+        - name: ZMCP_SHR_I_ROOT
+          adtType: DDLS/DF
+          type: view
+          description: Shared root CDS view entity
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared root CDS view entity
+            packageName: ZMCP_SHR_PKG
+            viewName: ZMCP_SHR_I_ROOT
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCByb290IENEUyB2aWV3IGVudGl0eScKQEFjY2Vzc0NvbnRyb2wuYXV0aG9yaXphdGlvbkNoZWNrIDogI05PVF9SRVFVSVJFRApkZWZpbmUgcm9vdCB2aWV3IGVudGl0eSBaTUNQX1NIUl9JX1JPT1QKICBhcyBzZWxlY3QgZnJvbSB6bWNwX3Nocl9ydGFibAogIGNvbXBvc2l0aW9uIFswLi4qXSBvZiBaTUNQX1NIUl9JX0NITEQgYXMgX2NoaWxkcmVuCnsKICBrZXkgZmxkMSBhcyBGbGQxLAogIGZsZDIgYXMgRmxkMiwKICBmbGQzIGFzIEZsZDMsCiAgZmxkNCBhcyBGbGQ0LAogIF9jaGlsZHJlbgp9Cg==
+          usedBy:
+            - behaviorDefinition:ZMCP_SHR_I_ROOT
+            - view:ZMCP_SHR_C_ROOT
+            - view:ZMCP_SHR_I_CHLD
+          codeChecksum: 6ffb270610dc740822b5ef82647a4398c4cb8d2d9118b6363b3bebf62da51dab
+        - name: ZMCP_BLD_SHR_FGR
+          adtType: FUGR/F
+          type: functionGroup
+          description: Shared function group for read tests
+          is_package: false
+          codeFormat: xml
+          children: []
+          functionGroupName: ZMCP_BLD_SHR_FGR
+          restoreStatus: ok
+          config:
+            functionGroupName: ZMCP_BLD_SHR_FGR
+            packageName: ZMCP_SHR_PKG
+            description: Shared function group for read tests
+          codeBase64: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48Z3JvdXA6YWJhcEZ1bmN0aW9uR3JvdXAgZ3JvdXA6bG9ja2VkQnlFZGl0b3I9ImZhbHNlIiBhYmFwc291cmNlOnNvdXJjZVVyaT0ic291cmNlL21haW4iIGFiYXBzb3VyY2U6Zml4UG9pbnRBcml0aG1ldGljPSJ0cnVlIiBhYmFwc291cmNlOmFjdGl2ZVVuaWNvZGVDaGVjaz0iZmFsc2UiIGFkdGNvcmU6cmVzcG9uc2libGU9IkNCOTk4MDAwODAzOCIgYWR0Y29yZTptYXN0ZXJMYW5ndWFnZT0iRU4iIGFkdGNvcmU6bWFzdGVyU3lzdGVtPSJUUkwiIGFkdGNvcmU6YWJhcExhbmd1YWdlVmVyc2lvbj0iY2xvdWREZXZlbG9wbWVudCIgYWR0Y29yZTpuYW1lPSJaTUNQX0JMRF9TSFJfRkdSIiBhZHRjb3JlOnR5cGU9IkZVR1IvRiIgYWR0Y29yZTpjaGFuZ2VkQXQ9IjIwMjYtMDUtMTNUMTE6MjU6MDlaIiBhZHRjb3JlOnZlcnNpb249ImFjdGl2ZSIgYWR0Y29yZTpjcmVhdGVkQXQ9IjIwMjYtMDUtMTNUMDA6MDA6MDBaIiBhZHRjb3JlOmNoYW5nZWRCeT0iQ0I5OTgwMDA4MDM4IiBhZHRjb3JlOmNyZWF0ZWRCeT0iQ0I5OTgwMDA4MDM4IiBhZHRjb3JlOmRlc2NyaXB0aW9uPSJTaGFyZWQgZnVuY3Rpb24gZ3JvdXAgZm9yIHJlYWQgdGVzdHMiIGFkdGNvcmU6ZGVzY3JpcHRpb25UZXh0TGltaXQ9IjQwIiBhZHRjb3JlOmxhbmd1YWdlPSJFTiIgeG1sbnM6Z3JvdXA9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvZnVuY3Rpb25zL2dyb3VwcyIgeG1sbnM6YWJhcHNvdXJjZT0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9hYmFwc291cmNlIiB4bWxuczphZHRjb3JlPSJodHRwOi8vd3d3LnNhcC5jb20vYWR0L2NvcmUiPjxhdG9tOmxpbmsgaHJlZj0ic291cmNlL21haW4vdmVyc2lvbnMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvdmVyc2lvbnMiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0ic291cmNlL21haW4iIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvc291cmNlIiB0eXBlPSJ0ZXh0L3BsYWluIiBldGFnPSIyMDI2MDUxMzExMjUwOTAwMTEiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0ic291cmNlL21haW4iIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvc291cmNlIiB0eXBlPSJ0ZXh0L2h0bWwiIGV0YWc9IjIwMjYwNTEzMTEyNTA5MDAxMSIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC90ZXh0ZWxlbWVudHMvZnVuY3Rpb25ncm91cHMvem1jcF9ibGRfc2hyX2ZnciIgcmVsPSJodHRwOi8vd3d3LnNhcC5jb20vYWR0L3JlbGF0aW9ucy9zb3VyY2VzL3RleHRlbGVtZW50cyIgdGl0bGU9IlRleHQgZWxlbWVudHMiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvZnVuY3Rpb25zL2dyb3Vwcy96bWNwX2JsZF9zaHJfZmdyL2VuaGFuY2VtZW50cy9pbXBsZW1lbnRhdGlvbnMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvZW5oYW5jZW1lbnRJbXBsZW1lbnRhdGlvbnMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC5zYXAuYWR0LmVuaGFuY2VtZW50aW1wbGVtZW50YXRpb25zLnYxK3htbCIgdGl0bGU9IkVuaGFuY2VtZW50IEltcGxlbWVudGF0aW9ucyIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9mdW5jdGlvbnMvZ3JvdXBzL3ptY3BfYmxkX3Nocl9mZ3IvZW5oYW5jZW1lbnRzL29wdGlvbnMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvZW5oYW5jZW1lbnRPcHRpb25zT2ZNYWluT2JqZWN0IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5lbmhhbmNlbWVudG9wdGlvbnMudjIreG1sIiB0aXRsZT0iRW5oYW5jZW1lbnQgT3B0aW9ucyBvZiBNYWluIE9iamVjdCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9mdW5jdGlvbnMvZ3JvdXBzL3ptY3BfYmxkX3Nocl9mZ3Ivc291cmNlL21haW4vZW5oYW5jZW1lbnRzL29wdGlvbnMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvZW5oYW5jZW1lbnRPcHRpb25zIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5lbmhhbmNlbWVudG9wdGlvbnMudjIreG1sIiB0aXRsZT0iRW5oYW5jZW1lbnQgT3B0aW9ucyIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIuL3ptY3BfYmxkX3Nocl9mZ3Ivb2JqZWN0c3RydWN0dXJlIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL29iamVjdHN0cnVjdHVyZSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQub2JqZWN0c3RydWN0dXJlLnYyK3htbCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGFkdGNvcmU6cGFja2FnZVJlZiBhZHRjb3JlOnVyaT0iL3NhcC9iYy9hZHQvcGFja2FnZXMvem1jcF9zaHJfcGtnIiBhZHRjb3JlOnR5cGU9IkRFVkMvSyIgYWR0Y29yZTpuYW1lPSJaTUNQX1NIUl9QS0ciLz48YWJhcHNvdXJjZTpzeW50YXhDb25maWd1cmF0aW9uPjxhYmFwc291cmNlOmxhbmd1YWdlPjxhYmFwc291cmNlOnZlcnNpb24+NTwvYWJhcHNvdXJjZTp2ZXJzaW9uPjxhYmFwc291cmNlOmRlc2NyaXB0aW9uPkFCQVAgZm9yIENsb3VkIERldmVsb3BtZW50PC9hYmFwc291cmNlOmRlc2NyaXB0aW9uPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvYWJhcHNvdXJjZS9wYXJzZXJzL3JuZC9ncmFtbWFyLzUiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvYWJhcHNvdXJjZS9wYXJzZXIiIHR5cGU9InRleHQvcGxhaW4iIHRpdGxlPSJBQkFQIGZvciBDbG91ZCBEZXZlbG9wbWVudCIgZXRhZz0iOTE4NSIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PC9hYmFwc291cmNlOmxhbmd1YWdlPjwvYWJhcHNvdXJjZTpzeW50YXhDb25maWd1cmF0aW9uPjwvZ3JvdXA6YWJhcEZ1bmN0aW9uR3JvdXA+
+          codeChecksum: f72d91864b4230246911290671526373adb9c2829054aea6a45b49161345487a
+        - name: ZMCP_SHR_SRVD01
+          adtType: SRVD/SRV
+          type: serviceDefinition
+          description: Shared service definition for binding tests
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            serviceDefinitionName: ZMCP_SHR_SRVD01
+            packageName: ZMCP_SHR_PKG
+            description: Shared service definition for binding tests
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsOiAnU2hhcmVkIHNlcnZpY2UgZGVmaW5pdGlvbiBmb3IgYmluZGluZyB0ZXN0cycKZGVmaW5lIHNlcnZpY2UgWk1DUF9TSFJfU1JWRDAxIHsKICBleHBvc2UgWk1DUF9TSFJfQ19ST09UIGFzIFZpZXcxOwp9Cg==
+          codeChecksum: c393972a15aa84cbf68444ba2df204d68c54ab15837463f517b618a7370da919
+        - name: ZMCP_CDS_TBL02
+          adtType: TABL/DT
+          type: table
+          description: Shared table for CDS unit test view
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared table for CDS unit test view
+            packageName: ZMCP_SHR_PKG
+            tableName: ZMCP_CDS_TBL02
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQ0RTIHVuaXQgdGVzdCB2aWV3JwpAQWJhcENhdGFsb2cuZW5oYW5jZW1lbnQuY2F0ZWdvcnkgOiAjTk9UX0VYVEVOU0lCTEUKQEFiYXBDYXRhbG9nLnRhYmxlQ2F0ZWdvcnkgOiAjVFJBTlNQQVJFTlQKQEFiYXBDYXRhbG9nLmRlbGl2ZXJ5Q2xhc3MgOiAjQQpAQWJhcENhdGFsb2cuZGF0YU1haW50ZW5hbmNlIDogI1JFU1RSSUNURUQKZGVmaW5lIHRhYmxlIHptY3BfY2RzX3RibDAyIHsKCiAga2V5IGNsaWVudCA6IGFiYXAuY2xudCBub3QgbnVsbDsKICBrZXkgaWQgICAgIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBuYW1lICAgICAgIDogYWJhcC5jaGFyKDUwKTsKICB2YWx1ZSAgICAgIDogYWJhcC5kZWMoMTAsMik7CiAgY3JlYXRlZF9hdCA6IGFiYXAuZGF0czsKCn0=
+          usedBy:
+            - view:ZMCP_BLD_CDSV_H1
+          codeChecksum: e0719eb6b37f46710715a9349aaf9d678a655b973c57fe77c43e634c9fe28f88
+        - name: ZMCP_SHR_BCTBL
+          adtType: TABL/DT
+          type: table
+          description: Shared table for BDEF test child entity
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared table for BDEF test child entity
+            packageName: ZMCP_SHR_PKG
+            tableName: ZMCP_SHR_BCTBL
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQkRFRiB0ZXN0IGNoaWxkIGVudGl0eScKQEFiYXBDYXRhbG9nLmVuaGFuY2VtZW50LmNhdGVnb3J5IDogI05PVF9FWFRFTlNJQkxFCkBBYmFwQ2F0YWxvZy50YWJsZUNhdGVnb3J5IDogI1RSQU5TUEFSRU5UCkBBYmFwQ2F0YWxvZy5kZWxpdmVyeUNsYXNzIDogI0EKQEFiYXBDYXRhbG9nLmRhdGFNYWludGVuYW5jZSA6ICNSRVNUUklDVEVECmRlZmluZSB0YWJsZSB6bWNwX3Nocl9iY3RibCB7CgogIGtleSBjbGllbnQgIDogYWJhcC5jbG50IG5vdCBudWxsOwogIGtleSBjaGxkX2lkIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBwYXJlbnRfaWQgICA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgZmxkMiAgICAgICAgOiBhYmFwLmNoYXIoNTApOwoKfQ==
+          usedBy:
+            - view:ZMCP_SHR_I_BCHD
+          codeChecksum: 60bf8d92cdd873f8c929eb71679f878f4ad45f2d7183a67a97fb76978199293c
+        - name: ZMCP_SHR_BLCTL
+          adtType: TABL/DT
+          type: table
+          description: Shared table for BDEF LOW test child entity
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared table for BDEF LOW test child entity
+            packageName: ZMCP_SHR_PKG
+            tableName: ZMCP_SHR_BLCTL
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQkRFRiBMT1cgdGVzdCBjaGlsZCBlbnRpdHknCkBBYmFwQ2F0YWxvZy5lbmhhbmNlbWVudC5jYXRlZ29yeSA6ICNOT1RfRVhURU5TSUJMRQpAQWJhcENhdGFsb2cudGFibGVDYXRlZ29yeSA6ICNUUkFOU1BBUkVOVApAQWJhcENhdGFsb2cuZGVsaXZlcnlDbGFzcyA6ICNBCkBBYmFwQ2F0YWxvZy5kYXRhTWFpbnRlbmFuY2UgOiAjUkVTVFJJQ1RFRApkZWZpbmUgdGFibGUgem1jcF9zaHJfYmxjdGwgewoKICBrZXkgY2xpZW50ICA6IGFiYXAuY2xudCBub3QgbnVsbDsKICBrZXkgY2hsZF9pZCA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgcGFyZW50X2lkICAgOiBhYmFwLmNoYXIoMTApIG5vdCBudWxsOwogIGZsZDIgICAgICAgIDogYWJhcC5jaGFyKDUwKTsKCn0=
+          usedBy:
+            - view:ZMCP_SHR_I_BCHL
+          codeChecksum: 8428bde8308a64ec228e048a69fc867f0f4ec7590197e4bca1345097f67334ea
+        - name: ZMCP_SHR_BLTBL
+          adtType: TABL/DT
+          type: table
+          description: Shared table for BDEF LOW test root entity
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared table for BDEF LOW test root entity
+            packageName: ZMCP_SHR_PKG
+            tableName: ZMCP_SHR_BLTBL
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQkRFRiBMT1cgdGVzdCByb290IGVudGl0eScKQEFiYXBDYXRhbG9nLmVuaGFuY2VtZW50LmNhdGVnb3J5IDogI05PVF9FWFRFTlNJQkxFCkBBYmFwQ2F0YWxvZy50YWJsZUNhdGVnb3J5IDogI1RSQU5TUEFSRU5UCkBBYmFwQ2F0YWxvZy5kZWxpdmVyeUNsYXNzIDogI0EKQEFiYXBDYXRhbG9nLmRhdGFNYWludGVuYW5jZSA6ICNSRVNUUklDVEVECmRlZmluZSB0YWJsZSB6bWNwX3Nocl9ibHRibCB7CgogIGtleSBjbGllbnQgOiBhYmFwLmNsbnQgbm90IG51bGw7CiAga2V5IGZsZDEgICA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgZmxkMiAgICAgICA6IGFiYXAuY2hhcig1MCk7CiAgZmxkMyAgICAgICA6IGFiYXAuZGVjKDEwLDIpOwogIGZsZDQgICAgICAgOiBhYmFwLmRhdHM7Cgp9
+          usedBy:
+            - view:ZMCP_SHR_I_BDFL
+          codeChecksum: 96baa71e4d0522c1d537ff7778aa48b8a5a42aecb77956e36fdbcee571e31141
+        - name: ZMCP_SHR_BTABL
+          adtType: TABL/DT
+          type: table
+          description: Shared table for BDEF test root entity
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared table for BDEF test root entity
+            packageName: ZMCP_SHR_PKG
+            tableName: ZMCP_SHR_BTABL
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQkRFRiB0ZXN0IHJvb3QgZW50aXR5JwpAQWJhcENhdGFsb2cuZW5oYW5jZW1lbnQuY2F0ZWdvcnkgOiAjTk9UX0VYVEVOU0lCTEUKQEFiYXBDYXRhbG9nLnRhYmxlQ2F0ZWdvcnkgOiAjVFJBTlNQQVJFTlQKQEFiYXBDYXRhbG9nLmRlbGl2ZXJ5Q2xhc3MgOiAjQQpAQWJhcENhdGFsb2cuZGF0YU1haW50ZW5hbmNlIDogI1JFU1RSSUNURUQKZGVmaW5lIHRhYmxlIHptY3Bfc2hyX2J0YWJsIHsKCiAga2V5IGNsaWVudCA6IGFiYXAuY2xudCBub3QgbnVsbDsKICBrZXkgZmxkMSAgIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBmbGQyICAgICAgIDogYWJhcC5jaGFyKDUwKTsKICBmbGQzICAgICAgIDogYWJhcC5kZWMoMTAsMik7CiAgZmxkNCAgICAgICA6IGFiYXAuZGF0czsKCn0=
+          usedBy:
+            - view:ZMCP_SHR_I_BDEF
+          codeChecksum: fde51e317ac26c4d628f94f6d891d0f9397d9715dcd439883baa90e70a96f497
+        - name: ZMCP_SHR_CTABL
+          adtType: TABL/DT
+          type: table
+          description: Shared table for child CDS entity
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared table for child CDS entity
+            packageName: ZMCP_SHR_PKG
+            tableName: ZMCP_SHR_CTABL
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgY2hpbGQgQ0RTIGVudGl0eScKQEFiYXBDYXRhbG9nLmVuaGFuY2VtZW50LmNhdGVnb3J5IDogI05PVF9FWFRFTlNJQkxFCkBBYmFwQ2F0YWxvZy50YWJsZUNhdGVnb3J5IDogI1RSQU5TUEFSRU5UCkBBYmFwQ2F0YWxvZy5kZWxpdmVyeUNsYXNzIDogI0EKQEFiYXBDYXRhbG9nLmRhdGFNYWludGVuYW5jZSA6ICNSRVNUUklDVEVECmRlZmluZSB0YWJsZSB6bWNwX3Nocl9jdGFibCB7CgogIGtleSBjbGllbnQgIDogYWJhcC5jbG50IG5vdCBudWxsOwogIGtleSBjaGxkX2lkIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBwYXJlbnRfaWQgICA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgZmxkMiAgICAgICAgOiBhYmFwLmNoYXIoNTApOwoKfQ==
+          usedBy:
+            - behaviorDefinition:ZMCP_SHR_I_ROOT
+            - view:ZMCP_SHR_I_CHLD
+          codeChecksum: 64a8e6a509b714ba2305214939e492ceb361a0cdb4436f625691005e5472d078
+        - name: ZMCP_SHR_RTABL
+          adtType: TABL/DT
+          type: table
+          description: Shared table for root CDS entity
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared table for root CDS entity
+            packageName: ZMCP_SHR_PKG
+            tableName: ZMCP_SHR_RTABL
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3Igcm9vdCBDRFMgZW50aXR5JwpAQWJhcENhdGFsb2cuZW5oYW5jZW1lbnQuY2F0ZWdvcnkgOiAjTk9UX0VYVEVOU0lCTEUKQEFiYXBDYXRhbG9nLnRhYmxlQ2F0ZWdvcnkgOiAjVFJBTlNQQVJFTlQKQEFiYXBDYXRhbG9nLmRlbGl2ZXJ5Q2xhc3MgOiAjQQpAQWJhcENhdGFsb2cuZGF0YU1haW50ZW5hbmNlIDogI1JFU1RSSUNURUQKZGVmaW5lIHRhYmxlIHptY3Bfc2hyX3J0YWJsIHsKCiAga2V5IGNsaWVudCA6IGFiYXAuY2xudCBub3QgbnVsbDsKICBrZXkgZmxkMSAgIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBmbGQyICAgICAgIDogYWJhcC5jaGFyKDUwKTsKICBmbGQzICAgICAgIDogYWJhcC5kZWMoMTAsMik7CiAgZmxkNCAgICAgICA6IGFiYXAuZGF0czsKCn0=
+          usedBy:
+            - behaviorDefinition:ZMCP_SHR_I_ROOT
+            - view:ZMCP_SHR_I_ROOT
+          codeChecksum: 2fa8da8edcd49bf2cbcbb5bd4ebf61af838a77c3b4786a39bc26bf55fdd04c43
+        - name: ZMCP_VIEW_TBL02
+          adtType: TABL/DT
+          type: table
+          description: Shared table for View builder tests
+          is_package: false
+          codeFormat: source
+          children: []
+          restoreStatus: ok
+          config:
+            description: Shared table for View builder tests
+            packageName: ZMCP_SHR_PKG
+            tableName: ZMCP_VIEW_TBL02
+          codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgVmlldyBidWlsZGVyIHRlc3RzJwpAQWJhcENhdGFsb2cuZW5oYW5jZW1lbnQuY2F0ZWdvcnkgOiAjTk9UX0VYVEVOU0lCTEUKQEFiYXBDYXRhbG9nLnRhYmxlQ2F0ZWdvcnkgOiAjVFJBTlNQQVJFTlQKQEFiYXBDYXRhbG9nLmRlbGl2ZXJ5Q2xhc3MgOiAjQQpAQWJhcENhdGFsb2cuZGF0YU1haW50ZW5hbmNlIDogI1JFU1RSSUNURUQKZGVmaW5lIHRhYmxlIHptY3Bfdmlld190YmwwMiB7CgogIGtleSBjbGllbnQgOiBhYmFwLmNsbnQgbm90IG51bGw7CiAga2V5IGlkICAgICA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgbmFtZSAgICAgICA6IGFiYXAuY2hhcig1MCk7CiAgdmFsdWUgICAgICA6IGFiYXAuZGVjKDEwLDIpOwogIGNyZWF0ZWRfYXQgOiBhYmFwLmRhdHM7Cgp9
+          codeChecksum: 68293e719756cfec0f44ac639f6b30334396b1821f6eff1c1a160f756f9481ab
+      restoreStatus: ok
+      description: Shared test dependencies package
+      config:
+        packageName: ZMCP_SHR_PKG
+        description: Shared test dependencies package
+        superPackage: ZADT_BLD_PKG03
+        softwareComponent: ZLOCAL
+        responsible: CB9980008038
+      codeBase64: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48cGFrOnBhY2thZ2UgYWR0Y29yZTpyZXNwb25zaWJsZT0iQ0I5OTgwMDA4MDM4IiBhZHRjb3JlOm1hc3Rlckxhbmd1YWdlPSJFTiIgYWR0Y29yZTptYXN0ZXJTeXN0ZW09IlRSTCIgYWR0Y29yZTpuYW1lPSJaTUNQX1NIUl9QS0ciIGFkdGNvcmU6dHlwZT0iREVWQy9LIiBhZHRjb3JlOmNoYW5nZWRBdD0iMjAyNi0wNS0xM1QwMDowMDowMFoiIGFkdGNvcmU6dmVyc2lvbj0iYWN0aXZlIiBhZHRjb3JlOmNyZWF0ZWRBdD0iMjAyNi0wNS0xM1QwMDowMDowMFoiIGFkdGNvcmU6Y2hhbmdlZEJ5PSJDQjk5ODAwMDgwMzgiIGFkdGNvcmU6Y3JlYXRlZEJ5PSJDQjk5ODAwMDgwMzgiIGFkdGNvcmU6ZGVzY3JpcHRpb249IlNoYXJlZCB0ZXN0IGRlcGVuZGVuY2llcyBwYWNrYWdlIiBhZHRjb3JlOmRlc2NyaXB0aW9uVGV4dExpbWl0PSI2MCIgYWR0Y29yZTpsYW5ndWFnZT0iRU4iIHhtbG5zOnBhaz0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9wYWNrYWdlcyIgeG1sbnM6YWR0Y29yZT0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9jb3JlIj48YXRvbTpsaW5rIGhyZWY9InZlcnNpb25zIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL3ZlcnNpb25zIiB0aXRsZT0iSGlzdG9yaWMgdmVyc2lvbnMiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvdml0L3diL29iamVjdF90eXBlL2RldmNrL29iamVjdF9uYW1lL1pNQ1BfU0hSX1BLRyIgcmVsPSJzZWxmIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLnNhcGd1aSIgdGl0bGU9IlJlcHJlc2VudGF0aW9uIGluIFNBUCBHdWkiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvcGFja2FnZXMvdmFsdWVoZWxwcy9hcHBsaWNhdGlvbmNvbXBvbmVudHMiIHJlbD0iYXBwbGljYXRpb25jb21wb25lbnRzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5uYW1lZGl0ZW1zLnYxK3htbCIgdGl0bGU9IkFwcGxpY2F0aW9uIENvbXBvbmVudHMgVmFsdWUgSGVscCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9wYWNrYWdlcy92YWx1ZWhlbHBzL3NvZnR3YXJlY29tcG9uZW50cyIgcmVsPSJzb2Z0d2FyZWNvbXBvbmVudHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC5zYXAuYWR0Lm5hbWVkaXRlbXMudjEreG1sIiB0aXRsZT0iU29mdHdhcmUgQ29tcG9uZW50cyBWYWx1ZSBIZWxwIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9Ii9zYXAvYmMvYWR0L3BhY2thZ2VzL3ZhbHVlaGVscHMvdHJhbnNwb3J0bGF5ZXJzIiByZWw9InRyYW5zcG9ydGxheWVycyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQubmFtZWRpdGVtcy52MSt4bWwiIHRpdGxlPSJUcmFuc3BvcnQgTGF5ZXJzIFZhbHVlIEhlbHAiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvcGFja2FnZXMvdmFsdWVoZWxwcy9hYmFwbGFuZ3VhZ2V2ZXJzaW9ucyIgcmVsPSJhYmFwbGFuZ3VhZ2V2ZXJzaW9ucyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQubmFtZWRpdGVtcy52MSt4bWwiIHRpdGxlPSJBQkFQIExhbmd1YWdlIFZlcnNpb24gVmFsdWUgSGVscCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9jaGVja3J1bnN7P3JlcG9ydGVyc30iIHJlbD0ic3VwcG9ydHNQYWNrYWdlQ2hlY2tBY3Rpb25zIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5jaGVja29iamVjdHMreG1sIiB0aXRsZT0iU3VwcG9ydHMgUGFja2FnZSBDaGVjayBhY3Rpb25zIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9Ii4vem1jcF9zaHJfcGtnIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL3NvdXJjZSIgdHlwZT0idGV4dC9odG1sIiB0aXRsZT0iTGFuZGluZyBQYWdlIChIVE1MKSIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGFkdGNvcmU6cGFja2FnZVJlZiBhZHRjb3JlOnVyaT0iL3NhcC9iYy9hZHQvcGFja2FnZXMvem1jcF9zaHJfcGtnIiBhZHRjb3JlOnR5cGU9IkRFVkMvSyIgYWR0Y29yZTpuYW1lPSJaTUNQX1NIUl9QS0ciIGFkdGNvcmU6ZGVzY3JpcHRpb249IlNoYXJlZCB0ZXN0IGRlcGVuZGVuY2llcyBwYWNrYWdlIi8+PHBhazphdHRyaWJ1dGVzIHBhazpwYWNrYWdlVHlwZT0iZGV2ZWxvcG1lbnQiIHBhazppc1BhY2thZ2VUeXBlRWRpdGFibGU9ImZhbHNlIiBwYWs6aXNBZGRpbmdPYmplY3RzQWxsb3dlZD0iZmFsc2UiIHBhazppc0FkZGluZ09iamVjdHNBbGxvd2VkRWRpdGFibGU9InRydWUiIHBhazppc0VuY2Fwc3VsYXRlZD0iZmFsc2UiIHBhazppc0VuY2Fwc3VsYXRpb25FZGl0YWJsZT0idHJ1ZSIgcGFrOmlzRW5jYXBzdWxhdGlvblZpc2libGU9InRydWUiIHBhazpyZWNvcmRDaGFuZ2VzPSJmYWxzZSIgcGFrOmlzUmVjb3JkQ2hhbmdlc0VkaXRhYmxlPSJmYWxzZSIgcGFrOmlzU3dpdGNoVmlzaWJsZT0iZmFsc2UiIHBhazpsYW5ndWFnZVZlcnNpb249IjUiIHBhazppc0xhbmd1YWdlVmVyc2lvblZpc2libGU9InRydWUiIHBhazppc0xhbmd1YWdlVmVyc2lvbkVkaXRhYmxlPSJ0cnVlIi8+PHBhazpzdXBlclBhY2thZ2UgYWR0Y29yZTp1cmk9Ii9zYXAvYmMvYWR0L3BhY2thZ2VzL3phZHRfYmxkX3BrZzAzIiBhZHRjb3JlOnR5cGU9IkRFVkMvSyIgYWR0Y29yZTpuYW1lPSJaQURUX0JMRF9QS0cwMyIgYWR0Y29yZTpkZXNjcmlwdGlvbj0iTUNQIHRlc3QgcGFja2FnZSIvPjxwYWs6YXBwbGljYXRpb25Db21wb25lbnQgcGFrOm5hbWU9IiIgcGFrOmRlc2NyaXB0aW9uPSJObyBhcHBsaWNhdGlvbiBjb21wb25lbnQgYXNzaWduZWQiIHBhazppc1Zpc2libGU9ImZhbHNlIiBwYWs6aXNFZGl0YWJsZT0iZmFsc2UiLz48cGFrOnRyYW5zcG9ydD48cGFrOnNvZnR3YXJlQ29tcG9uZW50IHBhazpuYW1lPSJaTE9DQUwiIHBhazpkZXNjcmlwdGlvbj0iU29mdHdhcmUgQ29tcG9uZW50IGZvciBsb2NhbCBkZXZlbG9wbWVudCIgcGFrOnR5cGU9IkoiIHBhazp0eXBlRGVzY3JpcHRpb249IkxvY2FsIGN1c3RvbWVyIGRldmVsb3BtZW50cyAoQUJBUCBmb3IgY2xvdWQgZGV2ZWxvcG1lbnQpIiBwYWs6aXNWaXNpYmxlPSJ0cnVlIiBwYWs6aXNFZGl0YWJsZT0iZmFsc2UiLz48cGFrOnRyYW5zcG9ydExheWVyIHBhazpuYW1lPSIiIHBhazpkZXNjcmlwdGlvbj0iIiBwYWs6aXNWaXNpYmxlPSJ0cnVlIiBwYWs6aXNFZGl0YWJsZT0iZmFsc2UiLz48L3Bhazp0cmFuc3BvcnQ+PHBhazp1c2VBY2Nlc3NlcyBwYWs6aXNWaXNpYmxlPSJ0cnVlIi8+PHBhazpwYWNrYWdlSW50ZXJmYWNlcyBwYWs6aXNWaXNpYmxlPSJ0cnVlIi8+PHBhazpzdWJQYWNrYWdlcy8+PC9wYWs6cGFja2FnZT4=
+      codeChecksum: 86e8f069c88fb8876751697d80acf1da1279dd7f05dac57c8c10bd9456a6b2a6
+  restoreStatus: ok
+  description: MCP test package
+  config:
+    packageName: ZADT_BLD_PKG03
+    description: MCP test package
+    superPackage: ZLOCAL
+    softwareComponent: ZLOCAL
+    responsible: CB9980008038
+  codeBase64: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48cGFrOnBhY2thZ2UgYWR0Y29yZTpyZXNwb25zaWJsZT0iQ0I5OTgwMDA4MDM4IiBhZHRjb3JlOm1hc3Rlckxhbmd1YWdlPSJFTiIgYWR0Y29yZTptYXN0ZXJTeXN0ZW09IlRSTCIgYWR0Y29yZTpuYW1lPSJaQURUX0JMRF9QS0cwMyIgYWR0Y29yZTp0eXBlPSJERVZDL0siIGFkdGNvcmU6Y2hhbmdlZEF0PSIyMDI2LTA1LTEzVDAwOjAwOjAwWiIgYWR0Y29yZTp2ZXJzaW9uPSJhY3RpdmUiIGFkdGNvcmU6Y3JlYXRlZEF0PSIyMDI2LTA1LTEzVDAwOjAwOjAwWiIgYWR0Y29yZTpjaGFuZ2VkQnk9IkNCOTk4MDAwODAzOCIgYWR0Y29yZTpjcmVhdGVkQnk9IkNCOTk4MDAwODAzOCIgYWR0Y29yZTpkZXNjcmlwdGlvbj0iTUNQIHRlc3QgcGFja2FnZSIgYWR0Y29yZTpkZXNjcmlwdGlvblRleHRMaW1pdD0iNjAiIGFkdGNvcmU6bGFuZ3VhZ2U9IkVOIiB4bWxuczpwYWs9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcGFja2FnZXMiIHhtbG5zOmFkdGNvcmU9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvY29yZSI+PGF0b206bGluayBocmVmPSJ2ZXJzaW9ucyIgcmVsPSJodHRwOi8vd3d3LnNhcC5jb20vYWR0L3JlbGF0aW9ucy92ZXJzaW9ucyIgdGl0bGU9Ikhpc3RvcmljIHZlcnNpb25zIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9Ii9zYXAvYmMvYWR0L3ZpdC93Yi9vYmplY3RfdHlwZS9kZXZjay9vYmplY3RfbmFtZS9aQURUX0JMRF9QS0cwMyIgcmVsPSJzZWxmIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLnNhcGd1aSIgdGl0bGU9IlJlcHJlc2VudGF0aW9uIGluIFNBUCBHdWkiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvcGFja2FnZXMvdmFsdWVoZWxwcy9hcHBsaWNhdGlvbmNvbXBvbmVudHMiIHJlbD0iYXBwbGljYXRpb25jb21wb25lbnRzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5uYW1lZGl0ZW1zLnYxK3htbCIgdGl0bGU9IkFwcGxpY2F0aW9uIENvbXBvbmVudHMgVmFsdWUgSGVscCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9wYWNrYWdlcy92YWx1ZWhlbHBzL3NvZnR3YXJlY29tcG9uZW50cyIgcmVsPSJzb2Z0d2FyZWNvbXBvbmVudHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC5zYXAuYWR0Lm5hbWVkaXRlbXMudjEreG1sIiB0aXRsZT0iU29mdHdhcmUgQ29tcG9uZW50cyBWYWx1ZSBIZWxwIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9Ii9zYXAvYmMvYWR0L3BhY2thZ2VzL3ZhbHVlaGVscHMvdHJhbnNwb3J0bGF5ZXJzIiByZWw9InRyYW5zcG9ydGxheWVycyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQubmFtZWRpdGVtcy52MSt4bWwiIHRpdGxlPSJUcmFuc3BvcnQgTGF5ZXJzIFZhbHVlIEhlbHAiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvcGFja2FnZXMvdmFsdWVoZWxwcy9hYmFwbGFuZ3VhZ2V2ZXJzaW9ucyIgcmVsPSJhYmFwbGFuZ3VhZ2V2ZXJzaW9ucyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQubmFtZWRpdGVtcy52MSt4bWwiIHRpdGxlPSJBQkFQIExhbmd1YWdlIFZlcnNpb24gVmFsdWUgSGVscCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9jaGVja3J1bnN7P3JlcG9ydGVyc30iIHJlbD0ic3VwcG9ydHNQYWNrYWdlQ2hlY2tBY3Rpb25zIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5jaGVja29iamVjdHMreG1sIiB0aXRsZT0iU3VwcG9ydHMgUGFja2FnZSBDaGVjayBhY3Rpb25zIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9Ii4vemFkdF9ibGRfcGtnMDMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvc291cmNlIiB0eXBlPSJ0ZXh0L2h0bWwiIHRpdGxlPSJMYW5kaW5nIFBhZ2UgKEhUTUwpIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YWR0Y29yZTpwYWNrYWdlUmVmIGFkdGNvcmU6dXJpPSIvc2FwL2JjL2FkdC9wYWNrYWdlcy96YWR0X2JsZF9wa2cwMyIgYWR0Y29yZTp0eXBlPSJERVZDL0siIGFkdGNvcmU6bmFtZT0iWkFEVF9CTERfUEtHMDMiIGFkdGNvcmU6ZGVzY3JpcHRpb249Ik1DUCB0ZXN0IHBhY2thZ2UiLz48cGFrOmF0dHJpYnV0ZXMgcGFrOnBhY2thZ2VUeXBlPSJkZXZlbG9wbWVudCIgcGFrOmlzUGFja2FnZVR5cGVFZGl0YWJsZT0iZmFsc2UiIHBhazppc0FkZGluZ09iamVjdHNBbGxvd2VkPSJmYWxzZSIgcGFrOmlzQWRkaW5nT2JqZWN0c0FsbG93ZWRFZGl0YWJsZT0idHJ1ZSIgcGFrOmlzRW5jYXBzdWxhdGVkPSJ0cnVlIiBwYWs6aXNFbmNhcHN1bGF0aW9uRWRpdGFibGU9InRydWUiIHBhazppc0VuY2Fwc3VsYXRpb25WaXNpYmxlPSJ0cnVlIiBwYWs6cmVjb3JkQ2hhbmdlcz0iZmFsc2UiIHBhazppc1JlY29yZENoYW5nZXNFZGl0YWJsZT0iZmFsc2UiIHBhazppc1N3aXRjaFZpc2libGU9ImZhbHNlIiBwYWs6bGFuZ3VhZ2VWZXJzaW9uPSI1IiBwYWs6aXNMYW5ndWFnZVZlcnNpb25WaXNpYmxlPSJ0cnVlIiBwYWs6aXNMYW5ndWFnZVZlcnNpb25FZGl0YWJsZT0idHJ1ZSIvPjxwYWs6c3VwZXJQYWNrYWdlIGFkdGNvcmU6dXJpPSIvc2FwL2JjL2FkdC9wYWNrYWdlcy96bG9jYWwiIGFkdGNvcmU6dHlwZT0iREVWQy9LIiBhZHRjb3JlOm5hbWU9IlpMT0NBTCIgYWR0Y29yZTpkZXNjcmlwdGlvbj0iR2VuZXJhdGVkIFBhY2thZ2UgZm9yIFpMT0NBTCIvPjxwYWs6YXBwbGljYXRpb25Db21wb25lbnQgcGFrOm5hbWU9IiIgcGFrOmRlc2NyaXB0aW9uPSJObyBhcHBsaWNhdGlvbiBjb21wb25lbnQgYXNzaWduZWQiIHBhazppc1Zpc2libGU9ImZhbHNlIiBwYWs6aXNFZGl0YWJsZT0iZmFsc2UiLz48cGFrOnRyYW5zcG9ydD48cGFrOnNvZnR3YXJlQ29tcG9uZW50IHBhazpuYW1lPSJaTE9DQUwiIHBhazpkZXNjcmlwdGlvbj0iU29mdHdhcmUgQ29tcG9uZW50IGZvciBsb2NhbCBkZXZlbG9wbWVudCIgcGFrOnR5cGU9IkoiIHBhazp0eXBlRGVzY3JpcHRpb249IkxvY2FsIGN1c3RvbWVyIGRldmVsb3BtZW50cyAoQUJBUCBmb3IgY2xvdWQgZGV2ZWxvcG1lbnQpIiBwYWs6aXNWaXNpYmxlPSJ0cnVlIiBwYWs6aXNFZGl0YWJsZT0iZmFsc2UiLz48cGFrOnRyYW5zcG9ydExheWVyIHBhazpuYW1lPSIiIHBhazpkZXNjcmlwdGlvbj0iIiBwYWs6aXNWaXNpYmxlPSJ0cnVlIiBwYWs6aXNFZGl0YWJsZT0iZmFsc2UiLz48L3Bhazp0cmFuc3BvcnQ+PHBhazp1c2VBY2Nlc3NlcyBwYWs6aXNWaXNpYmxlPSJ0cnVlIi8+PHBhazpwYWNrYWdlSW50ZXJmYWNlcyBwYWs6aXNWaXNpYmxlPSJ0cnVlIi8+PHBhazpzdWJQYWNrYWdlcz48cGFrOnBhY2thZ2VSZWYgYWR0Y29yZTp1cmk9Ii9zYXAvYmMvYWR0L3BhY2thZ2VzL3ptY3Bfc2hyX3BrZyIgYWR0Y29yZTp0eXBlPSJERVZDL0siIGFkdGNvcmU6bmFtZT0iWk1DUF9TSFJfUEtHIiBhZHRjb3JlOmRlc2NyaXB0aW9uPSJTaGFyZWQgdGVzdCBkZXBlbmRlbmNpZXMgcGFja2FnZSIvPjwvcGFrOnN1YlBhY2thZ2VzPjwvcGFrOnBhY2thZ2U+
+  codeChecksum: 86cbb4f688251316c9c0b1a9e821a3bca0de6182338bd18d2b4c01f86fa577ad
+checksum: b1762e7e09564a396c79b8584cb255a83cdd912949067372639113de6094c621

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.5.1",
+      "version": "6.5.2",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^5.2.1",
+        "@mcp-abap-adt/adt-clients": "^5.4.2",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
-        "@mcp-abap-adt/connection": "^1.8.0",
+        "@mcp-abap-adt/connection": "^1.8.1",
         "@mcp-abap-adt/header-validator": "^0.1.8",
         "@mcp-abap-adt/interfaces": "^7.0.0",
         "@mcp-abap-adt/logger": "^0.1.4",
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-5.2.1.tgz",
-      "integrity": "sha512-iBpPab2S2KU/WMq1DN6kabOBM0Va3sEQqEMUvTBiTREjRqZmVQROH623kxms9839lMfMsYYEyc7aK0PXx+BahQ==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-5.4.2.tgz",
+      "integrity": "sha512-VY5cEA5LYG3iiwNMuCmdh7aYpqJbRIG7imM5FCXPlzhOvaUaNeesFvEcKqZ4mOWCA5B/c7tCTtYlewoTvEiJ5w==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",
@@ -322,9 +322,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/connection": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/connection/-/connection-1.8.0.tgz",
-      "integrity": "sha512-EAysDsmoeOSc+Rsf0gsL8/8gnroeZlONY9n6iEv701+jKD6OVWP8WYZ377xAF3kPDcZ4UIkM5b5O/fVyOKtxkg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/connection/-/connection-1.8.1.tgz",
+      "integrity": "sha512-ctTtchVgK0ebOAPB7RdjrryIqktSANm9uFlRNdcuZaj3fPriadYPwR9T7LFmLVmBZx4YFQY/hz5mTl9/FlFD0g==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -136,11 +136,11 @@
     "yaml": "^2.8.1"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^5.2.1",
+    "@mcp-abap-adt/adt-clients": "^5.4.2",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",
-    "@mcp-abap-adt/connection": "^1.8.0",
+    "@mcp-abap-adt/connection": "^1.8.1",
     "@mcp-abap-adt/header-validator": "^0.1.8",
     "@mcp-abap-adt/interfaces": "^7.0.0",
     "@mcp-abap-adt/logger": "^0.1.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.5.1",
+  "version": "6.5.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.5.1",
+      "version": "6.5.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- Bump `@mcp-abap-adt/adt-clients` `^5.2.1` → `^5.4.2`
- Bump `@mcp-abap-adt/connection` `^1.8.0` → `^1.8.1`
- Release `@mcp-abap-adt/core@6.5.2` (`package.json`, `server.json`, `CHANGELOG.md`)
- Add `backups/shared-ZADT_BLD_PKG03.yaml` — `adt-backup` snapshot of the shared test package, lets new test accounts skip the fragile `shared:setup` group-activate path

## Background

Picks up the stale-CSRF token recovery fix end-to-end (issue chain: #78 → fr0ster/mcp-abap-connection#7 → fr0ster/mcp-abap-adt-clients#34 → this).

On on-prem SAP with basic auth, the CSRF token cached at connect time could go stale and SAP responded to POST/PUT/DELETE with `401 + login HTML` instead of `403 + CSRF`. The previous `shouldRetryCsrf()` only re-fetched on 401 when `csrfToken === null`, so cached-but-stale tokens caused permanent failures (e.g. `CreateDomain`). The connection layer now detects this case, clears `csrfToken`/`cookies`, and retries.

Closes #80.

## Test plan

- [x] Integration tests on trial cloud — 84/85 passed
- [ ] Pre-existing flakiness in `RuntimeProfilingAndDumpsHandlers` on trial (`Failed to resolve traceId` — handler polls 5×2s, trial SAP writes trace slower). Not related to this bump. Will be tracked in a separate issue.
- [ ] Field verification of CSRF fix on on-prem + basic auth (requires reporter or someone with that environment)