### PR TITLE
release(7.0.1): realign with adt-clients@5.4.4 — 423 lock fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [7.0.1] - 2026-06-11
+
+### Fixed
+- Bumped `@mcp-abap-adt/adt-clients` from `^5.4.2` to `^5.4.4` to pick up the stateful-lock-chain fix. Object writes (e.g. `UpdateClass`) no longer fail with HTTP `423 — not locked (invalid lock handle)` on older ABAP kernels (e.g. BASIS 7.55) over HTTP: the client now keeps the connection stateful for the whole `lock → check → update → unlock` chain across all object types, instead of switching back to stateless before the lock-bound PUT. Newer kernels (758/816) already tolerated the stateless write. No server-side API or tool-schema change. (#106)
+
 ## [7.0.0] - 2026-05-30
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^5.4.2",
+        "@mcp-abap-adt/adt-clients": "^5.4.4",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-5.4.2.tgz",
-      "integrity": "sha512-VY5cEA5LYG3iiwNMuCmdh7aYpqJbRIG7imM5FCXPlzhOvaUaNeesFvEcKqZ4mOWCA5B/c7tCTtYlewoTvEiJ5w==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-5.4.4.tgz",
+      "integrity": "sha512-V4Aj+m62suX6kJssbnuH23p7PKZklQsv0GqhoHgJF1PTcGT5sMPN958GQBFbbIAUIKw2MDcvtEQ1yugyTe8Lnw==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -136,7 +136,7 @@
     "yaml": "^2.8.1"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^5.4.2",
+    "@mcp-abap-adt/adt-clients": "^5.4.4",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "7.0.0",
+  "version": "7.0.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## What

Realign the server with `@mcp-abap-adt/adt-clients@5.4.4`.

## Why

adt-clients 5.4.4 fixes HTTP **423 — not locked (invalid lock handle)** on object writes (e.g. `UpdateClass`) on older ABAP kernels (e.g. BASIS 7.55) over HTTP. The client now keeps the connection **stateful for the whole `lock → check → update → unlock` chain** across all object types, instead of dropping to stateless before the lock-bound PUT. Newer kernels (758/816) already tolerated the stateless write.

See adt-clients fr0ster/mcp-abap-adt-clients#38 / #39 and the original report #106.

## Change

- `@mcp-abap-adt/adt-clients`: `^5.4.2` → `^5.4.4`
- Clean registry install — `package-lock.json` has **no** `link:true` / `file:` entries; `adt-clients@5.4.4` resolved from registry.npmjs.org.
- Version bump 7.0.0 → 7.0.1 (package.json, server.json, package-lock.json); CHANGELOG updated.
- No server-side API or tool-schema change.

## Verification

- `npm run build` (biome + tsc) clean; `npm run test:check` (tsc test) clean.
- End-to-end lock/unlock verification happens downstream in cloud-llm-hub once this is published and consumed there.

Refs #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
