### PR TITLE
chore(release): bump server.json to 8.0.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "7.2.1",
+  "version": "8.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "7.2.1",
+      "version": "8.0.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
server.json (mcphub registry config) version fields drifted at 7.2.1 while package.json is 8.0.0 (PR #122). Bumps both `version` fields to 8.0.0 so the registry listing matches the release. No code change.