### PR TITLE
chore(release): 6.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [6.11.3] - 2026-05-30
+
 ### Removed
 - **`GetProgFullCode` removed as a redundant read path.** A program or function group with includes can already be read through one canonical path — `ReadProgram` / `ReadFunctionGroup` (main) → `GetIncludesList` → `GetInclude` per include — and an explicit `GetInclude` is required anyway (includes can live outside any single object's tree). Two overlapping strategies made LLM and RAG-based tool selection non-deterministic. The piecemeal path covers function groups as well (`GetIncludesList` accepts `FUGR`), so no capability is lost. (#100)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.11.2",
+  "version": "6.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.11.2",
+      "version": "6.11.3",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.11.2",
+  "version": "6.11.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.11.2",
+  "version": "6.11.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.11.2",
+      "version": "6.11.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Release 6.11.3.

Bundles the merged #100 work (PR #101) and bumps version across `package.json`, `package-lock.json`, `server.json`, and the `CHANGELOG`.

## Changelog (6.11.3)

### Removed
- `GetProgFullCode` removed as a redundant read path. Canonical path is `ReadProgram`/`ReadFunctionGroup` → `GetIncludesList` → `GetInclude`; covers function groups too. (#100)

### Changed
- Sharpened `ReadProgram` and `GetInclude` descriptions for clearer LLM / RAG-based tool selection; `GetIncludesList` unchanged. (#100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)