### PR TITLE
fix(structures): GetStructuresList returns append structures — 7.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [7.2.1] - 2026-06-23
+
+### Fixed
+- **`GetStructuresList` now returns extension (append) structures in the tree.** Calling it with just a structure name (e.g. `ZMCP_SHR_STRU`) returns a hierarchy containing both the included structure (`kind: include`) and the appending structure that `extend type <this> with …` (`kind: append`). Previously appends were missed: the where-used lookup used the default scope (some object types unselected, so the extension's type was excluded) and a fragile `displayName`/`globalType` regex. It now uses `getWhereUsedList({ enableAllTypes: true })` and the parsed references. Also removed dead `.APPEND` source-parsing (ADT never emits `.APPEND` in a structure's source — appends are separate `extend type` objects). Verified end-to-end on a real system.
+
 ## [7.2.0] - 2026-06-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "7.2.0",
+  "version": "7.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/integration/readOnly/structure/GetStructuresListHandler.test.ts
+++ b/src/__tests__/integration/readOnly/structure/GetStructuresListHandler.test.ts
@@ -188,8 +188,24 @@ describe('GetStructuresList ReadOnly Handler Integration', () => {
       expect(child).toBeDefined();
       expect(child?.kind).toBe('include');
 
+      // Append (extension) child — config-driven; only asserted when the test
+      // case provides `expected_append` (the extension is created out-of-band,
+      // since adt-clients cannot create `extend type` objects).
+      const expectedAppend = testCase.params.expected_append
+        ? String(testCase.params.expected_append).toUpperCase()
+        : null;
+      if (expectedAppend) {
+        const appendChild = (tree.children ?? []).find(
+          (node) => node.structure === expectedAppend,
+        );
+        expect(appendChild).toBeDefined();
+        expect(appendChild?.kind).toBe('append');
+      }
+
       testLogger?.info(
-        `✅ GetStructuresList completed: found include ${expectedInclude}`,
+        `✅ GetStructuresList completed: found include ${expectedInclude}${
+          expectedAppend ? ` + append ${expectedAppend}` : ''
+        }`,
       );
     },
     getTimeout('medium'),

--- a/src/handlers/structure/readonly/handleGetStructuresList.ts
+++ b/src/handlers/structure/readonly/handleGetStructuresList.ts
@@ -60,10 +60,11 @@ interface EmbeddedRef {
  *   include <name>;                  -> anonymous include (attribute = null)
  *   <attr> : include <name>;         -> named include (attribute = <attr>)
  *   .INCLUDE <name>                  -> classic include
- *   .APPEND[STRUCTURE] <name>        -> classic append
- * Plain component lines (`fld : type;`) and annotations (`@AbapCatalog…`) are
- * NOT structure embeddings and are ignored — do NOT confuse the
- * `@AbapCatalog.enhancement.category` annotation with an include/append.
+ * Appends are NOT in the source — an append is a separate object that
+ * `extend type <this> with …`, resolved via where-used (findExtensions), not
+ * parsed here. Plain component lines (`fld : type;`) and annotations
+ * (`@AbapCatalog…`) are NOT structure embeddings and are ignored — do NOT
+ * confuse the `@AbapCatalog.enhancement.category` annotation with an include.
  */
 export function parseEmbeddedStructures(source: string): EmbeddedRef[] {
   const refs: EmbeddedRef[] = [];
@@ -76,18 +77,11 @@ export function parseEmbeddedStructures(source: string): EmbeddedRef[] {
     line = line.trim();
     if (!line || line.startsWith('@') || line.startsWith('*')) continue;
 
-    // Classic field-list: .INCLUDE <name> / .APPEND[STRUCTURE] <name>
-    const classicAppend = line.match(
-      /^\.append(?:structure)?\s+([a-z0-9_/]+)/i,
-    );
-    if (classicAppend) {
-      refs.push({
-        name: classicAppend[1].toUpperCase(),
-        attribute: null,
-        kind: 'append',
-      });
-      continue;
-    }
+    // Classic field-list include: .INCLUDE <name>
+    // NOTE: appends are NOT parsed from source — ADT does not emit a `.APPEND`
+    // line in a structure's source. An append is a separate object that
+    // `extend type <this> with …`; those are resolved via where-used in
+    // findExtensions(), not here.
     const classicInclude = line.match(/^\.include\s+([a-z0-9_/]+)/i);
     if (classicInclude) {
       refs.push({

--- a/src/handlers/structure/readonly/handleGetStructuresList.ts
+++ b/src/handlers/structure/readonly/handleGetStructuresList.ts
@@ -187,29 +187,35 @@ export async function handleGetStructuresList(
      */
     const findExtensions = async (baseName: string): Promise<EmbeddedRef[]> => {
       if (!includeExtensions) return [];
-      let wuData = '';
+      // Use getWhereUsedList with enableAllTypes: the DEFAULT where-used scope
+      // leaves some object types unselected, so an extension's type may be
+      // excluded and the search returns nothing useful. enableAllTypes selects
+      // every type, and the result is already parsed into { name, type } refs.
+      let references: Array<{ name?: string; type?: string }> = [];
       try {
-        const wu: any = await utils.getWhereUsed({
+        const wu = await utils.getWhereUsedList({
           object_name: baseName,
           object_type: 'structure',
+          enableAllTypes: true,
         } as any);
-        wuData = String(wu?.data ?? '');
+        references = (wu?.references ?? []) as Array<{
+          name?: string;
+          type?: string;
+        }>;
       } catch (e: any) {
         logger?.warn(
           `where-used failed for ${baseName}: ${e?.message ?? String(e)}`,
         );
         return [];
       }
-      // Candidate referencing STRUCTURES (globalType TABL/DS), excluding self.
+      // Candidate referencing DDIC structures/tables (TABL/*), excluding self.
+      // The authoritative filter is the source check below (`extend type`).
       const candidates = new Set<string>();
-      for (const m of wuData.matchAll(
-        /displayName="([^"]+)"[^>]*globalType="(TABL\/DS[^"]*)"/g,
-      )) {
-        const name = m[1]
-          .replace(/\s*\(.*\)$/, '')
-          .trim()
-          .toUpperCase();
-        if (name && name !== baseName) candidates.add(name);
+      for (const ref of references) {
+        const name = (ref.name ?? '').trim().toUpperCase();
+        if (!name || name === baseName) continue;
+        if (!/^TABL\//i.test(ref.type ?? '')) continue;
+        candidates.add(name);
       }
       const extendRe = new RegExp(
         `extend\\s+type\\s+${baseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+with`,

--- a/tests/test-config.yaml.template
+++ b/tests/test-config.yaml.template
@@ -2220,10 +2220,14 @@ get_structures_list_readonly:
     - name: "list_embedded_structures"
       enabled: true
       available_in: ["onprem", "cloud", "legacy"]
-      description: "List the structures embedded (.INCLUDE / include) in the shared base structure"
+      description: "List the structures embedded (include) and extending (append) the shared base structure"
       params:
         structure_name: "ZMCP_SHR_STRU"
         expected_include: "ZMCP_SHR_STRU_INC"
+        # Extension (append) structure that `extend type ZMCP_SHR_STRU with …`.
+        # Created out-of-band (adt-clients cannot create `extend type` objects);
+        # leave empty to skip the append assertion on systems without it.
+        expected_append: "ZOK_S_APPEND"
 
 # FunctionInclude high-level lifecycle (create -> update -> read -> delete)
 # Uses a LETTER-suffix include name (not numeric) so ADT can delete it.


### PR DESCRIPTION
`GetStructuresList { structure_name: "ZMCP_SHR_STRU" }` (just the name) now returns a hierarchy with BOTH the included and the appended structure.

## Problem
Appends (extension structures that `extend type <base> with …`) were never returned. `findExtensions` called `getWhereUsed` with the **default scope** — which leaves some object types unselected, so the extension's type was excluded and the search returned only the base object. It also parsed the raw XML with a fragile `displayName`/`globalType` regex.

## Fix
- Use `getWhereUsedList({ enableAllTypes: true })`: selects every scope type (so the extension appears) and returns **parsed** `{ name, type }` references. Candidates = DDIC structure/table references, confirmed by reading each source for `extend type <base> with` → `kind: append`.
- Removed dead `.APPEND` source-parsing (ADT never emits `.APPEND` in a structure's source; appends are separate objects).

## Verification
Trial cloud: `GetStructuresList(ZMCP_SHR_STRU)` →
```
ZMCP_SHR_STRU (root)
├─ ZMCP_SHR_STRU_INC (include)
└─ ZOK_S_APPEND      (append)
```
Added a config-driven `expected_append` assertion + template param. `build` + `test:check` clean.

Release 7.2.1. After merge: tag `v7.2.1`; maintainer publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)