### PR TITLE
chore(tests): add polygon backup fixture + polygon:backup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "shared:setup": "jest --testPathPatterns='admin/shared-deps/setup' --testPathIgnorePatterns='[]' --runInBand --passWithNoTests",
     "shared:teardown": "jest --testPathPatterns='admin/shared-deps/teardown' --testPathIgnorePatterns='[]' --runInBand --passWithNoTests",
     "shared:check": "jest --testPathPatterns='admin/shared-deps/check' --testPathIgnorePatterns='[]' --passWithNoTests",
+    "polygon:backup": "adt-backup backup --package ZMCP_SHR_PKG --env-path trial.env --output tests/fixtures/polygon.backup.yaml",
     "lint": "npx biome check --write src",
     "lint:check": "npx biome check src",
     "format": "npx biome format --write src",

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,26 @@
+# Test fixtures
+
+## `polygon.backup.yaml`
+
+A clean snapshot of the integration-test shared polygon (package `ZMCP_SHR_PKG`),
+produced by the external [`@mcp-abap-adt/adt-backup`](https://www.npmjs.com/package/@mcp-abap-adt/adt-backup)
+CLI (installed globally, **not** a dependency of this repo). schemaVersion 2.
+
+Captured objects include the shared tables/views/CDS/classes plus the
+function-group children (`ZMCP_SHR_FGRP` → `Z_MCP_SHR_FM`, `LZMCP_SHR_FGRPTOP`)
+and the embedded structures (`ZMCP_SHR_STRU` / `ZMCP_SHR_STRU_INC`). The generated
+`L<FUGR>UXX` collector is filtered out by the backup tool. **No secrets**
+(connection/auth details are never written to a backup — only object source/metadata).
+
+### Regenerate
+```bash
+npm run polygon:backup        # adt-backup ≥ 1.5.0 installed globally; trial.env at repo root
+```
+
+### Restore the polygon from this fixture (manual, external CLI)
+```bash
+adt-backup plan    --input tests/fixtures/polygon.backup.yaml --output /tmp/plan.yaml
+adt-backup verify  --plan  /tmp/plan.yaml --env-path trial.env
+adt-backup restore --plan  /tmp/plan.yaml --env-path trial.env
+```
+(Restore of function-group includes requires adt-backup ≥ 1.5.0.)

--- a/tests/fixtures/polygon.backup.yaml
+++ b/tests/fixtures/polygon.backup.yaml
@@ -1,0 +1,450 @@
+schemaVersion: 2
+generatedAt: 2026-06-19T09:23:04.916Z
+package: ZMCP_SHR_PKG
+root:
+  name: ZMCP_SHR_PKG
+  adtType: DEVC/K
+  type: package
+  is_package: true
+  codeFormat: xml
+  children:
+    - name: ZMCP_SHR_I_ROOT
+      adtType: BDEF/BDO
+      type: behaviorDefinition
+      description: Shared BDEF for BehaviorDefinition and BehaviorImplementatio
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        name: ZMCP_SHR_I_ROOT
+        description: Shared BDEF for BehaviorDefinition and BehaviorImplementatio
+        packageName: ZMCP_SHR_PKG
+        implementationType: Managed
+        rootEntity: ZMCP_SHR_I_ROOT
+      codeBase64: bWFuYWdlZCBpbXBsZW1lbnRhdGlvbiBpbiBjbGFzcyB6YnBfbWNwX3Nocl9pX3Jvb3QgdW5pcXVlOwpzdHJpY3QgKCAyICk7CgpkZWZpbmUgYmVoYXZpb3IgZm9yIFpNQ1BfU0hSX0lfUk9PVApwZXJzaXN0ZW50IHRhYmxlIHptY3Bfc2hyX3J0YWJsCmxvY2sgbWFzdGVyCmF1dGhvcml6YXRpb24gbWFzdGVyICggaW5zdGFuY2UgKQp7CiAgY3JlYXRlICggYXV0aG9yaXphdGlvbiA6IGdsb2JhbCApOwogIHVwZGF0ZTsKICBkZWxldGU7CiAgZmllbGQgKCByZWFkb25seSApIEZsZDE7CiAgYXNzb2NpYXRpb24gX2NoaWxkcmVuIHsgY3JlYXRlOyB9Cn0KCmRlZmluZSBiZWhhdmlvciBmb3IgWk1DUF9TSFJfSV9DSExECnBlcnNpc3RlbnQgdGFibGUgem1jcF9zaHJfY3RhYmwKbG9jayBkZXBlbmRlbnQgYnkgX3BhcmVudAphdXRob3JpemF0aW9uIGRlcGVuZGVudCBieSBfcGFyZW50CnsKICB1cGRhdGU7CiAgZGVsZXRlOwogIGZpZWxkICggcmVhZG9ubHk6dXBkYXRlICkgQ2hsZElkLCBQYXJlbnRJZDsKICBhc3NvY2lhdGlvbiBfcGFyZW50Owp9
+      codeChecksum: 11caf7909c75774af786d658f8f55d9a41de639a2fae311d1fd690170b17ac0a
+    - name: ZBP_MCP_SHR_I_ROOT
+      adtType: CLAS/OC
+      type: class
+      description: Shared BDEF implementation class for ZMCP_SHR_I_ROOT
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        className: ZBP_MCP_SHR_I_ROOT
+        description: Shared BDEF implementation class for ZMCP_SHR_I_ROOT
+        packageName: ZMCP_SHR_PKG
+        responsible: CB9980008038
+        masterSystem: TRL
+      codeBase64: Q0xBU1MgemJwX21jcF9zaHJfaV9yb290IERFRklOSVRJT04NCiAgUFVCTElDDQogIENSRUFURSBQVUJMSUMgLg0KDQogIFBVQkxJQyBTRUNUSU9OLg0KICBQUk9URUNURUQgU0VDVElPTi4NCiAgUFJJVkFURSBTRUNUSU9OLg0KRU5EQ0xBU1MuDQoNCg0KDQpDTEFTUyBaQlBfTUNQX1NIUl9JX1JPT1QgSU1QTEVNRU5UQVRJT04uDQpFTkRDTEFTUy4=
+      usedBy:
+        - behaviorDefinition:ZMCP_SHR_I_ROOT
+      codeChecksum: 94e2e9ba7bf4c15ab74277b6d2380c80496c0422205b4fe4da96f8339ea83e46
+    - name: ZMCP_BLD_CLSUT_L1
+      adtType: CLAS/OC
+      type: class
+      description: Shared container class for unit test integration tests
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        className: ZMCP_BLD_CLSUT_L1
+        description: Shared container class for unit test integration tests
+        packageName: ZMCP_SHR_PKG
+        responsible: CB9980008038
+        masterSystem: TRL
+      codeBase64: Q0xBU1Mgem1jcF9ibGRfY2xzdXRfbDEgREVGSU5JVElPTg0KICBQVUJMSUMNCiAgQ1JFQVRFIFBVQkxJQyAuDQoNCiAgUFVCTElDIFNFQ1RJT04uDQogIFBST1RFQ1RFRCBTRUNUSU9OLg0KICBQUklWQVRFIFNFQ1RJT04uDQpFTkRDTEFTUy4NCg0KDQoNCkNMQVNTIFpNQ1BfQkxEX0NMU1VUX0wxIElNUExFTUVOVEFUSU9OLg0KRU5EQ0xBU1Mu
+      codeChecksum: 8c6ced72af831efdd8f902761b567859c7826d87650896d854374e839258cbb5
+    - name: ZMCP_BLD_CDSV_H1
+      adtType: DDLS/DF
+      type: view
+      description: Shared CDS view for CDS unit test
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared CDS view for CDS unit test
+        packageName: ZMCP_SHR_PKG
+        viewName: ZMCP_BLD_CDSV_H1
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBDRFMgdmlldyBmb3IgQ0RTIHVuaXQgdGVzdCcKQEFjY2Vzc0NvbnRyb2wuYXV0aG9yaXphdGlvbkNoZWNrIDogI05PVF9SRVFVSVJFRApkZWZpbmUgdmlldyBlbnRpdHkgWk1DUF9CTERfQ0RTVl9IMQogIGFzIHNlbGVjdCBmcm9tIHptY3BfY2RzX3RibDAyCnsKICBrZXkgaWQsCiAgbmFtZSwKICB2YWx1ZSwKICBjcmVhdGVkX2F0Cn0K
+      codeChecksum: 23d9d5ac506108b476d9bd391b37c196e8245658a34e666dc7b3b8c0ca58e7fb
+    - name: ZMCP_SHR_C_ROOT
+      adtType: DDLS/DF
+      type: view
+      description: Shared consumption projection CDS view
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared consumption projection CDS view
+        packageName: ZMCP_SHR_PKG
+        viewName: ZMCP_SHR_C_ROOT
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBjb25zdW1wdGlvbiBwcm9qZWN0aW9uJwpAQWNjZXNzQ29udHJvbC5hdXRob3JpemF0aW9uQ2hlY2sgOiAjTk9UX1JFUVVJUkVECmRlZmluZSByb290IHZpZXcgZW50aXR5IFpNQ1BfU0hSX0NfUk9PVAogIHByb3ZpZGVyIGNvbnRyYWN0IHRyYW5zYWN0aW9uYWxfcXVlcnkKICBhcyBwcm9qZWN0aW9uIG9uIFpNQ1BfU0hSX0lfUk9PVAp7CiAga2V5IEZsZDEsCiAgRmxkMiwKICBGbGQzLAogIEZsZDQKfQo=
+      usedBy:
+        - serviceDefinition:ZMCP_SHR_SRVD01
+      codeChecksum: 44b7c1b9ba746a4b263c6d0ef1c015b06131aa69fc10ea50fa4eb3e95fca5d61
+    - name: ZMCP_SHR_I_BCHD
+      adtType: DDLS/DF
+      type: view
+      description: Shared child CDS view for BDEF HIGH test
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared child CDS view for BDEF HIGH test
+        packageName: ZMCP_SHR_PKG
+        viewName: ZMCP_SHR_I_BCHD
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBjaGlsZCBDRFMgdmlldyBmb3IgQkRFRiBISUdIIHRlc3QnCkBBY2Nlc3NDb250cm9sLmF1dGhvcml6YXRpb25DaGVjayA6ICNOT1RfUkVRVUlSRUQKZGVmaW5lIHZpZXcgZW50aXR5IFpNQ1BfU0hSX0lfQkNIRAogIGFzIHNlbGVjdCBmcm9tIHptY3Bfc2hyX2JjdGJsCiAgYXNzb2NpYXRpb24gdG8gcGFyZW50IFpNQ1BfU0hSX0lfQkRFRiBhcyBfcGFyZW50CiAgICBvbiAkcHJvamVjdGlvbi5QYXJlbnRJZCA9IF9wYXJlbnQuRmxkMQp7CiAga2V5IGNobGRfaWQgYXMgQ2hsZElkLAogIHBhcmVudF9pZCBhcyBQYXJlbnRJZCwKICBmbGQyIGFzIEZsZDIsCiAgX3BhcmVudAp9Cg==
+      usedBy:
+        - view:ZMCP_SHR_I_BDEF
+      codeChecksum: a31e95cd3d1935073ffd50ece0b3d33e9f64702993508f7612d35c67132a569d
+    - name: ZMCP_SHR_I_BCHL
+      adtType: DDLS/DF
+      type: view
+      description: Shared child CDS view for BDEF LOW test
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared child CDS view for BDEF LOW test
+        packageName: ZMCP_SHR_PKG
+        viewName: ZMCP_SHR_I_BCHL
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBjaGlsZCBDRFMgdmlldyBmb3IgQkRFRiBMT1cgdGVzdCcKQEFjY2Vzc0NvbnRyb2wuYXV0aG9yaXphdGlvbkNoZWNrIDogI05PVF9SRVFVSVJFRApkZWZpbmUgdmlldyBlbnRpdHkgWk1DUF9TSFJfSV9CQ0hMCiAgYXMgc2VsZWN0IGZyb20gem1jcF9zaHJfYmxjdGwKICBhc3NvY2lhdGlvbiB0byBwYXJlbnQgWk1DUF9TSFJfSV9CREZMIGFzIF9wYXJlbnQKICAgIG9uICRwcm9qZWN0aW9uLlBhcmVudElkID0gX3BhcmVudC5GbGQxCnsKICBrZXkgY2hsZF9pZCBhcyBDaGxkSWQsCiAgcGFyZW50X2lkIGFzIFBhcmVudElkLAogIGZsZDIgYXMgRmxkMiwKICBfcGFyZW50Cn0K
+      usedBy:
+        - view:ZMCP_SHR_I_BDFL
+      codeChecksum: 910875b102cd91cf9a1608e2be5452c687ecd27022a44d818a1b55bc0fb3a4a9
+    - name: ZMCP_SHR_I_BDEF
+      adtType: DDLS/DF
+      type: view
+      description: Shared root CDS view for BDEF HIGH test
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared root CDS view for BDEF HIGH test
+        packageName: ZMCP_SHR_PKG
+        viewName: ZMCP_SHR_I_BDEF
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCByb290IENEUyB2aWV3IGZvciBCREVGIEhJR0ggdGVzdCcKQEFjY2Vzc0NvbnRyb2wuYXV0aG9yaXphdGlvbkNoZWNrIDogI05PVF9SRVFVSVJFRApkZWZpbmUgcm9vdCB2aWV3IGVudGl0eSBaTUNQX1NIUl9JX0JERUYKICBhcyBzZWxlY3QgZnJvbSB6bWNwX3Nocl9idGFibAogIGNvbXBvc2l0aW9uIFswLi4qXSBvZiBaTUNQX1NIUl9JX0JDSEQgYXMgX2NoaWxkcmVuCnsKICBrZXkgZmxkMSBhcyBGbGQxLAogIGZsZDIgYXMgRmxkMiwKICBmbGQzIGFzIEZsZDMsCiAgZmxkNCBhcyBGbGQ0LAogIF9jaGlsZHJlbgp9Cg==
+      usedBy:
+        - view:ZMCP_SHR_I_BCHD
+      codeChecksum: e14e33247655b1a21891418119e74b985c0a85048f0b1a0db8fed0809ff91f94
+    - name: ZMCP_SHR_I_BDFL
+      adtType: DDLS/DF
+      type: view
+      description: Shared root CDS view for BDEF LOW test
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared root CDS view for BDEF LOW test
+        packageName: ZMCP_SHR_PKG
+        viewName: ZMCP_SHR_I_BDFL
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCByb290IENEUyB2aWV3IGZvciBCREVGIExPVyB0ZXN0JwpAQWNjZXNzQ29udHJvbC5hdXRob3JpemF0aW9uQ2hlY2sgOiAjTk9UX1JFUVVJUkVECmRlZmluZSByb290IHZpZXcgZW50aXR5IFpNQ1BfU0hSX0lfQkRGTAogIGFzIHNlbGVjdCBmcm9tIHptY3Bfc2hyX2JsdGJsCiAgY29tcG9zaXRpb24gWzAuLipdIG9mIFpNQ1BfU0hSX0lfQkNITCBhcyBfY2hpbGRyZW4KewogIGtleSBmbGQxIGFzIEZsZDEsCiAgZmxkMiBhcyBGbGQyLAogIGZsZDMgYXMgRmxkMywKICBmbGQ0IGFzIEZsZDQsCiAgX2NoaWxkcmVuCn0K
+      usedBy:
+        - view:ZMCP_SHR_I_BCHL
+      codeChecksum: 575578237d816e4a68c177007864e6412f22fbe72bb3ce6629e2128acee7c3a9
+    - name: ZMCP_SHR_I_CHLD
+      adtType: DDLS/DF
+      type: view
+      description: Shared child CDS view entity
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared child CDS view entity
+        packageName: ZMCP_SHR_PKG
+        viewName: ZMCP_SHR_I_CHLD
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBjaGlsZCBDRFMgdmlldyBlbnRpdHknCkBBY2Nlc3NDb250cm9sLmF1dGhvcml6YXRpb25DaGVjayA6ICNOT1RfUkVRVUlSRUQKZGVmaW5lIHZpZXcgZW50aXR5IFpNQ1BfU0hSX0lfQ0hMRAogIGFzIHNlbGVjdCBmcm9tIHptY3Bfc2hyX2N0YWJsCiAgYXNzb2NpYXRpb24gdG8gcGFyZW50IFpNQ1BfU0hSX0lfUk9PVCBhcyBfcGFyZW50CiAgICBvbiAkcHJvamVjdGlvbi5QYXJlbnRJZCA9IF9wYXJlbnQuRmxkMQp7CiAga2V5IGNobGRfaWQgYXMgQ2hsZElkLAogIHBhcmVudF9pZCBhcyBQYXJlbnRJZCwKICBmbGQyIGFzIEZsZDIsCiAgX3BhcmVudAp9Cg==
+      usedBy:
+        - behaviorDefinition:ZMCP_SHR_I_ROOT
+        - view:ZMCP_SHR_I_ROOT
+      codeChecksum: 09a94d5fbdc7e662e23062a352f668dc0902460815aaa02dcff420282cf5aad2
+    - name: ZMCP_SHR_I_ROOT
+      adtType: DDLS/DF
+      type: view
+      description: Shared root CDS view entity
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared root CDS view entity
+        packageName: ZMCP_SHR_PKG
+        viewName: ZMCP_SHR_I_ROOT
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCByb290IENEUyB2aWV3IGVudGl0eScKQEFjY2Vzc0NvbnRyb2wuYXV0aG9yaXphdGlvbkNoZWNrIDogI05PVF9SRVFVSVJFRApkZWZpbmUgcm9vdCB2aWV3IGVudGl0eSBaTUNQX1NIUl9JX1JPT1QKICBhcyBzZWxlY3QgZnJvbSB6bWNwX3Nocl9ydGFibAogIGNvbXBvc2l0aW9uIFswLi4qXSBvZiBaTUNQX1NIUl9JX0NITEQgYXMgX2NoaWxkcmVuCnsKICBrZXkgZmxkMSBhcyBGbGQxLAogIGZsZDIgYXMgRmxkMiwKICBmbGQzIGFzIEZsZDMsCiAgZmxkNCBhcyBGbGQ0LAogIF9jaGlsZHJlbgp9Cg==
+      usedBy:
+        - behaviorDefinition:ZMCP_SHR_I_ROOT
+        - view:ZMCP_SHR_C_ROOT
+        - view:ZMCP_SHR_I_CHLD
+      codeChecksum: 6ffb270610dc740822b5ef82647a4398c4cb8d2d9118b6363b3bebf62da51dab
+    - name: ZMCP_BLD_SHR_FGR
+      adtType: FUGR/F
+      type: functionGroup
+      description: Shared function group for read tests
+      is_package: false
+      codeFormat: xml
+      children:
+        - name: Z_MCP_BLD_SHR_FM
+          adtType: FUGR/FF
+          type: functionModule
+          functionGroupName: ZMCP_BLD_SHR_FGR
+          restoreStatus: ok
+          config:
+            functionGroupName: ZMCP_BLD_SHR_FGR
+            functionModuleName: Z_MCP_BLD_SHR_FM
+            description: Z_MCP_BLD_SHR_FM
+          codeBase64: RlVOQ1RJT04gel9tY3BfYmxkX3Nocl9mbQ0KICBJTVBPUlRJTkcNCiAgICBWQUxVRShpdl9pbnB1dCkgVFlQRSBzdHJpbmcNCiAgRVhQT1JUSU5HDQogICAgVkFMVUUoZXZfb3V0cHV0KSBUWVBFIHN0cmluZy4NCg0KDQoNCiAgZXZfb3V0cHV0ID0gfEVjaG86IHsgaXZfaW5wdXQgfXwuDQpFTkRGVU5DVElPTi4NCg==
+          codeFormat: source
+          codeChecksum: 9fc101928a23162fef4e5222ce1d9591e137f3b44ae60ba735bfcc4715aaeb1b
+        - name: LZMCP_BLD_SHR_FGRTOP
+          adtType: FUGR/I
+          type: functionInclude
+          functionGroupName: ZMCP_BLD_SHR_FGR
+          restoreStatus: ok
+          config:
+            includeName: LZMCP_BLD_SHR_FGRTOP
+            functionGroupName: ZMCP_BLD_SHR_FGR
+            description: LZMCP_BLD_SHR_FGRTOP
+          codeBase64: RlVOQ1RJT04tUE9PTCBaTUNQX0JMRF9TSFJfRkdSLiAgICAgICAgICAgICAiTUVTU0FHRS1JRCAuLg0KDQoqIElOQ0xVREUgTFpNQ1BfQkxEX1NIUl9GR1JELi4uICAgICAgICAgICAgICAiIExvY2FsIGNsYXNzIGRlZmluaXRpb24=
+          codeFormat: source
+          codeChecksum: ab07e47191994e4d2c79042ae8da299407e7bf6a49c85fae504096bc118c1435
+      functionGroupName: ZMCP_BLD_SHR_FGR
+      restoreStatus: ok
+      config:
+        functionGroupName: ZMCP_BLD_SHR_FGR
+        packageName: ZMCP_SHR_PKG
+        description: Shared function group for read tests
+      codeBase64: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48Z3JvdXA6YWJhcEZ1bmN0aW9uR3JvdXAgZ3JvdXA6bG9ja2VkQnlFZGl0b3I9ImZhbHNlIiBhYmFwc291cmNlOnNvdXJjZVVyaT0ic291cmNlL21haW4iIGFiYXBzb3VyY2U6Zml4UG9pbnRBcml0aG1ldGljPSJ0cnVlIiBhYmFwc291cmNlOmFjdGl2ZVVuaWNvZGVDaGVjaz0iZmFsc2UiIGFkdGNvcmU6cmVzcG9uc2libGU9IkNCOTk4MDAwODAzOCIgYWR0Y29yZTptYXN0ZXJMYW5ndWFnZT0iRU4iIGFkdGNvcmU6bWFzdGVyU3lzdGVtPSJUUkwiIGFkdGNvcmU6YWJhcExhbmd1YWdlVmVyc2lvbj0iY2xvdWREZXZlbG9wbWVudCIgYWR0Y29yZTpuYW1lPSJaTUNQX0JMRF9TSFJfRkdSIiBhZHRjb3JlOnR5cGU9IkZVR1IvRiIgYWR0Y29yZTpjaGFuZ2VkQXQ9IjIwMjYtMDUtMTNUMTE6MjU6MDlaIiBhZHRjb3JlOnZlcnNpb249ImFjdGl2ZSIgYWR0Y29yZTpjcmVhdGVkQXQ9IjIwMjYtMDUtMTNUMDA6MDA6MDBaIiBhZHRjb3JlOmNoYW5nZWRCeT0iQ0I5OTgwMDA4MDM4IiBhZHRjb3JlOmNyZWF0ZWRCeT0iQ0I5OTgwMDA4MDM4IiBhZHRjb3JlOmRlc2NyaXB0aW9uPSJTaGFyZWQgZnVuY3Rpb24gZ3JvdXAgZm9yIHJlYWQgdGVzdHMiIGFkdGNvcmU6ZGVzY3JpcHRpb25UZXh0TGltaXQ9IjQwIiBhZHRjb3JlOmxhbmd1YWdlPSJFTiIgeG1sbnM6Z3JvdXA9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvZnVuY3Rpb25zL2dyb3VwcyIgeG1sbnM6YWJhcHNvdXJjZT0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9hYmFwc291cmNlIiB4bWxuczphZHRjb3JlPSJodHRwOi8vd3d3LnNhcC5jb20vYWR0L2NvcmUiPjxhdG9tOmxpbmsgaHJlZj0ic291cmNlL21haW4vdmVyc2lvbnMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvdmVyc2lvbnMiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0ic291cmNlL21haW4iIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvc291cmNlIiB0eXBlPSJ0ZXh0L3BsYWluIiBldGFnPSIyMDI2MDUxMzExMjUwOTAwMTEiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0ic291cmNlL21haW4iIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvc291cmNlIiB0eXBlPSJ0ZXh0L2h0bWwiIGV0YWc9IjIwMjYwNTEzMTEyNTA5MDAxMSIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC90ZXh0ZWxlbWVudHMvZnVuY3Rpb25ncm91cHMvem1jcF9ibGRfc2hyX2ZnciIgcmVsPSJodHRwOi8vd3d3LnNhcC5jb20vYWR0L3JlbGF0aW9ucy9zb3VyY2VzL3RleHRlbGVtZW50cyIgdGl0bGU9IlRleHQgZWxlbWVudHMiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvZnVuY3Rpb25zL2dyb3Vwcy96bWNwX2JsZF9zaHJfZmdyL2VuaGFuY2VtZW50cy9pbXBsZW1lbnRhdGlvbnMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvZW5oYW5jZW1lbnRJbXBsZW1lbnRhdGlvbnMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC5zYXAuYWR0LmVuaGFuY2VtZW50aW1wbGVtZW50YXRpb25zLnYxK3htbCIgdGl0bGU9IkVuaGFuY2VtZW50IEltcGxlbWVudGF0aW9ucyIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9mdW5jdGlvbnMvZ3JvdXBzL3ptY3BfYmxkX3Nocl9mZ3IvZW5oYW5jZW1lbnRzL29wdGlvbnMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvZW5oYW5jZW1lbnRPcHRpb25zT2ZNYWluT2JqZWN0IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5lbmhhbmNlbWVudG9wdGlvbnMudjIreG1sIiB0aXRsZT0iRW5oYW5jZW1lbnQgT3B0aW9ucyBvZiBNYWluIE9iamVjdCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9mdW5jdGlvbnMvZ3JvdXBzL3ptY3BfYmxkX3Nocl9mZ3Ivc291cmNlL21haW4vZW5oYW5jZW1lbnRzL29wdGlvbnMiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvZW5oYW5jZW1lbnRPcHRpb25zIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5lbmhhbmNlbWVudG9wdGlvbnMudjIreG1sIiB0aXRsZT0iRW5oYW5jZW1lbnQgT3B0aW9ucyIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIuL3ptY3BfYmxkX3Nocl9mZ3Ivb2JqZWN0c3RydWN0dXJlIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL29iamVjdHN0cnVjdHVyZSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQub2JqZWN0c3RydWN0dXJlLnYyK3htbCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGFkdGNvcmU6cGFja2FnZVJlZiBhZHRjb3JlOnVyaT0iL3NhcC9iYy9hZHQvcGFja2FnZXMvem1jcF9zaHJfcGtnIiBhZHRjb3JlOnR5cGU9IkRFVkMvSyIgYWR0Y29yZTpuYW1lPSJaTUNQX1NIUl9QS0ciLz48YWJhcHNvdXJjZTpzeW50YXhDb25maWd1cmF0aW9uPjxhYmFwc291cmNlOmxhbmd1YWdlPjxhYmFwc291cmNlOnZlcnNpb24+NTwvYWJhcHNvdXJjZTp2ZXJzaW9uPjxhYmFwc291cmNlOmRlc2NyaXB0aW9uPkFCQVAgZm9yIENsb3VkIERldmVsb3BtZW50PC9hYmFwc291cmNlOmRlc2NyaXB0aW9uPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvYWJhcHNvdXJjZS9wYXJzZXJzL3JuZC9ncmFtbWFyLzUiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvYWJhcHNvdXJjZS9wYXJzZXIiIHR5cGU9InRleHQvcGxhaW4iIHRpdGxlPSJBQkFQIGZvciBDbG91ZCBEZXZlbG9wbWVudCIgZXRhZz0iOTE5NSIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PC9hYmFwc291cmNlOmxhbmd1YWdlPjwvYWJhcHNvdXJjZTpzeW50YXhDb25maWd1cmF0aW9uPjwvZ3JvdXA6YWJhcEZ1bmN0aW9uR3JvdXA+
+      codeChecksum: 72feb63b6173f1f33e73185c205677a8d3a61fcc4a01ceb22912914aa707772e
+    - name: ZMCP_SHR_FGRP
+      adtType: FUGR/F
+      type: functionGroup
+      description: Shared FUGR for include/FM tests
+      is_package: false
+      codeFormat: xml
+      children:
+        - name: Z_MCP_SHR_FM
+          adtType: FUGR/FF
+          type: functionModule
+          functionGroupName: ZMCP_SHR_FGRP
+          restoreStatus: ok
+          config:
+            functionGroupName: ZMCP_SHR_FGRP
+            functionModuleName: Z_MCP_SHR_FM
+            description: Z_MCP_SHR_FM
+          codeBase64: RlVOQ1RJT04gel9tY3Bfc2hyX2ZtDQogIElNUE9SVElORw0KICAgIFZBTFVFKGl2X2lucHV0KSBUWVBFIHN0cmluZw0KICBFWFBPUlRJTkcNCiAgICBWQUxVRShldl9vdXRwdXQpIFRZUEUgc3RyaW5nLg0KDQoNCg0KICBldl9vdXRwdXQgPSB8RWNobzogeyBpdl9pbnB1dCB9fC4NCkVOREZVTkNUSU9OLg0K
+          codeFormat: source
+          codeChecksum: 711deab2474908ac3fe7b4e57c0ca131e5cc0f833f8f52666a1b9715c0254ed8
+        - name: LZMCP_SHR_FGRPTOP
+          adtType: FUGR/I
+          type: functionInclude
+          functionGroupName: ZMCP_SHR_FGRP
+          restoreStatus: ok
+          config:
+            includeName: LZMCP_SHR_FGRPTOP
+            functionGroupName: ZMCP_SHR_FGRP
+            description: LZMCP_SHR_FGRPTOP
+          codeBase64: RlVOQ1RJT04tUE9PTCBaTUNQX1NIUl9GR1JQLiAgICAgICAgICAgICAgICAiTUVTU0FHRS1JRCAuLg0KDQoqIElOQ0xVREUgTFpNQ1BfU0hSX0ZHUlBELi4uICAgICAgICAgICAgICAgICAiIExvY2FsIGNsYXNzIGRlZmluaXRpb24=
+          codeFormat: source
+          codeChecksum: 5cdbeffdcacf48f32c46cd6cab8c79ef8c2968d3b9153287e0a2a0bd6702cd91
+      functionGroupName: ZMCP_SHR_FGRP
+      restoreStatus: ok
+      config:
+        functionGroupName: ZMCP_SHR_FGRP
+        packageName: ZMCP_SHR_PKG
+        description: Shared FUGR for include/FM tests
+      codeBase64: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48Z3JvdXA6YWJhcEZ1bmN0aW9uR3JvdXAgZ3JvdXA6bG9ja2VkQnlFZGl0b3I9ImZhbHNlIiBhYmFwc291cmNlOnNvdXJjZVVyaT0ic291cmNlL21haW4iIGFiYXBzb3VyY2U6Zml4UG9pbnRBcml0aG1ldGljPSJ0cnVlIiBhYmFwc291cmNlOmFjdGl2ZVVuaWNvZGVDaGVjaz0iZmFsc2UiIGFkdGNvcmU6cmVzcG9uc2libGU9IkNCOTk4MDAwODAzOCIgYWR0Y29yZTptYXN0ZXJMYW5ndWFnZT0iRU4iIGFkdGNvcmU6bWFzdGVyU3lzdGVtPSJUUkwiIGFkdGNvcmU6YWJhcExhbmd1YWdlVmVyc2lvbj0iY2xvdWREZXZlbG9wbWVudCIgYWR0Y29yZTpuYW1lPSJaTUNQX1NIUl9GR1JQIiBhZHRjb3JlOnR5cGU9IkZVR1IvRiIgYWR0Y29yZTpjaGFuZ2VkQXQ9IjIwMjYtMDYtMTlUMDc6NTY6MTlaIiBhZHRjb3JlOnZlcnNpb249ImluYWN0aXZlIiBhZHRjb3JlOmNyZWF0ZWRBdD0iMjAyNi0wNi0xOVQwMDowMDowMFoiIGFkdGNvcmU6Y2hhbmdlZEJ5PSJDQjk5ODAwMDgwMzgiIGFkdGNvcmU6Y3JlYXRlZEJ5PSJDQjk5ODAwMDgwMzgiIGFkdGNvcmU6ZGVzY3JpcHRpb249IlNoYXJlZCBGVUdSIGZvciBpbmNsdWRlL0ZNIHRlc3RzIiBhZHRjb3JlOmRlc2NyaXB0aW9uVGV4dExpbWl0PSI0MCIgYWR0Y29yZTpsYW5ndWFnZT0iRU4iIHhtbG5zOmdyb3VwPSJodHRwOi8vd3d3LnNhcC5jb20vYWR0L2Z1bmN0aW9ucy9ncm91cHMiIHhtbG5zOmFiYXBzb3VyY2U9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvYWJhcHNvdXJjZSIgeG1sbnM6YWR0Y29yZT0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9jb3JlIj48YXRvbTpsaW5rIGhyZWY9InNvdXJjZS9tYWluL3ZlcnNpb25zIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL3ZlcnNpb25zIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9InNvdXJjZS9tYWluIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL3NvdXJjZSIgdHlwZT0idGV4dC9wbGFpbiIgZXRhZz0iMjAyNjA2MTkwNzU2MTkwMDAxIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9InNvdXJjZS9tYWluIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL3NvdXJjZSIgdHlwZT0idGV4dC9odG1sIiBldGFnPSIyMDI2MDYxOTA3NTYxOTAwMDEiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvdGV4dGVsZW1lbnRzL2Z1bmN0aW9uZ3JvdXBzL3ptY3Bfc2hyX2ZncnAiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvc291cmNlcy90ZXh0ZWxlbWVudHMiIHRpdGxlPSJUZXh0IGVsZW1lbnRzIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9Ii9zYXAvYmMvYWR0L2Z1bmN0aW9ucy9ncm91cHMvem1jcF9zaHJfZmdycC9lbmhhbmNlbWVudHMvaW1wbGVtZW50YXRpb25zIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL2VuaGFuY2VtZW50SW1wbGVtZW50YXRpb25zIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5lbmhhbmNlbWVudGltcGxlbWVudGF0aW9ucy52MSt4bWwiIHRpdGxlPSJFbmhhbmNlbWVudCBJbXBsZW1lbnRhdGlvbnMiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvZnVuY3Rpb25zL2dyb3Vwcy96bWNwX3Nocl9mZ3JwL2VuaGFuY2VtZW50cy9vcHRpb25zIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL2VuaGFuY2VtZW50T3B0aW9uc09mTWFpbk9iamVjdCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQuZW5oYW5jZW1lbnRvcHRpb25zLnYyK3htbCIgdGl0bGU9IkVuaGFuY2VtZW50IE9wdGlvbnMgb2YgTWFpbiBPYmplY3QiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvZnVuY3Rpb25zL2dyb3Vwcy96bWNwX3Nocl9mZ3JwL3NvdXJjZS9tYWluL2VuaGFuY2VtZW50cy9vcHRpb25zIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL2VuaGFuY2VtZW50T3B0aW9ucyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQuZW5oYW5jZW1lbnRvcHRpb25zLnYyK3htbCIgdGl0bGU9IkVuaGFuY2VtZW50IE9wdGlvbnMiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvZnVuY3Rpb25zL2dyb3Vwcy96bWNwX3Nocl9mZ3JwL3NvdXJjZS9tYWluP3ZlcnNpb249YWN0aXZlIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL29iamVjdHN0YXRlcyIgdGl0bGU9IlJlZmVyZW5jZSB0byBhY3RpdmUgb3IgaW5hY3RpdmUgdmVyc2lvbiIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIuL3ptY3Bfc2hyX2ZncnAvb2JqZWN0c3RydWN0dXJlIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL29iamVjdHN0cnVjdHVyZSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQub2JqZWN0c3RydWN0dXJlLnYyK3htbCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGFkdGNvcmU6cGFja2FnZVJlZiBhZHRjb3JlOnVyaT0iL3NhcC9iYy9hZHQvcGFja2FnZXMvem1jcF9zaHJfcGtnIiBhZHRjb3JlOnR5cGU9IkRFVkMvSyIgYWR0Y29yZTpuYW1lPSJaTUNQX1NIUl9QS0ciLz48YWJhcHNvdXJjZTpzeW50YXhDb25maWd1cmF0aW9uPjxhYmFwc291cmNlOmxhbmd1YWdlPjxhYmFwc291cmNlOnZlcnNpb24+NTwvYWJhcHNvdXJjZTp2ZXJzaW9uPjxhYmFwc291cmNlOmRlc2NyaXB0aW9uPkFCQVAgZm9yIENsb3VkIERldmVsb3BtZW50PC9hYmFwc291cmNlOmRlc2NyaXB0aW9uPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvYWJhcHNvdXJjZS9wYXJzZXJzL3JuZC9ncmFtbWFyLzUiIHJlbD0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9yZWxhdGlvbnMvYWJhcHNvdXJjZS9wYXJzZXIiIHR5cGU9InRleHQvcGxhaW4iIHRpdGxlPSJBQkFQIGZvciBDbG91ZCBEZXZlbG9wbWVudCIgZXRhZz0iOTE5NSIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PC9hYmFwc291cmNlOmxhbmd1YWdlPjwvYWJhcHNvdXJjZTpzeW50YXhDb25maWd1cmF0aW9uPjwvZ3JvdXA6YWJhcEZ1bmN0aW9uR3JvdXA+
+      codeChecksum: fecaac85b5f0736ca2d95568336eb74d9b3736e61f86e1d7eef987f74ea21efe
+    - name: ZMCP_SHR_SRVD01
+      adtType: SRVD/SRV
+      type: serviceDefinition
+      description: Shared service definition for binding tests
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        serviceDefinitionName: ZMCP_SHR_SRVD01
+        packageName: ZMCP_SHR_PKG
+        description: Shared service definition for binding tests
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsOiAnU2hhcmVkIHNlcnZpY2UgZGVmaW5pdGlvbiBmb3IgYmluZGluZyB0ZXN0cycKZGVmaW5lIHNlcnZpY2UgWk1DUF9TSFJfU1JWRDAxIHsKICBleHBvc2UgWk1DUF9TSFJfQ19ST09UIGFzIFZpZXcxOwp9Cg==
+      codeChecksum: c393972a15aa84cbf68444ba2df204d68c54ab15837463f517b618a7370da919
+    - name: ZMCP_SHR_STRU
+      adtType: TABL/DS
+      type: structure
+      description: Shared base struct
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared base struct
+        packageName: ZMCP_SHR_PKG
+        structureName: ZMCP_SHR_STRU
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBiYXNlIHN0cnVjdCcKQEFiYXBDYXRhbG9nLmVuaGFuY2VtZW50LmNhdGVnb3J5IDogI0VYVEVOU0lCTEVfQU5ZCmRlZmluZSBzdHJ1Y3R1cmUgem1jcF9zaHJfc3RydSB7CgogIGJhc2VfYSA6IGFiYXAuY2hhcig1KTsKICBpbmNsdWRlIHptY3Bfc2hyX3N0cnVfaW5jOwogIGJhc2VfYiA6IGFiYXAubnVtYyg0KTsKCn0=
+      codeChecksum: 909776e068dc96e81f780e31b6165f2e2faac2d6ab211fdde3c28fcf6e3df148
+    - name: ZMCP_SHR_STRU_INC
+      adtType: TABL/DS
+      type: structure
+      description: Shared struct include
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared struct include
+        packageName: ZMCP_SHR_PKG
+        structureName: ZMCP_SHR_STRU_INC
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCBzdHJ1Y3QgaW5jbHVkZScKQEFiYXBDYXRhbG9nLmVuaGFuY2VtZW50LmNhdGVnb3J5IDogI05PVF9FWFRFTlNJQkxFCmRlZmluZSBzdHJ1Y3R1cmUgem1jcF9zaHJfc3RydV9pbmMgewoKICBpbmNfYSA6IGFiYXAuY2hhcigxMCk7CiAgaW5jX2IgOiBhYmFwLmludDQ7Cgp9
+      usedBy:
+        - structure:ZMCP_SHR_STRU
+      codeChecksum: e756fc1d93e6f89051d5c649f459f459ffacf536426fc65f830eb2b2332284b0
+    - name: ZMCP_CDS_TBL02
+      adtType: TABL/DT
+      type: table
+      description: Shared table for CDS unit test view
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared table for CDS unit test view
+        packageName: ZMCP_SHR_PKG
+        tableName: ZMCP_CDS_TBL02
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQ0RTIHVuaXQgdGVzdCB2aWV3JwpAQWJhcENhdGFsb2cuZW5oYW5jZW1lbnQuY2F0ZWdvcnkgOiAjTk9UX0VYVEVOU0lCTEUKQEFiYXBDYXRhbG9nLnRhYmxlQ2F0ZWdvcnkgOiAjVFJBTlNQQVJFTlQKQEFiYXBDYXRhbG9nLmRlbGl2ZXJ5Q2xhc3MgOiAjQQpAQWJhcENhdGFsb2cuZGF0YU1haW50ZW5hbmNlIDogI1JFU1RSSUNURUQKZGVmaW5lIHRhYmxlIHptY3BfY2RzX3RibDAyIHsKCiAga2V5IGNsaWVudCA6IGFiYXAuY2xudCBub3QgbnVsbDsKICBrZXkgaWQgICAgIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBuYW1lICAgICAgIDogYWJhcC5jaGFyKDUwKTsKICB2YWx1ZSAgICAgIDogYWJhcC5kZWMoMTAsMik7CiAgY3JlYXRlZF9hdCA6IGFiYXAuZGF0czsKCn0=
+      usedBy:
+        - view:ZMCP_BLD_CDSV_H1
+      codeChecksum: e0719eb6b37f46710715a9349aaf9d678a655b973c57fe77c43e634c9fe28f88
+    - name: ZMCP_SHR_BCTBL
+      adtType: TABL/DT
+      type: table
+      description: Shared table for BDEF test child entity
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared table for BDEF test child entity
+        packageName: ZMCP_SHR_PKG
+        tableName: ZMCP_SHR_BCTBL
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQkRFRiB0ZXN0IGNoaWxkIGVudGl0eScKQEFiYXBDYXRhbG9nLmVuaGFuY2VtZW50LmNhdGVnb3J5IDogI05PVF9FWFRFTlNJQkxFCkBBYmFwQ2F0YWxvZy50YWJsZUNhdGVnb3J5IDogI1RSQU5TUEFSRU5UCkBBYmFwQ2F0YWxvZy5kZWxpdmVyeUNsYXNzIDogI0EKQEFiYXBDYXRhbG9nLmRhdGFNYWludGVuYW5jZSA6ICNSRVNUUklDVEVECmRlZmluZSB0YWJsZSB6bWNwX3Nocl9iY3RibCB7CgogIGtleSBjbGllbnQgIDogYWJhcC5jbG50IG5vdCBudWxsOwogIGtleSBjaGxkX2lkIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBwYXJlbnRfaWQgICA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgZmxkMiAgICAgICAgOiBhYmFwLmNoYXIoNTApOwoKfQ==
+      usedBy:
+        - view:ZMCP_SHR_I_BCHD
+      codeChecksum: 60bf8d92cdd873f8c929eb71679f878f4ad45f2d7183a67a97fb76978199293c
+    - name: ZMCP_SHR_BLCTL
+      adtType: TABL/DT
+      type: table
+      description: Shared table for BDEF LOW test child entity
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared table for BDEF LOW test child entity
+        packageName: ZMCP_SHR_PKG
+        tableName: ZMCP_SHR_BLCTL
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQkRFRiBMT1cgdGVzdCBjaGlsZCBlbnRpdHknCkBBYmFwQ2F0YWxvZy5lbmhhbmNlbWVudC5jYXRlZ29yeSA6ICNOT1RfRVhURU5TSUJMRQpAQWJhcENhdGFsb2cudGFibGVDYXRlZ29yeSA6ICNUUkFOU1BBUkVOVApAQWJhcENhdGFsb2cuZGVsaXZlcnlDbGFzcyA6ICNBCkBBYmFwQ2F0YWxvZy5kYXRhTWFpbnRlbmFuY2UgOiAjUkVTVFJJQ1RFRApkZWZpbmUgdGFibGUgem1jcF9zaHJfYmxjdGwgewoKICBrZXkgY2xpZW50ICA6IGFiYXAuY2xudCBub3QgbnVsbDsKICBrZXkgY2hsZF9pZCA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgcGFyZW50X2lkICAgOiBhYmFwLmNoYXIoMTApIG5vdCBudWxsOwogIGZsZDIgICAgICAgIDogYWJhcC5jaGFyKDUwKTsKCn0=
+      usedBy:
+        - view:ZMCP_SHR_I_BCHL
+      codeChecksum: 8428bde8308a64ec228e048a69fc867f0f4ec7590197e4bca1345097f67334ea
+    - name: ZMCP_SHR_BLTBL
+      adtType: TABL/DT
+      type: table
+      description: Shared table for BDEF LOW test root entity
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared table for BDEF LOW test root entity
+        packageName: ZMCP_SHR_PKG
+        tableName: ZMCP_SHR_BLTBL
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQkRFRiBMT1cgdGVzdCByb290IGVudGl0eScKQEFiYXBDYXRhbG9nLmVuaGFuY2VtZW50LmNhdGVnb3J5IDogI05PVF9FWFRFTlNJQkxFCkBBYmFwQ2F0YWxvZy50YWJsZUNhdGVnb3J5IDogI1RSQU5TUEFSRU5UCkBBYmFwQ2F0YWxvZy5kZWxpdmVyeUNsYXNzIDogI0EKQEFiYXBDYXRhbG9nLmRhdGFNYWludGVuYW5jZSA6ICNSRVNUUklDVEVECmRlZmluZSB0YWJsZSB6bWNwX3Nocl9ibHRibCB7CgogIGtleSBjbGllbnQgOiBhYmFwLmNsbnQgbm90IG51bGw7CiAga2V5IGZsZDEgICA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgZmxkMiAgICAgICA6IGFiYXAuY2hhcig1MCk7CiAgZmxkMyAgICAgICA6IGFiYXAuZGVjKDEwLDIpOwogIGZsZDQgICAgICAgOiBhYmFwLmRhdHM7Cgp9
+      usedBy:
+        - view:ZMCP_SHR_I_BDFL
+      codeChecksum: 96baa71e4d0522c1d537ff7778aa48b8a5a42aecb77956e36fdbcee571e31141
+    - name: ZMCP_SHR_BTABL
+      adtType: TABL/DT
+      type: table
+      description: Shared table for BDEF test root entity
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared table for BDEF test root entity
+        packageName: ZMCP_SHR_PKG
+        tableName: ZMCP_SHR_BTABL
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgQkRFRiB0ZXN0IHJvb3QgZW50aXR5JwpAQWJhcENhdGFsb2cuZW5oYW5jZW1lbnQuY2F0ZWdvcnkgOiAjTk9UX0VYVEVOU0lCTEUKQEFiYXBDYXRhbG9nLnRhYmxlQ2F0ZWdvcnkgOiAjVFJBTlNQQVJFTlQKQEFiYXBDYXRhbG9nLmRlbGl2ZXJ5Q2xhc3MgOiAjQQpAQWJhcENhdGFsb2cuZGF0YU1haW50ZW5hbmNlIDogI1JFU1RSSUNURUQKZGVmaW5lIHRhYmxlIHptY3Bfc2hyX2J0YWJsIHsKCiAga2V5IGNsaWVudCA6IGFiYXAuY2xudCBub3QgbnVsbDsKICBrZXkgZmxkMSAgIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBmbGQyICAgICAgIDogYWJhcC5jaGFyKDUwKTsKICBmbGQzICAgICAgIDogYWJhcC5kZWMoMTAsMik7CiAgZmxkNCAgICAgICA6IGFiYXAuZGF0czsKCn0=
+      usedBy:
+        - view:ZMCP_SHR_I_BDEF
+      codeChecksum: fde51e317ac26c4d628f94f6d891d0f9397d9715dcd439883baa90e70a96f497
+    - name: ZMCP_SHR_CTABL
+      adtType: TABL/DT
+      type: table
+      description: Shared table for child CDS entity
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared table for child CDS entity
+        packageName: ZMCP_SHR_PKG
+        tableName: ZMCP_SHR_CTABL
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgY2hpbGQgQ0RTIGVudGl0eScKQEFiYXBDYXRhbG9nLmVuaGFuY2VtZW50LmNhdGVnb3J5IDogI05PVF9FWFRFTlNJQkxFCkBBYmFwQ2F0YWxvZy50YWJsZUNhdGVnb3J5IDogI1RSQU5TUEFSRU5UCkBBYmFwQ2F0YWxvZy5kZWxpdmVyeUNsYXNzIDogI0EKQEFiYXBDYXRhbG9nLmRhdGFNYWludGVuYW5jZSA6ICNSRVNUUklDVEVECmRlZmluZSB0YWJsZSB6bWNwX3Nocl9jdGFibCB7CgogIGtleSBjbGllbnQgIDogYWJhcC5jbG50IG5vdCBudWxsOwogIGtleSBjaGxkX2lkIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBwYXJlbnRfaWQgICA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgZmxkMiAgICAgICAgOiBhYmFwLmNoYXIoNTApOwoKfQ==
+      usedBy:
+        - behaviorDefinition:ZMCP_SHR_I_ROOT
+        - view:ZMCP_SHR_I_CHLD
+      codeChecksum: 64a8e6a509b714ba2305214939e492ceb361a0cdb4436f625691005e5472d078
+    - name: ZMCP_SHR_RTABL
+      adtType: TABL/DT
+      type: table
+      description: Shared table for root CDS entity
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared table for root CDS entity
+        packageName: ZMCP_SHR_PKG
+        tableName: ZMCP_SHR_RTABL
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3Igcm9vdCBDRFMgZW50aXR5JwpAQWJhcENhdGFsb2cuZW5oYW5jZW1lbnQuY2F0ZWdvcnkgOiAjTk9UX0VYVEVOU0lCTEUKQEFiYXBDYXRhbG9nLnRhYmxlQ2F0ZWdvcnkgOiAjVFJBTlNQQVJFTlQKQEFiYXBDYXRhbG9nLmRlbGl2ZXJ5Q2xhc3MgOiAjQQpAQWJhcENhdGFsb2cuZGF0YU1haW50ZW5hbmNlIDogI1JFU1RSSUNURUQKZGVmaW5lIHRhYmxlIHptY3Bfc2hyX3J0YWJsIHsKCiAga2V5IGNsaWVudCA6IGFiYXAuY2xudCBub3QgbnVsbDsKICBrZXkgZmxkMSAgIDogYWJhcC5jaGFyKDEwKSBub3QgbnVsbDsKICBmbGQyICAgICAgIDogYWJhcC5jaGFyKDUwKTsKICBmbGQzICAgICAgIDogYWJhcC5kZWMoMTAsMik7CiAgZmxkNCAgICAgICA6IGFiYXAuZGF0czsKCn0=
+      usedBy:
+        - behaviorDefinition:ZMCP_SHR_I_ROOT
+        - view:ZMCP_SHR_I_ROOT
+      codeChecksum: 2fa8da8edcd49bf2cbcbb5bd4ebf61af838a77c3b4786a39bc26bf55fdd04c43
+    - name: ZMCP_VIEW_TBL02
+      adtType: TABL/DT
+      type: table
+      description: Shared table for View builder tests
+      is_package: false
+      codeFormat: source
+      children: []
+      restoreStatus: ok
+      config:
+        description: Shared table for View builder tests
+        packageName: ZMCP_SHR_PKG
+        tableName: ZMCP_VIEW_TBL02
+      codeBase64: QEVuZFVzZXJUZXh0LmxhYmVsIDogJ1NoYXJlZCB0YWJsZSBmb3IgVmlldyBidWlsZGVyIHRlc3RzJwpAQWJhcENhdGFsb2cuZW5oYW5jZW1lbnQuY2F0ZWdvcnkgOiAjTk9UX0VYVEVOU0lCTEUKQEFiYXBDYXRhbG9nLnRhYmxlQ2F0ZWdvcnkgOiAjVFJBTlNQQVJFTlQKQEFiYXBDYXRhbG9nLmRlbGl2ZXJ5Q2xhc3MgOiAjQQpAQWJhcENhdGFsb2cuZGF0YU1haW50ZW5hbmNlIDogI1JFU1RSSUNURUQKZGVmaW5lIHRhYmxlIHptY3Bfdmlld190YmwwMiB7CgogIGtleSBjbGllbnQgOiBhYmFwLmNsbnQgbm90IG51bGw7CiAga2V5IGlkICAgICA6IGFiYXAuY2hhcigxMCkgbm90IG51bGw7CiAgbmFtZSAgICAgICA6IGFiYXAuY2hhcig1MCk7CiAgdmFsdWUgICAgICA6IGFiYXAuZGVjKDEwLDIpOwogIGNyZWF0ZWRfYXQgOiBhYmFwLmRhdHM7Cgp9
+      codeChecksum: 68293e719756cfec0f44ac639f6b30334396b1821f6eff1c1a160f756f9481ab
+  restoreStatus: ok
+  description: Shared test dependencies package
+  config:
+    packageName: ZMCP_SHR_PKG
+    description: Shared test dependencies package
+    superPackage: ZADT_BLD_PKG03
+    softwareComponent: ZLOCAL
+    responsible: CB9980008038
+  codeBase64: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48cGFrOnBhY2thZ2UgYWR0Y29yZTpyZXNwb25zaWJsZT0iQ0I5OTgwMDA4MDM4IiBhZHRjb3JlOm1hc3Rlckxhbmd1YWdlPSJFTiIgYWR0Y29yZTptYXN0ZXJTeXN0ZW09IlRSTCIgYWR0Y29yZTpuYW1lPSJaTUNQX1NIUl9QS0ciIGFkdGNvcmU6dHlwZT0iREVWQy9LIiBhZHRjb3JlOmNoYW5nZWRBdD0iMjAyNi0wNS0xM1QwMDowMDowMFoiIGFkdGNvcmU6dmVyc2lvbj0iYWN0aXZlIiBhZHRjb3JlOmNyZWF0ZWRBdD0iMjAyNi0wNS0xM1QwMDowMDowMFoiIGFkdGNvcmU6Y2hhbmdlZEJ5PSJDQjk5ODAwMDgwMzgiIGFkdGNvcmU6Y3JlYXRlZEJ5PSJDQjk5ODAwMDgwMzgiIGFkdGNvcmU6ZGVzY3JpcHRpb249IlNoYXJlZCB0ZXN0IGRlcGVuZGVuY2llcyBwYWNrYWdlIiBhZHRjb3JlOmRlc2NyaXB0aW9uVGV4dExpbWl0PSI2MCIgYWR0Y29yZTpsYW5ndWFnZT0iRU4iIHhtbG5zOnBhaz0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9wYWNrYWdlcyIgeG1sbnM6YWR0Y29yZT0iaHR0cDovL3d3dy5zYXAuY29tL2FkdC9jb3JlIj48YXRvbTpsaW5rIGhyZWY9InZlcnNpb25zIiByZWw9Imh0dHA6Ly93d3cuc2FwLmNvbS9hZHQvcmVsYXRpb25zL3ZlcnNpb25zIiB0aXRsZT0iSGlzdG9yaWMgdmVyc2lvbnMiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvdml0L3diL29iamVjdF90eXBlL2RldmNrL29iamVjdF9uYW1lL1pNQ1BfU0hSX1BLRyIgcmVsPSJzZWxmIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLnNhcGd1aSIgdGl0bGU9IlJlcHJlc2VudGF0aW9uIGluIFNBUCBHdWkiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvcGFja2FnZXMvdmFsdWVoZWxwcy9hcHBsaWNhdGlvbmNvbXBvbmVudHMiIHJlbD0iYXBwbGljYXRpb25jb21wb25lbnRzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQuc2FwLmFkdC5uYW1lZGl0ZW1zLnYxK3htbCIgdGl0bGU9IkFwcGxpY2F0aW9uIENvbXBvbmVudHMgVmFsdWUgSGVscCIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9wYWNrYWdlcy92YWx1ZWhlbHBzL3NvZnR3YXJlY29tcG9uZW50cyIgcmVsPSJzb2Z0d2FyZWNvbXBvbmVudHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC5zYXAuYWR0Lm5hbWVkaXRlbXMudjEreG1sIiB0aXRsZT0iU29mdHdhcmUgQ29tcG9uZW50cyBWYWx1ZSBIZWxwIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9Ii9zYXAvYmMvYWR0L3BhY2thZ2VzL3ZhbHVlaGVscHMvc29mdHdhcmVjb21wb25lbnRzez9uYW1lLGRhdGF9IiByZWw9ImFsbG93ZWRzb2Z0d2FyZWNvbXBvbmVudHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC5zYXAuYWR0Lm5hbWVkaXRlbXMudjEreG1sIiB0aXRsZT0iU29mdHdhcmUgQ29tcG9uZW50cyBWYWx1ZSBIZWxwIGJhc2VkIG9uIFBhY2thZ2UgQ29uc3RyYWlucyIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIvc2FwL2JjL2FkdC9wYWNrYWdlcy92YWx1ZWhlbHBzL3RyYW5zcG9ydGxheWVycyIgcmVsPSJ0cmFuc3BvcnRsYXllcnMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC5zYXAuYWR0Lm5hbWVkaXRlbXMudjEreG1sIiB0aXRsZT0iVHJhbnNwb3J0IExheWVycyBWYWx1ZSBIZWxwIiB4bWxuczphdG9tPSJodHRwOi8vd3d3LnczLm9yZy8yMDA1L0F0b20iLz48YXRvbTpsaW5rIGhyZWY9Ii9zYXAvYmMvYWR0L3BhY2thZ2VzL3ZhbHVlaGVscHMvYWJhcGxhbmd1YWdldmVyc2lvbnMiIHJlbD0iYWJhcGxhbmd1YWdldmVyc2lvbnMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC5zYXAuYWR0Lm5hbWVkaXRlbXMudjEreG1sIiB0aXRsZT0iQUJBUCBMYW5ndWFnZSBWZXJzaW9uIFZhbHVlIEhlbHAiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhdG9tOmxpbmsgaHJlZj0iL3NhcC9iYy9hZHQvY2hlY2tydW5zez9yZXBvcnRlcnN9IiByZWw9InN1cHBvcnRzUGFja2FnZUNoZWNrQWN0aW9ucyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnNhcC5hZHQuY2hlY2tvYmplY3RzK3htbCIgdGl0bGU9IlN1cHBvcnRzIFBhY2thZ2UgQ2hlY2sgYWN0aW9ucyIgeG1sbnM6YXRvbT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS9BdG9tIi8+PGF0b206bGluayBocmVmPSIuL3ptY3Bfc2hyX3BrZyIgcmVsPSJodHRwOi8vd3d3LnNhcC5jb20vYWR0L3JlbGF0aW9ucy9zb3VyY2UiIHR5cGU9InRleHQvaHRtbCIgdGl0bGU9IkxhbmRpbmcgUGFnZSAoSFRNTCkiIHhtbG5zOmF0b209Imh0dHA6Ly93d3cudzMub3JnLzIwMDUvQXRvbSIvPjxhZHRjb3JlOnBhY2thZ2VSZWYgYWR0Y29yZTp1cmk9Ii9zYXAvYmMvYWR0L3BhY2thZ2VzL3ptY3Bfc2hyX3BrZyIgYWR0Y29yZTp0eXBlPSJERVZDL0siIGFkdGNvcmU6bmFtZT0iWk1DUF9TSFJfUEtHIiBhZHRjb3JlOmRlc2NyaXB0aW9uPSJTaGFyZWQgdGVzdCBkZXBlbmRlbmNpZXMgcGFja2FnZSIvPjxwYWs6YXR0cmlidXRlcyBwYWs6cGFja2FnZVR5cGU9ImRldmVsb3BtZW50IiBwYWs6aXNQYWNrYWdlVHlwZUVkaXRhYmxlPSJmYWxzZSIgcGFrOmlzQWRkaW5nT2JqZWN0c0FsbG93ZWQ9ImZhbHNlIiBwYWs6aXNBZGRpbmdPYmplY3RzQWxsb3dlZEVkaXRhYmxlPSJ0cnVlIiBwYWs6aXNFbmNhcHN1bGF0ZWQ9ImZhbHNlIiBwYWs6aXNFbmNhcHN1bGF0aW9uRWRpdGFibGU9InRydWUiIHBhazppc0VuY2Fwc3VsYXRpb25WaXNpYmxlPSJ0cnVlIiBwYWs6cmVjb3JkQ2hhbmdlcz0iZmFsc2UiIHBhazppc1JlY29yZENoYW5nZXNFZGl0YWJsZT0iZmFsc2UiIHBhazppc1N3aXRjaFZpc2libGU9ImZhbHNlIiBwYWs6bGFuZ3VhZ2VWZXJzaW9uPSI1IiBwYWs6aXNMYW5ndWFnZVZlcnNpb25WaXNpYmxlPSJ0cnVlIiBwYWs6aXNMYW5ndWFnZVZlcnNpb25FZGl0YWJsZT0idHJ1ZSIvPjxwYWs6c3VwZXJQYWNrYWdlIGFkdGNvcmU6dXJpPSIvc2FwL2JjL2FkdC9wYWNrYWdlcy96YWR0X2JsZF9wa2cwMyIgYWR0Y29yZTp0eXBlPSJERVZDL0siIGFkdGNvcmU6bmFtZT0iWkFEVF9CTERfUEtHMDMiIGFkdGNvcmU6ZGVzY3JpcHRpb249Ik1DUCB0ZXN0IHBhY2thZ2UiLz48cGFrOmFwcGxpY2F0aW9uQ29tcG9uZW50IHBhazpuYW1lPSIiIHBhazpkZXNjcmlwdGlvbj0iTm8gYXBwbGljYXRpb24gY29tcG9uZW50IGFzc2lnbmVkIiBwYWs6aXNWaXNpYmxlPSJmYWxzZSIgcGFrOmlzRWRpdGFibGU9ImZhbHNlIi8+PHBhazp0cmFuc3BvcnQ+PHBhazpzb2Z0d2FyZUNvbXBvbmVudCBwYWs6bmFtZT0iWkxPQ0FMIiBwYWs6ZGVzY3JpcHRpb249IlNvZnR3YXJlIENvbXBvbmVudCBmb3IgbG9jYWwgZGV2ZWxvcG1lbnQiIHBhazp0eXBlPSJKIiBwYWs6dHlwZURlc2NyaXB0aW9uPSJMb2NhbCBjdXN0b21lciBkZXZlbG9wbWVudHMgKEFCQVAgZm9yIGNsb3VkIGRldmVsb3BtZW50KSIgcGFrOmlzVmlzaWJsZT0idHJ1ZSIgcGFrOmlzRWRpdGFibGU9ImZhbHNlIi8+PHBhazp0cmFuc3BvcnRMYXllciBwYWs6bmFtZT0iIiBwYWs6ZGVzY3JpcHRpb249IiIgcGFrOmlzVmlzaWJsZT0idHJ1ZSIgcGFrOmlzRWRpdGFibGU9ImZhbHNlIi8+PC9wYWs6dHJhbnNwb3J0PjxwYWs6dXNlQWNjZXNzZXMgcGFrOmlzVmlzaWJsZT0idHJ1ZSIvPjxwYWs6cGFja2FnZUludGVyZmFjZXMgcGFrOmlzVmlzaWJsZT0idHJ1ZSIvPjxwYWs6c3ViUGFja2FnZXMvPjwvcGFrOnBhY2thZ2U+
+  codeChecksum: 4a43e6edc7dd73d4cf0c1fa552513aedf8f0e0dacbc793a9076fdf81e25131e7
+checksum: 15f3daa0492650013fd199a24823715fc108d486e073870e1bdb3b1c8c8d6403


### PR DESCRIPTION
Adds a clean snapshot of the integration-test shared polygon (`ZMCP_SHR_PKG`) produced by the external `adt-backup` CLI (≥1.5.0):

- `tests/fixtures/polygon.backup.yaml` — schemaVersion 2; shared tables/views/CDS/classes + function-group children (`ZMCP_SHR_FGRP` → `Z_MCP_SHR_FM`, `LZMCP_SHR_FGRPTOP`) + embedded structures (`ZMCP_SHR_STRU` / `_INC`). Generated `L<FUGR>UXX` collector filtered. **No secrets** (backups carry only object source/metadata, never connection/auth).
- `npm run polygon:backup` to regenerate (adt-backup is a global tool, not a repo dependency).
- `tests/fixtures/README.md` documents regenerate/restore.

Verified: secret scan of the fixture is empty; the polygon is set up + active on trial and the new function-include/structure integration tests pass against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)