### PR TITLE
feat(where-used): type filters + adt-clients 6.1.0

### DIFF
--- a/docs/user-guide/AVAILABLE_TOOLS.md
+++ b/docs/user-guide/AVAILABLE_TOOLS.md
@@ -968,7 +968,9 @@ Generated from code in `src/handlers/**` (not from docs).
 **Source:** `src/handlers/system/readonly/handleGetWhereUsed.ts`
 
 **Parameters:**
+- `disable_types` (array, optional) - Remove these ADT object types from the default scope, keeping the rest (e.g. ['CLAS/OC'] to drop class usages). Applied on top of the default scope or of enable_only_types/enable_all_types.
 - `enable_all_types` (boolean, optional (default: false)) - If true, expands the scope to all available object types (Eclipse 'select all' behavior) by flipping every isSelected flag in the scope XML. Default: false (SAP default scope). Note: on large systems this can make the search significantly slower.
+- `enable_only_types` (array, optional) - Restrict the search to ONLY these ADT object types (e.g. ['TABL/DS','TABL/DT'] for structures, ['DDLS/DF'] for CDS sources). SAP applies the selection server-side, so unwanted types (e.g. hundreds of CLAS/OC) are never searched nor returned — use this instead of enable_all_types to avoid huge result sets. Type codes come from the where-used scope. Takes precedence over enable_all_types.
 - `object_name` (string, required) - Name of the ABAP object. For function modules the name MUST be in the form 'GROUP|FM_NAME' (function group name, pipe, function module name).
 - `object_type` (string, required) - Type of the ABAP object. Case-insensitive. Accepts either a human alias or an ADT type code. Supported values: 'class' / 'clas/oc', 'interface' / 'intf/if', 'program' / 'prog/p', 'include', 'function' / 'functiongroup' / 'fugr' (function group), 'functionmodule' / 'function_module' / 'fugr/ff' (function module — see object_name format), 'package' / 'devc/k', 'table' / 'tabl/dt', 'structure' / 'stru/dt', 'domain' / 'doma/dd', 'dataelement' / 'dtel', 'view' / 'ddls/df' (CDS DDL source only — classic DDIC views are not supported). Any other value throws 'Unsupported object type'.
 
@@ -5044,4 +5046,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-06-26*

--- a/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
@@ -554,4 +554,4 @@ Preferred dedicated compact tools and minimal payloads:
 
 ---
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-06-26*

--- a/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
@@ -2102,4 +2102,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-06-26*

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -2522,4 +2522,4 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-06-26*

--- a/docs/user-guide/AVAILABLE_TOOLS_LOW.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LOW.md
@@ -1991,4 +1991,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-06-26*

--- a/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
@@ -656,7 +656,9 @@ Generated from code in `src/handlers/**` (not from docs).
 **Source:** `src/handlers/system/readonly/handleGetWhereUsed.ts`
 
 **Parameters:**
+- `disable_types` (array, optional) - Remove these ADT object types from the default scope, keeping the rest (e.g. ['CLAS/OC'] to drop class usages). Applied on top of the default scope or of enable_only_types/enable_all_types.
 - `enable_all_types` (boolean, optional (default: false)) - If true, expands the scope to all available object types (Eclipse 'select all' behavior) by flipping every isSelected flag in the scope XML. Default: false (SAP default scope). Note: on large systems this can make the search significantly slower.
+- `enable_only_types` (array, optional) - Restrict the search to ONLY these ADT object types (e.g. ['TABL/DS','TABL/DT'] for structures, ['DDLS/DF'] for CDS sources). SAP applies the selection server-side, so unwanted types (e.g. hundreds of CLAS/OC) are never searched nor returned — use this instead of enable_all_types to avoid huge result sets. Type codes come from the where-used scope. Takes precedence over enable_all_types.
 - `object_name` (string, required) - Name of the ABAP object. For function modules the name MUST be in the form 'GROUP|FM_NAME' (function group name, pipe, function module name).
 - `object_type` (string, required) - Type of the ABAP object. Case-insensitive. Accepts either a human alias or an ADT type code. Supported values: 'class' / 'clas/oc', 'interface' / 'intf/if', 'program' / 'prog/p', 'include', 'function' / 'functiongroup' / 'fugr' (function group), 'functionmodule' / 'function_module' / 'fugr/ff' (function module — see object_name format), 'package' / 'devc/k', 'table' / 'tabl/dt', 'structure' / 'stru/dt', 'domain' / 'doma/dd', 'dataelement' / 'dtel', 'view' / 'ddls/df' (CDS DDL source only — classic DDIC views are not supported). Any other value throws 'Unsupported object type'.
 
@@ -957,4 +959,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-25*
+*Last updated: 2026-06-26*

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^6.0.0",
+        "@mcp-abap-adt/adt-clients": "^6.1.0",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
@@ -225,9 +225,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-6.0.0.tgz",
-      "integrity": "sha512-o8ShjetsS3pCOO02aKP5AmZ9o8MfXvQIgHV/hfluFiPFzi4s+zemF/dt7SWVq4eoi9WdvUNAuIe7FvoB4zj3nQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-6.1.0.tgz",
+      "integrity": "sha512-F4xqH3eyLljAfVWjHThpr/xpRBN3yJoolwjulCYoOw7hWooaqMxvkPR0uvZS107FF8wuxY41zi9kwDiJaEjUQw==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "yaml": "^2.8.1"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^6.0.0",
+    "@mcp-abap-adt/adt-clients": "^6.1.0",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",

--- a/src/__tests__/unit/handleGetWhereUsedFilters.test.ts
+++ b/src/__tests__/unit/handleGetWhereUsedFilters.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit test for GetWhereUsed type-filtering params (adt-clients 6.1.0).
+ *
+ * Verifies the tool exposes enable_only_types / disable_types and forwards them
+ * to getWhereUsedList as enableOnlyTypes / disableTypes — SAP-free via a mocked
+ * AdtClient.
+ */
+
+const mockGetWhereUsedList = jest.fn().mockResolvedValue({
+  objectName: 'ZT',
+  objectType: 'table',
+  totalReferences: 0,
+  resultDescription: '',
+  references: [],
+});
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getUtils: () => ({ getWhereUsedList: mockGetWhereUsedList }),
+  }),
+}));
+
+import {
+  handleGetWhereUsed,
+  TOOL_DEFINITION,
+} from '../../handlers/system/readonly/handleGetWhereUsed';
+
+describe('GetWhereUsed type-filter params', () => {
+  beforeEach(() => mockGetWhereUsedList.mockClear());
+
+  it('exposes enable_only_types and disable_types as string arrays in the input schema', () => {
+    const props = TOOL_DEFINITION.inputSchema.properties as Record<string, any>;
+    expect(props.enable_only_types?.type).toBe('array');
+    expect(props.enable_only_types?.items?.type).toBe('string');
+    expect(props.disable_types?.type).toBe('array');
+    expect(props.disable_types?.items?.type).toBe('string');
+  });
+
+  it('forwards enable_only_types/disable_types to getWhereUsedList', async () => {
+    await handleGetWhereUsed(
+      { connection: {}, logger: undefined } as any,
+      {
+        object_name: 'ZT',
+        object_type: 'table',
+        enable_only_types: ['TABL/DS', 'TABL/DT'],
+        disable_types: ['CLAS/OC'],
+      } as any,
+    );
+
+    expect(mockGetWhereUsedList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        object_name: 'ZT',
+        object_type: 'table',
+        enableOnlyTypes: ['TABL/DS', 'TABL/DT'],
+        disableTypes: ['CLAS/OC'],
+      }),
+    );
+  });
+
+  it('omits the filter keys when not provided (no accidental empty arrays)', async () => {
+    await handleGetWhereUsed(
+      { connection: {}, logger: undefined } as any,
+      {
+        object_name: 'ZT',
+        object_type: 'table',
+      } as any,
+    );
+
+    const arg = mockGetWhereUsedList.mock.calls[0][0];
+    expect(arg.enableOnlyTypes).toBeUndefined();
+    expect(arg.disableTypes).toBeUndefined();
+  });
+});

--- a/src/handlers/system/readonly/handleGetWhereUsed.ts
+++ b/src/handlers/system/readonly/handleGetWhereUsed.ts
@@ -33,6 +33,18 @@ export const TOOL_DEFINITION = {
           "If true, expands the scope to all available object types (Eclipse 'select all' behavior) by flipping every isSelected flag in the scope XML. Default: false (SAP default scope). Note: on large systems this can make the search significantly slower.",
         default: false,
       },
+      enable_only_types: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          "Restrict the search to ONLY these ADT object types (e.g. ['TABL/DS','TABL/DT'] for structures, ['DDLS/DF'] for CDS sources). SAP applies the selection server-side, so unwanted types (e.g. hundreds of CLAS/OC) are never searched nor returned — use this instead of enable_all_types to avoid huge result sets. Type codes come from the where-used scope. Takes precedence over enable_all_types.",
+      },
+      disable_types: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          "Remove these ADT object types from the default scope, keeping the rest (e.g. ['CLAS/OC'] to drop class usages). Applied on top of the default scope or of enable_only_types/enable_all_types.",
+      },
     },
     required: ['object_name', 'object_type'],
   },
@@ -42,6 +54,8 @@ interface WhereUsedArgs {
   object_name: string;
   object_type: string;
   enable_all_types?: boolean;
+  enable_only_types?: string[];
+  disable_types?: string[];
 }
 
 /**
@@ -77,6 +91,8 @@ export async function handleGetWhereUsed(
       object_name: typedArgs.object_name,
       object_type: typedArgs.object_type,
       enableAllTypes: typedArgs.enable_all_types,
+      enableOnlyTypes: typedArgs.enable_only_types,
+      disableTypes: typedArgs.disable_types,
     });
 
     logger?.debug(
@@ -88,6 +104,8 @@ export async function handleGetWhereUsed(
       object_name: result.objectName,
       object_type: result.objectType,
       enable_all_types: typedArgs.enable_all_types || false,
+      enable_only_types: typedArgs.enable_only_types,
+      disable_types: typedArgs.disable_types,
       total_references: result.totalReferences,
       result_description: result.resultDescription,
       references: result.references.map((ref) => ({


### PR DESCRIPTION
## Why

Upgrades `@mcp-abap-adt/adt-clients` `^6.0.0` → `^6.1.0` and surfaces its new
**server-side where-used type filtering** in the `GetWhereUsed` tool.

Previously the tool only offered `enable_all_types` (default scope or *everything*),
so a heavily-referenced object returned hundreds of `CLAS/OC` references — oversized
and prone to truncation. Now callers can ask SAP for only the types they need.

## What

- `package.json`: `@mcp-abap-adt/adt-clients` `^6.0.0` → `^6.1.0` (+ lockfile; resolves 6.1.0, no `link`)
- `GetWhereUsed` tool — new optional params:
  - `enable_only_types` (string[]) — restrict the search to specific ADT object types (e.g. `['TABL/DS','TABL/DT']`). SAP applies the selection server-side, so unwanted types are never searched nor returned. Takes precedence over `enable_all_types`.
  - `disable_types` (string[]) — prune types from the default scope.
  - Both forwarded to `getWhereUsedList` as `enableOnlyTypes` / `disableTypes`; response echoes the applied filters.
- Regenerated `AVAILABLE_TOOLS*` docs from the schema (`npm run docs:tools`).

## Tests

- New SAP-free unit test (`handleGetWhereUsedFilters.test.ts`): schema exposes the params, handler forwards them, omits keys when absent (TDD red→green).
- Full unit suite green: **181 tests**. `npm run build` (biome + tsc) clean.

## Notes

- **No server version bump** (kept `8.0.0`) to avoid churn with in-flight #123. Version to be decided at release time.
- No file overlap with #123 (`fix/compact-schema-name-args` touches `compactSchemas.ts`; this PR touches `handleGetWhereUsed.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)