### PR TITLE
feat(runtime): expose trace-lookup tunables on RuntimeRunClassWithProfiling (#82), release 6.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [6.5.3] - 2026-05-13
+
+### Added
+- `RuntimeRunClassWithProfiling` now accepts optional `max_trace_attempts`, `trace_retry_delay_ms`, and `trace_lookup_uris` so callers can tune trace-resolution polling. Defaults remain 5 attempts × 2000 ms; raise on slow systems (e.g. SAP trial cloud) where the trace file is written with extra delay. Closes #82.
+
 ## [6.5.2] - 2026-05-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.5.2",
+      "version": "6.5.3",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.5.2",
+  "version": "6.5.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.5.2",
+      "version": "6.5.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/integration/readOnly/system/RuntimeProfilingAndDumpsHandlers.test.ts
+++ b/src/__tests__/integration/readOnly/system/RuntimeProfilingAndDumpsHandlers.test.ts
@@ -375,29 +375,36 @@ describe('Runtime Profiling and Dumps Handlers Integration', () => {
             tester.isHardMode() ? invoke : undefined,
           );
 
+          const profiledRunArgs = {
+            class_name: className,
+            description: `MCP_RUNTIME_CLASS_${Date.now()}`,
+            all_procedural_units: true,
+            sql_trace: true,
+            all_db_events: true,
+            max_time_for_tracing: 1800,
+            max_trace_attempts:
+              toPositiveInt(
+                context.params?.profiled_run_max_trace_attempts,
+                0,
+              ) || undefined,
+            trace_retry_delay_ms:
+              toPositiveInt(
+                context.params?.profiled_run_trace_retry_delay_ms,
+                0,
+              ) || undefined,
+          };
           const profiledRun = await invoke(
             'RuntimeRunClassWithProfiling',
-            {
-              class_name: className,
-              description: `MCP_RUNTIME_CLASS_${Date.now()}`,
-              all_procedural_units: true,
-              sql_trace: true,
-              all_db_events: true,
-              max_time_for_tracing: 1800,
-            },
+            profiledRunArgs,
             async () => {
               const handlerContext = createHandlerContext({
                 connection: context.connection,
                 logger,
               });
-              return handleRuntimeRunClassWithProfiling(handlerContext, {
-                class_name: className,
-                description: `MCP_RUNTIME_CLASS_${Date.now()}`,
-                all_procedural_units: true,
-                sql_trace: true,
-                all_db_events: true,
-                max_time_for_tracing: 1800,
-              });
+              return handleRuntimeRunClassWithProfiling(
+                handlerContext,
+                profiledRunArgs,
+              );
             },
           );
 

--- a/src/handlers/system/readonly/handleRuntimeRunClassWithProfiling.ts
+++ b/src/handlers/system/readonly/handleRuntimeRunClassWithProfiling.ts
@@ -32,18 +32,20 @@ export const TOOL_DEFINITION = {
       amdp_trace: { type: 'boolean' },
       max_time_for_tracing: { type: 'number' },
       max_trace_attempts: {
-        type: 'number',
+        type: 'integer',
+        minimum: 1,
         description:
           'Max polling attempts to resolve traceId after execution (default 5). Increase for slow systems (e.g. SAP trial cloud).',
       },
       trace_retry_delay_ms: {
-        type: 'number',
+        type: 'integer',
+        minimum: 0,
         description:
           'Delay in ms between trace polling attempts (default 2000).',
       },
       trace_lookup_uris: {
         type: 'array',
-        items: { type: 'string' },
+        items: { type: 'string', minLength: 1 },
         description:
           'Additional URIs to consult when resolving the trace (advanced).',
       },
@@ -88,12 +90,30 @@ export async function handleRuntimeRunClassWithProfiling(
     const executor = new AdtExecutor(connection, logger);
     const classExecutor = executor.getClassExecutor();
 
+    const maxTraceAttempts =
+      typeof args.max_trace_attempts === 'number' &&
+      Number.isFinite(args.max_trace_attempts) &&
+      args.max_trace_attempts >= 1
+        ? Math.trunc(args.max_trace_attempts)
+        : undefined;
+    const traceRetryDelayMs =
+      typeof args.trace_retry_delay_ms === 'number' &&
+      Number.isFinite(args.trace_retry_delay_ms) &&
+      args.trace_retry_delay_ms >= 0
+        ? Math.trunc(args.trace_retry_delay_ms)
+        : undefined;
+    const traceLookupUris = Array.isArray(args.trace_lookup_uris)
+      ? args.trace_lookup_uris.filter(
+          (uri): uri is string => typeof uri === 'string' && uri.length > 0,
+        )
+      : undefined;
+
     const result = await classExecutor.runWithProfiling(
       { className },
       {
-        maxTraceAttempts: args.max_trace_attempts,
-        traceRetryDelayMs: args.trace_retry_delay_ms,
-        traceLookupUris: args.trace_lookup_uris,
+        maxTraceAttempts,
+        traceRetryDelayMs,
+        traceLookupUris,
         profilerParameters: {
           description: args.description,
           allProceduralUnits: args.all_procedural_units,

--- a/src/handlers/system/readonly/handleRuntimeRunClassWithProfiling.ts
+++ b/src/handlers/system/readonly/handleRuntimeRunClassWithProfiling.ts
@@ -31,6 +31,22 @@ export const TOOL_DEFINITION = {
       max_size_for_trace_file: { type: 'number' },
       amdp_trace: { type: 'boolean' },
       max_time_for_tracing: { type: 'number' },
+      max_trace_attempts: {
+        type: 'number',
+        description:
+          'Max polling attempts to resolve traceId after execution (default 5). Increase for slow systems (e.g. SAP trial cloud).',
+      },
+      trace_retry_delay_ms: {
+        type: 'number',
+        description:
+          'Delay in ms between trace polling attempts (default 2000).',
+      },
+      trace_lookup_uris: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Additional URIs to consult when resolving the trace (advanced).',
+      },
     },
     required: ['class_name'],
   },
@@ -52,6 +68,9 @@ interface RuntimeRunClassWithProfilingArgs {
   max_size_for_trace_file?: number;
   amdp_trace?: boolean;
   max_time_for_tracing?: number;
+  max_trace_attempts?: number;
+  trace_retry_delay_ms?: number;
+  trace_lookup_uris?: string[];
 }
 
 export async function handleRuntimeRunClassWithProfiling(
@@ -72,6 +91,9 @@ export async function handleRuntimeRunClassWithProfiling(
     const result = await classExecutor.runWithProfiling(
       { className },
       {
+        maxTraceAttempts: args.max_trace_attempts,
+        traceRetryDelayMs: args.trace_retry_delay_ms,
+        traceLookupUris: args.trace_lookup_uris,
         profilerParameters: {
           description: args.description,
           allProceduralUnits: args.all_procedural_units,

--- a/tests/test-config.yaml.template
+++ b/tests/test-config.yaml.template
@@ -1866,6 +1866,10 @@ runtime_readonly_handlers:
         # Retries for trace files feed lookup (trace can appear with delay)
         trace_feed_retries: 6
         trace_feed_retry_delay_ms: 1000
+        # Executor-level trace polling (passed to RuntimeRunClassWithProfiling).
+        # Increase for slow systems (e.g. SAP trial cloud) — default in client is 5×2000ms.
+        profiled_run_max_trace_attempts: 15
+        profiled_run_trace_retry_delay_ms: 2000
         # Retries for reading profiler trace data (trace can appear with delay)
         trace_read_retries: 6
         trace_read_retry_delay_ms: 1500


### PR DESCRIPTION
## Summary

- `RuntimeRunClassWithProfiling` now accepts optional `max_trace_attempts`, `trace_retry_delay_ms`, and `trace_lookup_uris` and forwards them into `ClassExecutor.runWithProfiling`
- Test config (`profiled_run_max_trace_attempts`, `profiled_run_trace_retry_delay_ms`) wired into the profiling integration test
- Release 6.5.3 (`package.json`, `server.json`, `CHANGELOG.md`)

## Why

Defaults in `@mcp-abap-adt/adt-clients` are 5 polling attempts × 2000 ms. On slow systems (SAP trial cloud) the trace file is written with extra delay and the handler returns `Failed to resolve traceId after profiled execution`. Callers can now raise these tunables.

Note: on the local trial cloud the test still fails even with `max_trace_attempts=15` — the trace simply doesn't appear within 30 s. That's a separate environmental concern (profiler may not be writing traces under trial, or a user-filter issue) and is unrelated to this knob.

Closes #82.

## Test plan

- [x] Type check + lint
- [x] Integration test passes the new args through (verified by jest run on trial — handler accepts them, executor receives them; trial trace-availability is a separate issue)
- [ ] Field verification on a system where 5×2 s is genuinely too short (e.g. busy on-prem)