### PR TITLE
release(7.0.2): realign with adt-clients@5.5.0 — master language from SAP_LANGUAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [7.0.2] - 2026-06-13
+
+### Added
+- **Created objects now adopt the logon language as their master/original language.** `getSystemContext()` reads `SAP_LANGUAGE` into `masterLanguage`, and `createAdtClient()` forwards it to the ADT client, so every `Create*` tool stamps `adtcore:masterLanguage`/`adtcore:language` with the session language instead of always `EN`. When `SAP_LANGUAGE` is unset the client still defaults to `EN`. Requires the configured language to be installed on the target system (otherwise SAP normalizes it to the system default). (#105)
+
+### Changed
+- Bumped `@mcp-abap-adt/adt-clients` from `^5.4.4` to `^5.5.0` for the configurable-master-language support. Clean registry install (no `link:true`/`file:` in the lockfile).
+
+### Note
+- A per-call `master_language` parameter on the high-level `Create*` tool schemas (to override the session language per object) is planned as a follow-up; the underlying client already supports `config.masterLanguage`.
+
 ## [7.0.1] - 2026-06-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^5.4.4",
+        "@mcp-abap-adt/adt-clients": "^5.5.0",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-5.4.4.tgz",
-      "integrity": "sha512-V4Aj+m62suX6kJssbnuH23p7PKZklQsv0GqhoHgJF1PTcGT5sMPN958GQBFbbIAUIKw2MDcvtEQ1yugyTe8Lnw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-5.5.0.tgz",
+      "integrity": "sha512-8HZGvx8NcczhhY4KiBBdq8oPz0Pfhx7P+bT0Nol0mravGiWX2H6yJlqWyq9LNcgb+uQBrdt2bRS9e9ODfGphLg==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -136,7 +136,7 @@
     "yaml": "^2.8.1"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^5.4.4",
+    "@mcp-abap-adt/adt-clients": "^5.5.0",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "7.0.1",
+  "version": "7.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/lib/clients.ts
+++ b/src/lib/clients.ts
@@ -14,8 +14,12 @@ export function createAdtClient(
 ): AdtClient {
   const ctx = getSystemContext();
   const options =
-    ctx.masterSystem || ctx.responsible
-      ? { masterSystem: ctx.masterSystem, responsible: ctx.responsible }
+    ctx.masterSystem || ctx.responsible || ctx.masterLanguage
+      ? {
+          masterSystem: ctx.masterSystem,
+          responsible: ctx.responsible,
+          masterLanguage: ctx.masterLanguage,
+        }
       : undefined;
   if (ctx.isLegacy) {
     return new AdtClientLegacy(connection, logger, options);

--- a/src/lib/systemContext.ts
+++ b/src/lib/systemContext.ts
@@ -7,6 +7,8 @@ export interface IAdtSystemContext {
   responsible?: string;
   client?: string;
   isLegacy?: boolean;
+  /** Master/original language for created objects (adtcore:masterLanguage). From SAP_LANGUAGE; library defaults to EN when unset. */
+  masterLanguage?: string;
 }
 
 // Singleton cache is sufficient: one MCP session always maps to one SAP system.
@@ -38,6 +40,7 @@ export async function resolveSystemContext(
     cached = {
       masterSystem: overrides.masterSystem,
       responsible: overrides.responsible,
+      masterLanguage: overrides.masterLanguage ?? process.env.SAP_LANGUAGE,
       isLegacy: cached?.isLegacy ?? detectLegacy(),
     };
     return cached;
@@ -51,9 +54,10 @@ export async function resolveSystemContext(
   // Priority 2: env vars (on-prem or explicitly configured)
   const masterSystem = process.env.SAP_MASTER_SYSTEM;
   const responsible = process.env.SAP_RESPONSIBLE || process.env.SAP_USERNAME;
+  const masterLanguage = process.env.SAP_LANGUAGE;
 
-  if (masterSystem || responsible) {
-    cached = { masterSystem, responsible, isLegacy };
+  if (masterSystem || responsible || masterLanguage) {
+    cached = { masterSystem, responsible, masterLanguage, isLegacy };
     return cached;
   }
 
@@ -64,10 +68,11 @@ export async function resolveSystemContext(
       masterSystem: info?.systemID,
       responsible: info?.userName,
       client: info?.client,
+      masterLanguage,
       isLegacy,
     };
   } catch {
-    cached = { isLegacy };
+    cached = { masterLanguage, isLegacy };
   }
 
   return cached;


### PR DESCRIPTION
## What

Realign the server with `@mcp-abap-adt/adt-clients@5.5.0` and wire its new master-language support.

## Why

adt-clients 5.5.0 makes the master/original language of created objects configurable (was hardcoded `EN`). This realign sources it from the session logon language so `Create*` tools stamp `adtcore:masterLanguage`/`adtcore:language` with `SAP_LANGUAGE` instead of always `EN` (fr0ster/mcp-abap-adt#105).

## Change

- `@mcp-abap-adt/adt-clients`: `^5.4.4` → `^5.5.0` (clean registry install — no `link:true`/`file:` in the lockfile).
- `getSystemContext()` reads `SAP_LANGUAGE` into `masterLanguage`; `createAdtClient()` forwards it to the ADT client. Unset → client defaults to `EN`.
- Version bump 7.0.1 → 7.0.2 (package.json, server.json, package-lock.json); CHANGELOG updated.

## Verification

`npm run build` (biome + tsc) clean; `npm run test:check` clean. The underlying language wiring was verified at the wire level on a live BTP trial in the adt-clients repo. Requires the configured language to be installed on the target system (else SAP normalizes to the system default).

## Follow-up

A per-call `master_language` parameter on the high-level `Create*` tool schemas (override the session language per object) — the client already supports `config.masterLanguage`, so this is purely additive on the consumer side.

Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
