### PR TITLE
test(profiling): give runnable class real CPU work so a trace is produced

### DIFF
--- a/src/__tests__/integration/readOnly/system/RuntimeProfilingAndDumpsHandlers.test.ts
+++ b/src/__tests__/integration/readOnly/system/RuntimeProfilingAndDumpsHandlers.test.ts
@@ -102,6 +102,15 @@ ENDCLASS.
 
 CLASS ${className} IMPLEMENTATION.
   METHOD if_oo_adt_classrun~main.
+    " Do measurable CPU work so the runtime profiler has time to arm and
+    " actually captures a trace — a trivial single-statement body finishes
+    " before tracing engages, so no trace file is ever written (the trace
+    " then never resolves no matter how long we poll).
+    DATA lv_x TYPE i.
+    DO 2000000 TIMES.
+      lv_x = sy-index MOD 100.
+    ENDDO.
+    out->write( lv_x ).
     out->write( |MCP runtime class profiling ${className}| ).
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
## Problem
`RuntimeRunClassWithProfiling` failed on SAP trial cloud: **`Failed to resolve traceId after profiled execution`** — even after polling 30×5s (~5.6 min).

## Root cause (not polling duration)
The runnable test class had a trivial single-statement body (`out->write(...)`). It finishes **before the runtime profiler arms**, so SAP never writes a trace file → the traceId can never resolve, regardless of how long we poll. Longer polling windows (15→30 attempts, 2s→5s) did not help, confirming it's not a timing/eventual-consistency issue.

## Fix
Add a small CPU workload to the runnable class so the profiler captures something:
```abap
DATA lv_x TYPE i.
DO 2000000 TIMES.
  lv_x = sy-index MOD 100.
ENDDO.
out->write( lv_x ).
```

## Verification
Trial cloud: profiling test passes; full `RuntimeProfilingAndDumps` suite green (**5/5**).

## Rejected alternative
Activating the class (`activateOnUpdate` in the shared `createRunnableClass` helper) was tried and **rejected** — it consistently broke the division-by-zero dump test (2/2), and `classrun` executes the class without it. The workload alone is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)