### PR TITLE
feat(runtime): RuntimeRunClass + RuntimeRunProgram with optional profiling (#84), release 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [6.6.0] - 2026-05-14
+
+### Added
+- `RuntimeRunClass` (onprem + cloud) — execute an ABAP class implementing `if_oo_adt_classrun` and return its stdout text. Optional `profile=true` runs through the profiler and additionally surfaces `profile.profiler_id` / `profile.trace_id` (same retry tunables as the previous tool).
+- `RuntimeRunProgram` (onprem only) — execute an ABAP report and return its stdout text. Optional `profile=true` starts a profiler trace; trace must be located afterwards via `RuntimeListProfilerTraceFiles` (program execution is fire-and-forget).
+
+### Deprecated
+- `RuntimeRunClassWithProfiling` and `RuntimeRunProgramWithProfiling` are now marked deprecated in their tool descriptions. They remain functional. Prefer the unified `RuntimeRunClass` / `RuntimeRunProgram` with `profile=true`. Scheduled for removal in a future major release.
+
 ## [6.5.3] - 2026-05-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.5.3",
+  "version": "6.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.5.3",
+      "version": "6.6.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.5.3",
+  "version": "6.6.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/scripts/probe-run-class.ts
+++ b/scripts/probe-run-class.ts
@@ -1,0 +1,19 @@
+import { handleRuntimeRunClass } from '../src/handlers/system/readonly/handleRuntimeRunClass';
+import { createTestConnectionAndSession } from '../src/__tests__/integration/helpers/sessionHelpers';
+
+async function main(): Promise<void> {
+  const className = process.argv[2] || 'ZMCP_BLD_CLSLOC_H1';
+  const { connection } = await createTestConnectionAndSession();
+  const res = await handleRuntimeRunClass(
+    { connection, logger: console as any },
+    { class_name: className },
+  );
+  console.log('=== RuntimeRunClass result ===');
+  const text = res.content?.[0]?.text ?? '';
+  console.log(typeof text === 'string' ? text.slice(0, 2000) : text);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.5.3",
+  "version": "6.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.5.3",
+      "version": "6.6.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/handlers/system/readonly/handleRuntimeRunClass.ts
+++ b/src/handlers/system/readonly/handleRuntimeRunClass.ts
@@ -3,10 +3,10 @@ import type { HandlerContext } from '../../../lib/handlers/interfaces';
 import { return_error, return_response } from '../../../lib/utils';
 
 export const TOOL_DEFINITION = {
-  name: 'RuntimeRunClassWithProfiling',
+  name: 'RuntimeRunClass',
   available_in: ['onprem', 'cloud'] as const,
   description:
-    '[runtime][deprecated] Execute ABAP class with profiler enabled and return created profilerId + traceId. Prefer RuntimeRunClass with profile=true; this tool is kept for backward compatibility and will be removed in a future major release.',
+    '[runtime] Execute an ABAP class implementing if_oo_adt_classrun and return its output. Set profile=true to also capture a profiler trace (returns profilerId/traceId alongside output).',
   inputSchema: {
     type: 'object',
     properties: {
@@ -14,9 +14,15 @@ export const TOOL_DEFINITION = {
         type: 'string',
         description: 'ABAP class name to execute.',
       },
+      profile: {
+        type: 'boolean',
+        description:
+          'When true, run with the profiler and resolve the resulting traceId. Default false.',
+      },
       description: {
         type: 'string',
-        description: 'Profiler trace description.',
+        description:
+          'Profiler trace description (only used when profile=true).',
       },
       all_procedural_units: { type: 'boolean' },
       all_misc_abap_statements: { type: 'boolean' },
@@ -35,27 +41,28 @@ export const TOOL_DEFINITION = {
         type: 'integer',
         minimum: 1,
         description:
-          'Max polling attempts to resolve traceId after execution (default 5). Increase for slow systems (e.g. SAP trial cloud).',
+          'Max polling attempts to resolve traceId after execution (default 5). Only used when profile=true.',
       },
       trace_retry_delay_ms: {
         type: 'integer',
         minimum: 0,
         description:
-          'Delay in ms between trace polling attempts (default 2000).',
+          'Delay in ms between trace polling attempts (default 2000). Only used when profile=true.',
       },
       trace_lookup_uris: {
         type: 'array',
         items: { type: 'string', minLength: 1 },
         description:
-          'Additional URIs to consult when resolving the trace (advanced).',
+          'Additional URIs to consult when resolving the trace (advanced, profile=true).',
       },
     },
     required: ['class_name'],
   },
 } as const;
 
-interface RuntimeRunClassWithProfilingArgs {
+interface RuntimeRunClassArgs {
   class_name: string;
+  profile?: boolean;
   description?: string;
   all_procedural_units?: boolean;
   all_misc_abap_statements?: boolean;
@@ -75,9 +82,9 @@ interface RuntimeRunClassWithProfilingArgs {
   trace_lookup_uris?: string[];
 }
 
-export async function handleRuntimeRunClassWithProfiling(
+export async function handleRuntimeRunClass(
   context: HandlerContext,
-  args: RuntimeRunClassWithProfilingArgs,
+  args: RuntimeRunClassArgs,
 ) {
   const { connection, logger } = context;
 
@@ -89,6 +96,26 @@ export async function handleRuntimeRunClassWithProfiling(
     const className = args.class_name.trim().toUpperCase();
     const executor = new AdtExecutor(connection, logger);
     const classExecutor = executor.getClassExecutor();
+
+    if (!args.profile) {
+      const response = await classExecutor.run({ className });
+      return return_response({
+        data: JSON.stringify(
+          {
+            success: true,
+            class_name: className,
+            output: typeof response.data === 'string' ? response.data : '',
+            run_status: response.status,
+          },
+          null,
+          2,
+        ),
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+        config: response.config,
+      });
+    }
 
     const maxTraceAttempts =
       typeof args.max_trace_attempts === 'number' &&
@@ -138,10 +165,16 @@ export async function handleRuntimeRunClassWithProfiling(
         {
           success: true,
           class_name: className,
-          profiler_id: result.profilerId,
-          trace_id: result.traceId,
+          output:
+            typeof result.response?.data === 'string'
+              ? result.response.data
+              : '',
           run_status: result.response?.status,
-          trace_requests_status: result.traceRequestsResponse?.status,
+          profile: {
+            profiler_id: result.profilerId,
+            trace_id: result.traceId,
+            trace_requests_status: result.traceRequestsResponse?.status,
+          },
         },
         null,
         2,
@@ -152,7 +185,7 @@ export async function handleRuntimeRunClassWithProfiling(
       config: result.response?.config,
     });
   } catch (error: any) {
-    logger?.error('Error running class with profiling:', error);
+    logger?.error('Error running class:', error);
     return return_error(error);
   }
 }

--- a/src/handlers/system/readonly/handleRuntimeRunProgram.ts
+++ b/src/handlers/system/readonly/handleRuntimeRunProgram.ts
@@ -3,20 +3,26 @@ import type { HandlerContext } from '../../../lib/handlers/interfaces';
 import { return_error, return_response } from '../../../lib/utils';
 
 export const TOOL_DEFINITION = {
-  name: 'RuntimeRunClassWithProfiling',
-  available_in: ['onprem', 'cloud'] as const,
+  name: 'RuntimeRunProgram',
+  available_in: ['onprem'] as const,
   description:
-    '[runtime][deprecated] Execute ABAP class with profiler enabled and return created profilerId + traceId. Prefer RuntimeRunClass with profile=true; this tool is kept for backward compatibility and will be removed in a future major release.',
+    '[runtime] Execute an ABAP program (report) and return its output. Set profile=true to also start a profiler trace; use RuntimeListProfilerTraceFiles afterwards to locate the trace (program execution is fire-and-forget, so traceId is not returned synchronously).',
   inputSchema: {
     type: 'object',
     properties: {
-      class_name: {
+      program_name: {
         type: 'string',
-        description: 'ABAP class name to execute.',
+        description: 'ABAP program name to execute.',
+      },
+      profile: {
+        type: 'boolean',
+        description:
+          'When true, run with the profiler. Default false. Trace must be located afterwards via RuntimeListProfilerTraceFiles — program execution does not return traceId synchronously.',
       },
       description: {
         type: 'string',
-        description: 'Profiler trace description.',
+        description:
+          'Profiler trace description (only used when profile=true).',
       },
       all_procedural_units: { type: 'boolean' },
       all_misc_abap_statements: { type: 'boolean' },
@@ -31,31 +37,14 @@ export const TOOL_DEFINITION = {
       max_size_for_trace_file: { type: 'number' },
       amdp_trace: { type: 'boolean' },
       max_time_for_tracing: { type: 'number' },
-      max_trace_attempts: {
-        type: 'integer',
-        minimum: 1,
-        description:
-          'Max polling attempts to resolve traceId after execution (default 5). Increase for slow systems (e.g. SAP trial cloud).',
-      },
-      trace_retry_delay_ms: {
-        type: 'integer',
-        minimum: 0,
-        description:
-          'Delay in ms between trace polling attempts (default 2000).',
-      },
-      trace_lookup_uris: {
-        type: 'array',
-        items: { type: 'string', minLength: 1 },
-        description:
-          'Additional URIs to consult when resolving the trace (advanced).',
-      },
     },
-    required: ['class_name'],
+    required: ['program_name'],
   },
 } as const;
 
-interface RuntimeRunClassWithProfilingArgs {
-  class_name: string;
+interface RuntimeRunProgramArgs {
+  program_name: string;
+  profile?: boolean;
   description?: string;
   all_procedural_units?: boolean;
   all_misc_abap_statements?: boolean;
@@ -70,50 +59,46 @@ interface RuntimeRunClassWithProfilingArgs {
   max_size_for_trace_file?: number;
   amdp_trace?: boolean;
   max_time_for_tracing?: number;
-  max_trace_attempts?: number;
-  trace_retry_delay_ms?: number;
-  trace_lookup_uris?: string[];
 }
 
-export async function handleRuntimeRunClassWithProfiling(
+export async function handleRuntimeRunProgram(
   context: HandlerContext,
-  args: RuntimeRunClassWithProfilingArgs,
+  args: RuntimeRunProgramArgs,
 ) {
   const { connection, logger } = context;
 
   try {
-    if (!args?.class_name) {
-      throw new Error('Parameter "class_name" is required');
+    if (!args?.program_name) {
+      throw new Error('Parameter "program_name" is required');
     }
 
-    const className = args.class_name.trim().toUpperCase();
+    const programName = args.program_name.trim().toUpperCase();
     const executor = new AdtExecutor(connection, logger);
-    const classExecutor = executor.getClassExecutor();
+    const programExecutor = executor.getProgramExecutor();
 
-    const maxTraceAttempts =
-      typeof args.max_trace_attempts === 'number' &&
-      Number.isFinite(args.max_trace_attempts) &&
-      args.max_trace_attempts >= 1
-        ? Math.trunc(args.max_trace_attempts)
-        : undefined;
-    const traceRetryDelayMs =
-      typeof args.trace_retry_delay_ms === 'number' &&
-      Number.isFinite(args.trace_retry_delay_ms) &&
-      args.trace_retry_delay_ms >= 0
-        ? Math.trunc(args.trace_retry_delay_ms)
-        : undefined;
-    const traceLookupUris = Array.isArray(args.trace_lookup_uris)
-      ? args.trace_lookup_uris.filter(
-          (uri): uri is string => typeof uri === 'string' && uri.length > 0,
-        )
-      : undefined;
+    if (!args.profile) {
+      const response = await programExecutor.run({ programName });
+      return return_response({
+        data: JSON.stringify(
+          {
+            success: true,
+            program_name: programName,
+            output: typeof response.data === 'string' ? response.data : '',
+            run_status: response.status,
+          },
+          null,
+          2,
+        ),
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+        config: response.config,
+      });
+    }
 
-    const result = await classExecutor.runWithProfiling(
-      { className },
+    const result = await programExecutor.runWithProfiling(
+      { programName },
       {
-        maxTraceAttempts,
-        traceRetryDelayMs,
-        traceLookupUris,
         profilerParameters: {
           description: args.description,
           allProceduralUnits: args.all_procedural_units,
@@ -137,11 +122,16 @@ export async function handleRuntimeRunClassWithProfiling(
       data: JSON.stringify(
         {
           success: true,
-          class_name: className,
-          profiler_id: result.profilerId,
-          trace_id: result.traceId,
+          program_name: programName,
+          output:
+            typeof result.response?.data === 'string'
+              ? result.response.data
+              : '',
           run_status: result.response?.status,
-          trace_requests_status: result.traceRequestsResponse?.status,
+          profile: {
+            profiler_id: result.profilerId,
+            // traceId is not returned for programs — use RuntimeListProfilerTraceFiles to find it.
+          },
         },
         null,
         2,
@@ -152,7 +142,7 @@ export async function handleRuntimeRunClassWithProfiling(
       config: result.response?.config,
     });
   } catch (error: any) {
-    logger?.error('Error running class with profiling:', error);
+    logger?.error('Error running program:', error);
     return return_error(error);
   }
 }

--- a/src/handlers/system/readonly/handleRuntimeRunProgramWithProfiling.ts
+++ b/src/handlers/system/readonly/handleRuntimeRunProgramWithProfiling.ts
@@ -6,7 +6,7 @@ export const TOOL_DEFINITION = {
   name: 'RuntimeRunProgramWithProfiling',
   available_in: ['onprem'] as const,
   description:
-    '[runtime] Execute ABAP program with profiler enabled and return created profilerId + traceId.',
+    '[runtime][deprecated] Execute ABAP program with profiler enabled and return created profilerId. Prefer RuntimeRunProgram with profile=true; this tool is kept for backward compatibility and will be removed in a future major release.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/lib/handlers/groups/SystemHandlersGroup.ts
+++ b/src/lib/handlers/groups/SystemHandlersGroup.ts
@@ -99,9 +99,17 @@ import {
   TOOL_DEFINITION as RuntimeListSystemMessages_Tool,
 } from '../../../handlers/system/readonly/handleRuntimeListSystemMessages';
 import {
+  handleRuntimeRunClass,
+  TOOL_DEFINITION as RuntimeRunClass_Tool,
+} from '../../../handlers/system/readonly/handleRuntimeRunClass';
+import {
   handleRuntimeRunClassWithProfiling,
   TOOL_DEFINITION as RuntimeRunClassWithProfiling_Tool,
 } from '../../../handlers/system/readonly/handleRuntimeRunClassWithProfiling';
+import {
+  handleRuntimeRunProgram,
+  TOOL_DEFINITION as RuntimeRunProgram_Tool,
+} from '../../../handlers/system/readonly/handleRuntimeRunProgram';
 import {
   handleRuntimeRunProgramWithProfiling,
   TOOL_DEFINITION as RuntimeRunProgramWithProfiling_Tool,
@@ -146,6 +154,14 @@ export class SystemHandlersGroup extends BaseHandlerGroup {
       {
         toolDefinition: RuntimeGetDumpById_Tool,
         handler: (args: any) => handleRuntimeGetDumpById(this.context, args),
+      },
+      {
+        toolDefinition: RuntimeRunClass_Tool,
+        handler: (args: any) => handleRuntimeRunClass(this.context, args),
+      },
+      {
+        toolDefinition: RuntimeRunProgram_Tool,
+        handler: (args: any) => handleRuntimeRunProgram(this.context, args),
       },
       {
         toolDefinition: RuntimeRunClassWithProfiling_Tool,


### PR DESCRIPTION
## Summary

Two new MCP tools that surface `ClassExecutor.run()` / `ProgramExecutor.run()` from `@mcp-abap-adt/adt-clients` (already shipped in 5.4.2) without forcing the profiler path:

- `RuntimeRunClass` (onprem + cloud) — run an `if_oo_adt_classrun` class and return stdout. `profile=true` → also resolves a profiler trace and adds `profile.profiler_id` / `profile.trace_id`.
- `RuntimeRunProgram` (onprem) — run an ABAP report and return stdout. `profile=true` → starts a profiler trace; trace must be located afterwards via `RuntimeListProfilerTraceFiles` (program execution is fire-and-forget; `traceId` not returned synchronously).

Existing `*WithProfiling` tools remain (marked `[deprecated]` in their descriptions). Scheduled for removal in a future major.

Unblocks fr0ster/mcp-abap-adt#79: `SearchSource` onprem path becomes `RuntimeRunProgram('AFX_CODE_SCANER', ...)`.

Closes #84.

## Test plan

- [x] Type check + lint (biome formatted)
- [x] Smoke on trial cloud via `scripts/probe-run-class.ts` — endpoint reached, response shape correct (object-not-exist for the probe target is expected and confirms wire-up)
- [ ] Onprem verification (RuntimeRunProgram against real reports — to be done on the machine with onprem access)
- [ ] Profile path against an existing runnable class on a system that actually writes traces

## Response shape

```jsonc
// profile=false (default)
{
  "success": true,
  "class_name": "ZFOO",
  "output": "...stdout text from classrun...",
  "run_status": 200
}

// profile=true
{
  "success": true,
  "class_name": "ZFOO",
  "output": "...stdout text from classrun...",
  "run_status": 200,
  "profile": {
    "profiler_id": "...",
    "trace_id": "...",
    "trace_requests_status": 200
  }
}
```