### PR TITLE
chore(release): 7.1.2 — integration-test reliability fixes (test-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,17 @@
 
 ## [Unreleased]
 
+## [7.1.2] - 2026-06-20
+
+> **Test infrastructure only.** The published runtime (`dist/`) is unchanged from
+> 7.1.1 — no tool, handler, or library behaviour changed for consumers. This
+> release bundles integration-test reliability fixes and a stale-metadata fix.
+
 ### Fixed
-- **Test infrastructure (`shared:setup`):** the shared-dependency setup is now resilient to the cloud activation-run timeout. Bulk-activating the ~24 shared objects in one activation run can exceed adt-clients' fixed ~45s request timeout; the setup now skips the doomed full-group retries on a timeout and falls back to batched activation (chunks of 5, with a second pass retrying only the leftovers). No change to the published package — test tooling only.
+- **`shared:setup` resilient to the cloud activation-run timeout.** Bulk-activating the ~24 shared objects in one activation run can exceed adt-clients' fixed ~45s request timeout; on a timeout the setup now skips the doomed full-group retries and falls back to batched activation (chunks of 5, with a second pass retrying only the leftovers) instead of failing.
+- **Runtime profiling test produces a trace.** The runnable class now does measurable CPU work so the profiler arms and a trace is written; a trivial single-statement class finished before tracing engaged, so the trace never resolved (`Failed to resolve traceId`).
+- **Runtime dump test actually creates and reads a dump** (was silently skipping or hitting a `400 session` error). It activates the division-by-zero class, triggers the dump on a separate connection (so the dumping run's server-side context loss does not poison the connection used to read the dump), fixes dump-id extraction from the feed entry (`id` field, plural `/runtime/dumps/<id>` path, URL-encoded, no decode), binds the read dump to the uniquely-named generated class, and fails (instead of skipping) when no dump is produced. `params.dump_id` remains the explicit opt-out for read-only environments.
+- **`server.json` version** was stale at `7.0.3`; bumped to match the package version.
 
 ## [7.1.1] - 2026-06-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "7.0.3",
+  "version": "7.1.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "7.0.3",
+      "version": "7.1.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Patch release bundling the integration-test reliability work merged since 7.1.1.

**Test infrastructure only — the published `dist/` is unchanged from 7.1.1.** No tool/handler/library behaviour changed for consumers.

## Included
- `shared:setup` batched-activation fallback on the cloud 45s activation timeout (#114).
- Runtime profiling test: CPU-workload in the runnable class so the profiler produces a trace (#116).
- Runtime dump test: actually creates and reads a dump — separate trigger connection (avoids `400 session`), dump-id extraction fix, class-binding, fail-not-skip (#117).
- Fixes the stale `server.json` version (`7.0.3` → `7.1.2`).

## Release files bumped
`package.json`, `package-lock.json`, `server.json` (both version fields), `CHANGELOG.md` (`[7.1.2]`).

## Gates
`npm run build` + `npm run test:check` clean; lock has no `link:`/`file:`. SAP integration suites for the above were verified live on trial (soft mode) before their merges.

After merge: tag `v7.1.2`; **publish is done by the maintainer** (`npm publish @mcp-abap-adt/core@7.1.2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)