### PR TITLE
fix(program): reject non-PROG/P object types in ReadProgram — 6.11.2 (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [6.11.2] - 2026-05-29
+
+### Fixed
+- **`ReadProgram` could still return a silent `{ success: true, source_code: null }` for non-main-program names.** The 6.11.1 heuristic only fired when *both* source and metadata came back empty; when the `programs` endpoint returned metadata for a non-`PROG/P` object (e.g. an include) the response slipped through to a misleading `success: true` with `source_code: null`. `ReadProgram` now parses `adtcore:type` from the metadata and rejects anything other than a main program (`PROG/P`) with a structured `{ success: false, error: "invalid_object_type", object_type, message }`. No tool redirect is emitted — choosing the right tool is the consumer's decision. The tool description now states it works only for main programs (`PROG/P`). (#91)
+
 ## [6.11.1] - 2026-05-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.11.1",
+  "version": "6.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.11.1",
+      "version": "6.11.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.11.1",
+  "version": "6.11.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.11.1",
+  "version": "6.11.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.11.1",
+      "version": "6.11.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/handlers/program/readonly/handleReadProgram.ts
+++ b/src/handlers/program/readonly/handleReadProgram.ts
@@ -10,7 +10,7 @@ export const TOOL_DEFINITION = {
   name: 'ReadProgram',
   available_in: ['onprem', 'legacy'] as const,
   description:
-    'Operation: Read, Create, Update. Subject: Program. Will be useful for reading, creating, or updating program. [read-only] Read ABAP program (report) source code and metadata. Answers: "show program code", "display report source", "view program X", "get program source". Returns source code, package, responsible, description.',
+    'Operation: Read, Create, Update. Subject: Program. Will be useful for reading, creating, or updating program. [read-only] Read ABAP MAIN PROGRAM (report) source code and metadata. Works ONLY for main programs (adtcore type PROG/P); include names (PROG/I) and other object types are rejected with error "invalid_object_type". Answers: "show program code", "display report source", "view program X", "get program source". Returns source code, package, responsible, description.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -72,20 +72,32 @@ export async function handleReadProgram(
       logger?.warn(`Could not read metadata for ${programName}: ${e?.message}`);
     }
 
-    // A readable main program (PROG/P) always returns source. If both source
-    // and metadata are empty, the name is almost certainly an include
-    // (PROG/I) — surface that as a structured error with a redirect instead of
-    // a misleading { success: true, source_code: null } that the model reads
-    // as a permission/inactive-object problem rather than "wrong tool".
-    if (source_code === null && metadata === null) {
+    // ReadProgram only reads main programs (PROG/P). Detect the actual object
+    // type from the metadata and reject anything else (e.g. includes PROG/I) so
+    // the caller gets a structured "invalid_object_type" error instead of a
+    // misleading { success: true, source_code: null } that reads as a
+    // permission/inactive-object problem rather than "wrong object type".
+    // No redirect/suggestion is emitted — choosing the right tool is the
+    // consumer's decision; we only report what the object is.
+    const objectType = metadata
+      ? (/adtcore:type="([^"]+)"/.exec(metadata)?.[1] ?? null)
+      : null;
+
+    const isMainProgram = objectType === 'PROG/P';
+    // When metadata is missing entirely we cannot read it as a main program
+    // either (the programs endpoint returned nothing usable for both source
+    // and metadata) — treat that as the same error.
+    if (!isMainProgram || (source_code === null && metadata === null)) {
       return return_response({
         data: JSON.stringify(
           {
             success: false,
-            error: 'include_name_passed',
+            error: 'invalid_object_type',
             program_name: programName,
-            message: `No main-program source found for "${programName}". If this is an include (e.g. a name returned by GetIncludesList), call GetInclude("${programName}") instead.`,
-            suggestion: `GetInclude("${programName}")`,
+            object_type: objectType,
+            message: objectType
+              ? `"${programName}" has object type ${objectType}, not a main program (PROG/P). ReadProgram reads only main programs (PROG/P).`
+              : `No main-program (PROG/P) source or metadata found for "${programName}". ReadProgram reads only main programs (PROG/P).`,
           },
           null,
           2,


### PR DESCRIPTION
## Problem

`ReadProgram` could still return a silent `{ success: true, source_code: null }` for non-main-program names. The 6.11.1 fix only fired when **both** source and metadata came back empty. When the `programs` ADT endpoint returns metadata for a non-`PROG/P` object (e.g. an include `PROG/I`), the response slipped through to a misleading `success: true` with `source_code: null` — which an LLM agent reads as a permission/inactive-object problem rather than "wrong object type".

## Change

- Parse `adtcore:type` from the metadata; reject anything other than a main program (`PROG/P`) with a structured `{ success: false, error: "invalid_object_type", object_type, message }`.
- **No tool redirect** is emitted — choosing the right tool (e.g. `GetInclude`) is the consumer's decision; the handler only reports what the object is.
- Tool description now states `ReadProgram` works only for main programs (`PROG/P`).
- Version bump 6.11.1 → 6.11.2 (`package.json`, `package-lock.json`, `server.json`, `CHANGELOG.md`).

## Verification

- `npm run build` green (biome + tsc).
- ⚠️ Not yet exercised against a live SAP system — the `success:true/null` slip-through path should be confirmed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)