### PR TITLE
release(7.0.0): EmbeddableMcpServer dedups Read<X>/Get<X> by default (BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-05-30
+
 ### Changed
-- **`EmbeddableMcpServer` now applies `ReadVsGetDedupStrategy` by default.** Previously the embeddable server defaulted to `NoDedupStrategy`, so exposing `readonly` + `high` together surfaced both `Read<X>` and `Get<X>` for the same operation (e.g. `ReadProgram` + `GetProgram`), leaving tool selection up to the client. Embedders (e.g. cloud-llm-hub) now get the same single-tool-per-operation view as the standalone launcher. **Behavior change**: consumers that relied on both variants being exposed must now opt out by passing `readOnlyDedupStrategy: new NoDedupStrategy()`.
+- **BREAKING: `EmbeddableMcpServer` now applies `ReadVsGetDedupStrategy` by default.** Previously the embeddable server defaulted to `NoDedupStrategy`, so exposing `readonly` + `high` together surfaced both `Read<X>` and `Get<X>` for the same operation (e.g. `ReadProgram` + `GetProgram`), leaving tool selection up to the client. Embedders (e.g. cloud-llm-hub) now get the same single-tool-per-operation view as the standalone launcher. Consumers that relied on both variants being exposed must opt out by passing `readOnlyDedupStrategy: new NoDedupStrategy()`. No code-level API change — the difference is the set of tools exposed to clients.
 
 ## [6.11.3] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **`EmbeddableMcpServer` now applies `ReadVsGetDedupStrategy` by default.** Previously the embeddable server defaulted to `NoDedupStrategy`, so exposing `readonly` + `high` together surfaced both `Read<X>` and `Get<X>` for the same operation (e.g. `ReadProgram` + `GetProgram`), leaving tool selection up to the client. Embedders (e.g. cloud-llm-hub) now get the same single-tool-per-operation view as the standalone launcher. **Behavior change**: consumers that relied on both variants being exposed must now opt out by passing `readOnlyDedupStrategy: new NoDedupStrategy()`.
+
 ## [6.11.3] - 2026-05-30
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -88,20 +88,21 @@ Embed MCP server into existing applications (e.g., SAP CAP/CDS, Express):
 ```typescript
 import {
   EmbeddableMcpServer,
-  ReadVsGetDedupStrategy, // optional: hide Read<X> when Get<X> also exposed
+  NoDedupStrategy, // optional: expose both Read<X> and Get<X>
 } from '@mcp-abap-adt/core/server';
 
 const server = new EmbeddableMcpServer({
   connection,              // Your AbapConnection instance
   logger,                  // Optional logger
   exposition: ['readonly', 'high'],  // Handler groups to expose
-  // Optional; default: no dedup — existing consumers see no change.
-  readOnlyDedupStrategy: new ReadVsGetDedupStrategy(),
+  // Default hides Read<X> when Get<X> is exposed (ReadVsGetDedupStrategy).
+  // Pass NoDedupStrategy to expose both variants instead.
+  // readOnlyDedupStrategy: new NoDedupStrategy(),
 });
 await server.connect(transport);
 ```
 
-See [Handlers Management → EmbeddableMcpServer dedup strategies](docs/user-guide/HANDLERS_MANAGEMENT.md#embeddablemcpserver-dedup-strategies) for opt-in dedup of readonly tools against high/low/compact, including how to plug a custom `IReadOnlyDedupStrategy` for role-based rules.
+See [Handlers Management → EmbeddableMcpServer dedup strategies](docs/user-guide/HANDLERS_MANAGEMENT.md#embeddablemcpserver-dedup-strategies) for how readonly tools are deduped against high/low/compact, how to opt out with `NoDedupStrategy`, and how to plug a custom `IReadOnlyDedupStrategy` for role-based rules.
 
 ## Quick Start
 

--- a/docs/user-guide/HANDLERS_MANAGEMENT.md
+++ b/docs/user-guide/HANDLERS_MANAGEMENT.md
@@ -109,7 +109,7 @@ Valid combinations: `[readonly]`, `[readonly, high]`, `[readonly, low]`, `[high]
 
 When both `readonly` and `high` are exposed, `Read<X>` readonly handlers duplicate the corresponding `Get<X>` from the high-level group (e.g. `ReadFunctionModule` vs `GetFunctionModule`). The launcher hides the readonly `Read<X>` variants in this case so that only one tool per operation is visible to the client.
 
-Embedder consumers of `EmbeddableMcpServer` keep the previous behavior (both variants exposed) unless they opt in by passing a `readOnlyDedupStrategy`. See [EmbeddableMcpServer dedup strategies](#embeddablemcpserver-dedup-strategies) below.
+`EmbeddableMcpServer` applies the same dedup by default, so embedders see one tool per operation just like the launcher. Consumers that need both variants can opt out by passing `new NoDedupStrategy()` as `readOnlyDedupStrategy`. See [EmbeddableMcpServer dedup strategies](#embeddablemcpserver-dedup-strategies) below.
 
 ### Config File
 
@@ -280,7 +280,9 @@ import {
 const server = new EmbeddableMcpServer({
   connection,
   exposition: ['readonly', 'high'],
-  // Opt in to dedup — hide ReadFunctionModule when GetFunctionModule is exposed, etc.
+  // Default already applies ReadVsGetDedupStrategy — hides ReadFunctionModule
+  // when GetFunctionModule is exposed, etc. Pass it explicitly to be explicit,
+  // or pass `new NoDedupStrategy()` to expose both variants.
   readOnlyDedupStrategy: new ReadVsGetDedupStrategy(),
 });
 ```
@@ -289,8 +291,8 @@ const server = new EmbeddableMcpServer({
 
 | Strategy | Behavior |
 |---|---|
-| `NoDedupStrategy` (default) | Never excludes anything — readonly group is exposed as-is. |
-| `ReadVsGetDedupStrategy` | Hides a `Read<X>` entry when a corresponding `Get<X>` is contributed by another group. |
+| `NoDedupStrategy` | Never excludes anything — readonly group is exposed as-is (opt-out). |
+| `ReadVsGetDedupStrategy` (default) | Hides a `Read<X>` entry when a corresponding `Get<X>` is contributed by another group. |
 
 **Custom strategies**: implement `IReadOnlyDedupStrategy` for role-based or domain-specific rules:
 
@@ -311,4 +313,4 @@ class RoleAwareDedup implements IReadOnlyDedupStrategy {
 }
 ```
 
-The default (no dedup) preserves behavior for existing consumers — upgrading the package does not change exposed tool sets unless the consumer explicitly passes a strategy.
+The default (`ReadVsGetDedupStrategy`) gives embedders the same single-tool-per-operation view as the launcher. Consumers that relied on both `Read<X>` and `Get<X>` being exposed must pass `new NoDedupStrategy()` to keep that behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "6.11.3",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "6.11.3",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "6.11.3",
+  "version": "7.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "6.11.3",
+  "version": "7.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "6.11.3",
+      "version": "7.0.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/unit/embeddableDedupDefault.test.ts
+++ b/src/__tests__/unit/embeddableDedupDefault.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit test: verifies the default duplicate-suppression behavior of
+ * `EmbeddableMcpServer`.
+ *
+ * When both the `readonly` and `high` sets are exposed, a readonly `Read<X>`
+ * handler and a high-level `Get<X>` handler can refer to the same operation
+ * (e.g. ReadProgram vs GetProgram). By default the server must suppress the
+ * `Read<X>` duplicate so consumers (e.g. cloud-llm-hub) get a single,
+ * deterministic tool per operation. Consumers can opt out by passing
+ * `new NoDedupStrategy()`.
+ *
+ * No SAP connection is needed: handler registration is lazy (wrapper lambdas
+ * call getConnection() only at invocation time), so a dummy connection object
+ * is sufficient to inspect the registered tool set.
+ *
+ * Run: npm test -- --testPathPatterns=unit/embeddableDedupDefault
+ */
+
+import { NoDedupStrategy } from '../../lib/handlers/groups/strategies/index';
+import { EmbeddableMcpServer } from '../../server/EmbeddableMcpServer';
+
+type RegisteredToolsMap = Record<string, unknown>;
+
+function getRegisteredToolNames(server: EmbeddableMcpServer): Set<string> {
+  const tools = (server as unknown as { _registeredTools: RegisteredToolsMap })
+    ._registeredTools;
+  return new Set(Object.keys(tools || {}));
+}
+
+const dummyConnection = {} as never;
+
+describe('EmbeddableMcpServer default Read/Get dedup', () => {
+  const ORIGINAL_SAP_SYSTEM_TYPE = process.env.SAP_SYSTEM_TYPE;
+
+  beforeAll(() => {
+    // Program tools are onprem/legacy-only; force onprem so Get/ReadProgram register.
+    process.env.SAP_SYSTEM_TYPE = 'onprem';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SAP_SYSTEM_TYPE === undefined) {
+      delete process.env.SAP_SYSTEM_TYPE;
+    } else {
+      process.env.SAP_SYSTEM_TYPE = ORIGINAL_SAP_SYSTEM_TYPE;
+    }
+  });
+
+  test('readonly+high hides Read<X> when Get<X> is present (default)', () => {
+    const server = new EmbeddableMcpServer({
+      connection: dummyConnection,
+      exposition: ['readonly', 'high'],
+      systemType: 'onprem',
+    });
+
+    const names = getRegisteredToolNames(server);
+
+    // Get<X> from the high group wins...
+    expect(names.has('GetProgram')).toBe(true);
+    expect(names.has('GetClass')).toBe(true);
+    expect(names.has('GetTable')).toBe(true);
+    // ...and the readonly Read<X> duplicate is suppressed by default.
+    expect(names.has('ReadProgram')).toBe(false);
+    expect(names.has('ReadClass')).toBe(false);
+    expect(names.has('ReadTable')).toBe(false);
+  });
+
+  test('readonly-only keeps Read<X> (no overriding group)', () => {
+    const server = new EmbeddableMcpServer({
+      connection: dummyConnection,
+      exposition: ['readonly'],
+      systemType: 'onprem',
+    });
+
+    const names = getRegisteredToolNames(server);
+
+    expect(names.has('ReadProgram')).toBe(true);
+    expect(names.has('GetProgram')).toBe(false);
+  });
+
+  test('explicit NoDedupStrategy opts out — both Read and Get exposed', () => {
+    const server = new EmbeddableMcpServer({
+      connection: dummyConnection,
+      exposition: ['readonly', 'high'],
+      systemType: 'onprem',
+      readOnlyDedupStrategy: new NoDedupStrategy(),
+    });
+
+    const names = getRegisteredToolNames(server);
+
+    expect(names.has('GetProgram')).toBe(true);
+    expect(names.has('ReadProgram')).toBe(true);
+  });
+});

--- a/src/server/EmbeddableMcpServer.ts
+++ b/src/server/EmbeddableMcpServer.ts
@@ -8,7 +8,10 @@ import { LowLevelHandlersGroup } from '../lib/handlers/groups/LowLevelHandlersGr
 import { ReadOnlyHandlersGroup } from '../lib/handlers/groups/ReadOnlyHandlersGroup.js';
 import { SearchHandlersGroup } from '../lib/handlers/groups/SearchHandlersGroup.js';
 import { SystemHandlersGroup } from '../lib/handlers/groups/SystemHandlersGroup.js';
-import type { IReadOnlyDedupStrategy } from '../lib/handlers/groups/strategies/index.js';
+import {
+  type IReadOnlyDedupStrategy,
+  ReadVsGetDedupStrategy,
+} from '../lib/handlers/groups/strategies/index.js';
 import type {
   IHandlerGroup,
   IHandlersRegistry,
@@ -85,11 +88,12 @@ export interface EmbeddableMcpServerOptions {
    * Optional strategy that decides which readonly handlers to dedup (hide)
    * when overriding groups (high / low / compact) are also exposed.
    *
-   * Default: no dedup — readonly handlers are exposed verbatim, preserving
-   * prior behavior for existing consumers. Pass `new ReadVsGetDedupStrategy()`
-   * (exported from this package) to hide `Read<X>` when a corresponding
-   * `Get<X>` is contributed by another group, or supply a custom
-   * implementation for bespoke role-based rules.
+   * Default: `ReadVsGetDedupStrategy` — hides a readonly `Read<X>` handler
+   * when a corresponding `Get<X>` is contributed by another group, so a single
+   * deterministic tool is exposed per operation (matching the standalone
+   * launcher). Pass `new NoDedupStrategy()` (exported from this package) to
+   * expose readonly handlers verbatim, or supply a custom implementation for
+   * bespoke role-based rules.
    */
   readOnlyDedupStrategy?: IReadOnlyDedupStrategy;
 }
@@ -168,7 +172,7 @@ export class EmbeddableMcpServer extends BaseMcpServer {
       | 'search'
     )[],
     logger?: Logger,
-    readOnlyDedupStrategy?: IReadOnlyDedupStrategy,
+    readOnlyDedupStrategy: IReadOnlyDedupStrategy = new ReadVsGetDedupStrategy(),
   ): IHandlersRegistry {
     // Dummy context - not actually used because BaseMcpServer.registerHandlers()
     // creates wrapper lambdas that call getConnection() for fresh context
@@ -178,7 +182,7 @@ export class EmbeddableMcpServer extends BaseMcpServer {
     };
 
     // Build non-readonly groups first so their tool names can feed the
-    // readonly dedup strategy (when one is provided by the consumer).
+    // readonly dedup strategy (defaults to ReadVsGetDedupStrategy).
     const overridingGroups: IHandlerGroup[] = [];
     if (exposition.includes('high')) {
       overridingGroups.push(new HighLevelHandlersGroup(dummyContext));


### PR DESCRIPTION
## Проблема

У наборах `readonly` і `high` частина тулзів робить одне й те саме під різними іменами — `Read<X>` (readonly) та `Get<X>` (high), наприклад `ReadProgram` vs `GetProgram`. Таких пар 16 (Class, Table, View, FunctionModule, Program, …).

Standalone-`launcher` уже прибирав дублікати через `ReadVsGetDedupStrategy`, але `EmbeddableMcpServer` (яким користується cloud-llm-hub) за замовчуванням мав `NoDedupStrategy`. Тому при `readonly + high` експонувалися **обидва** тули, і який із них обере LLM — недетерміновано.

## Зміна

Default `readOnlyDedupStrategy` в `EmbeddableMcpServer` → `ReadVsGetDedupStrategy`. Тепер embedder бачить один тул на операцію, як і launcher.

**BREAKING**: default змінює видимий набір тулзів у споживача без змін коду. Хто покладався на наявність обох варіантів — має явно передати `readOnlyDedupStrategy: new NoDedupStrategy()` (escape hatch збережено). Рівень API не змінюється.

## Реліз

**7.0.0** (major — breaking-зміна поведінки): `package.json`, `server.json` (×2), `package-lock.json` → 7.0.0; CHANGELOG-запис `[7.0.0]` з позначкою BREAKING.

## Зроблено

- `src/server/EmbeddableMcpServer.ts` — default стратегії в `createDefaultRegistry`; оновлено JSDoc.
- Юніт-тест `embeddableDedupDefault.test.ts` — default дедуп, readonly-only, opt-out через `NoDedupStrategy`.
- README, `docs/user-guide/HANDLERS_MANAGEMENT.md` — синхронізовано з новим дефолтом.

## Перевірка

- `tsc --noEmit` — чисто
- `jest unit` — 54/54 (3 нові)
- pre-push build (biome + tsc) — без помилок

## Після мерджу

Публікація npm — за тобою (агент не публікує). Після bump-у залежності в cloud-llm-hub зникне дубль у парах `Read`/`Get` — варто перевірити на реальному запиті.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
