### PR TITLE
fix(program): ReadProgram include-name error + GetProgFullCode source key (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [6.11.1] - 2026-05-29
+
+### Fixed
+- **`ReadProgram` returned a silent `{ success: true, source_code: null }` for include names.** LLM agents loading a report's full source call `ReadProgram` on the include names returned by `GetIncludesList`, get `null`, read it as a permission/inactive-object problem rather than "wrong tool", and stall. A readable main program (`PROG/P`) always returns source; when both source and metadata come back empty the name is an include (`PROG/I`). `ReadProgram` now returns a structured `{ success: false, error: "include_name_passed", suggestion: "GetInclude(\"<name>\")" }` so the caller gets an actionable signal at the point of failure. (#91)
+- **`GetProgFullCode` read include source via the wrong content key.** `handleGetInclude` returns `{ type: 'text', text }`, but two call sites read `c.data`: the recursive `collectIncludes` helper (so nested includes were never discovered) and the `FUGR` branch (so every function-group include came back as `code: null`). All sites now read `c.text`. (#91)
+
 ## [6.11.0] - 2026-05-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.11.0",
+      "version": "6.11.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.11.0",
+  "version": "6.11.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.11.0",
+      "version": "6.11.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/handlers/program/readonly/handleGetProgFullCode.ts
+++ b/src/handlers/program/readonly/handleGetProgFullCode.ts
@@ -90,7 +90,7 @@ export async function handleGetProgFullCode(
       includeResult.content.length > 0
     ) {
       const c = includeResult.content[0];
-      if (c.type === 'text' && 'data' in c) code = c.data as string;
+      if (c.type === 'text' && 'text' in c) code = c.text as string;
     }
 
     // Find nested includes in code (ABAP: INCLUDE <name>. or 'INCLUDE <name> .')
@@ -269,7 +269,7 @@ export async function handleGetProgFullCode(
               incResult.content.length > 0
             ) {
               const c = incResult.content[0];
-              if (c.type === 'text' && 'data' in c) incCode = c.data as string;
+              if (c.type === 'text' && 'text' in c) incCode = c.text as string;
             }
             codeObjects.push({
               OBJECT_TYPE: 'PROG/I',

--- a/src/handlers/program/readonly/handleReadProgram.ts
+++ b/src/handlers/program/readonly/handleReadProgram.ts
@@ -72,6 +72,27 @@ export async function handleReadProgram(
       logger?.warn(`Could not read metadata for ${programName}: ${e?.message}`);
     }
 
+    // A readable main program (PROG/P) always returns source. If both source
+    // and metadata are empty, the name is almost certainly an include
+    // (PROG/I) — surface that as a structured error with a redirect instead of
+    // a misleading { success: true, source_code: null } that the model reads
+    // as a permission/inactive-object problem rather than "wrong tool".
+    if (source_code === null && metadata === null) {
+      return return_response({
+        data: JSON.stringify(
+          {
+            success: false,
+            error: 'include_name_passed',
+            program_name: programName,
+            message: `No main-program source found for "${programName}". If this is an include (e.g. a name returned by GetIncludesList), call GetInclude("${programName}") instead.`,
+            suggestion: `GetInclude("${programName}")`,
+          },
+          null,
+          2,
+        ),
+      } as AxiosResponse);
+    }
+
     return return_response({
       data: JSON.stringify(
         {


### PR DESCRIPTION
Fixes #91.

## Problem
LLM agents loading a report's full source call `ReadProgram` on the include names returned by `GetIncludesList`, get a silent `{ success: true, source_code: null }`, read it as a permission/inactive-object problem rather than "wrong tool", and stall the analysis.

The issue proposed tightening tool descriptions, but MCP tool descriptions can't be tuned to a single workflow reliably — so the fix is behavioral, at the point of failure, independent of description wording.

## Changes
- **`ReadProgram` → structured error.** A readable main program (`PROG/P`) always returns source; when both source and metadata come back empty the name is an include (`PROG/I`). Instead of the silent `source_code: null`, `ReadProgram` now returns `{ success: false, error: "include_name_passed", suggestion: "GetInclude(\"<name>\")" }`.
- **`GetProgFullCode` source-key bug.** `handleGetInclude` returns `{ type: 'text', text }`, but two call sites read `c.data`: the recursive `collectIncludes` helper (nested includes were never discovered) and the `FUGR` branch (every function-group include came back as `code: null`). All sites now read `c.text`.

## Release
Patch bump **6.11.0 → 6.11.1** (`package.json`, `package-lock.json`, `server.json`, `CHANGELOG.md`).

## Verification
- `npm run build` (biome + tsc) green.
- Runtime behavior (include-name error path, `GetProgFullCode` FUGR + nested includes) to be verified against a live SAP system before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)