### PR TITLE
release(7.0.3): realign with adt-clients@5.6.0 (package master language #105 + behaviorDefinition namespace fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [7.0.3] - 2026-06-13
+
+### Changed
+- Bumped `@mcp-abap-adt/adt-clients` from `^5.5.0` to `^5.6.0`. Picks up: `package` create now honours the configurable master language (so `CreatePackage` stamps the session `SAP_LANGUAGE` like the other object types — #105), and the behaviorDefinition namespace URL-encoding fix (namespaced `/NSP/…` behavior definitions can now be read/locked/updated/activated/checked/unlocked/deleted). Clean registry install (no `link:true`/`file:` in the lockfile).
+
+### Note
+- Per-call `master_language` tool parameter on `Create*` and the inbound `X-SAP-Language` header override are a planned follow-up; this release wires the session-language default to package as well.
+
 ## [7.0.2] - 2026-06-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "7.0.2",
+      "version": "7.0.3",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^5.5.0",
+        "@mcp-abap-adt/adt-clients": "^5.6.0",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
@@ -226,17 +226,26 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-5.5.0.tgz",
-      "integrity": "sha512-8HZGvx8NcczhhY4KiBBdq8oPz0Pfhx7P+bT0Nol0mravGiWX2H6yJlqWyq9LNcgb+uQBrdt2bRS9e9ODfGphLg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-5.6.0.tgz",
+      "integrity": "sha512-fyIHiMbkFzAhAkD9xy6P2KDJIGT4l1aJuShXHFt+1SKf6lESQKW+kNaogfa85rQ6FlTSk4C8mYyUB6lN/QsGqQ==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^7.0.0",
+        "@mcp-abap-adt/interfaces": "^7.3.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.13.6",
         "fast-xml-parser": "^5.4.1",
         "yaml": "^2.3.4"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/adt-clients/node_modules/@mcp-abap-adt/interfaces": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-7.3.0.tgz",
+      "integrity": "sha512-9Q7L/min183Zq/0WUoHXyzB4QzeYMoizYsyDlechk9CoAq8VGJ7AYxh/EUQIS8y6lPpugtAK9McKgolImnefVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -136,7 +136,7 @@
     "yaml": "^2.8.1"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^5.5.0",
+    "@mcp-abap-adt/adt-clients": "^5.6.0",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "7.0.2",
+  "version": "7.0.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "7.0.2",
+      "version": "7.0.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Bumps `@mcp-abap-adt/adt-clients` `^5.5.0` → `^5.6.0`.

Picks up:
- **package** create honours the configurable master language — `CreatePackage` now stamps the session `SAP_LANGUAGE` like the other object types (#105).
- **behaviorDefinition namespace URL-encoding fix** — namespaced `/NSP/…` behavior definitions can be read/locked/updated/activated/checked/unlocked/deleted.

Clean registry install (no `link:true`/`file:` in lockfile). `npm run build` clean.

Per-call `master_language` tool param + inbound `X-SAP-Language` header override are a planned follow-up.

Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)