### PR TITLE
fix(structures): GetStructuresList scopes append where-used to TABL/DS (8.1.1, #128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.1.1] - 2026-06-27
+
+### Fixed
+- **`GetStructuresList` no longer loses append structures on heavily-used objects (#128).** The append (where-used) search now scopes to append structures only (`enableOnlyTypes: ['TABL/DS']`) instead of searching all types: where-used caps the number of returned records, so on a widely-referenced base (e.g. a standard S/4 table) the append records were crowded out by other reference types and dropped, yielding `0` appends. It also resolves the base `object_type` itself (try `structure`, fall back to `table`) so a table base no longer 404s on a structures URI, and it sets `appends_unavailable: true` when the where-used lookup fails for every object_type — so callers can tell "could not determine appends" apart from "no appends" instead of getting a silent `0`.
+
 ## [8.1.0] - 2026-06-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.1.0",
+  "version": "8.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/unit/handleGetStructuresListAppends.test.ts
+++ b/src/__tests__/unit/handleGetStructuresListAppends.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit test (#128): GetStructuresList append (where-used) handling.
+ *  - scopes the search to append structures only (enableOnlyTypes: ['TABL/DS']),
+ *    so a heavily-used base does not lose its appends to the where-used record cap;
+ *  - resolves the base object_type itself (try 'structure', fall back to 'table'),
+ *    since adt-clients does not auto-fallback;
+ *  - does NOT swallow a where-used failure — it flags `appends_unavailable`.
+ * SAP-free via a mocked AdtClient.
+ */
+
+const mockStructRead = jest.fn();
+const mockTableRead = jest.fn();
+const mockWhereUsed = jest.fn();
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getStructure: () => ({ read: mockStructRead }),
+    getTable: () => ({ read: mockTableRead }),
+    getUtils: () => ({ getWhereUsedList: mockWhereUsed }),
+  }),
+}));
+
+import { handleGetStructuresList } from '../../handlers/structure/readonly/handleGetStructuresList';
+
+const ctx = { connection: {}, logger: undefined } as any;
+
+function payload(result: any) {
+  const text =
+    (result.content.find((c: any) => c.type === 'text') as any)?.text || '';
+  return JSON.parse(text);
+}
+
+describe('GetStructuresList append handling (#128)', () => {
+  beforeEach(() => {
+    mockStructRead.mockReset();
+    mockTableRead.mockReset();
+    mockWhereUsed.mockReset();
+    // Root reads as a structure with no embedded includes.
+    mockStructRead.mockResolvedValue({ data: 'define structure zs { }' });
+    mockTableRead.mockResolvedValue(null);
+  });
+
+  it('scopes the append search to TABL/DS and tries object_type "structure" first', async () => {
+    mockWhereUsed.mockResolvedValue({ references: [] });
+
+    const result = await handleGetStructuresList(ctx, { structure_name: 'ZS' });
+
+    expect(result.isError).toBe(false);
+    expect(mockWhereUsed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        object_name: 'ZS',
+        object_type: 'structure',
+        enableOnlyTypes: ['TABL/DS'],
+      }),
+    );
+    expect(payload(result).appends_unavailable).toBeUndefined();
+  });
+
+  it('falls back to object_type "table" when the structure URI 404s', async () => {
+    mockWhereUsed.mockImplementation((p: any) => {
+      if (p.object_type === 'structure') {
+        return Promise.reject(new Error('Request failed with status code 404'));
+      }
+      return Promise.resolve({ references: [] });
+    });
+
+    const result = await handleGetStructuresList(ctx, {
+      structure_name: 'VBAK',
+    });
+
+    expect(result.isError).toBe(false);
+    const types = mockWhereUsed.mock.calls.map((c) => c[0].object_type);
+    expect(types).toEqual(['structure', 'table']);
+    expect(payload(result).appends_unavailable).toBeUndefined();
+  });
+
+  it('flags appends_unavailable when where-used fails for every object_type', async () => {
+    mockWhereUsed.mockRejectedValue(
+      new Error('Request failed with status code 404'),
+    );
+
+    const result = await handleGetStructuresList(ctx, { structure_name: 'ZS' });
+
+    expect(result.isError).toBe(false);
+    const data = payload(result);
+    expect(data.success).toBe(true);
+    expect(data.appends_unavailable).toBe(true);
+  });
+
+  it('does not run where-used (or flag) when include_extensions is false', async () => {
+    const result = await handleGetStructuresList(ctx, {
+      structure_name: 'ZS',
+      include_extensions: false,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockWhereUsed).not.toHaveBeenCalled();
+    expect(payload(result).appends_unavailable).toBeUndefined();
+  });
+});

--- a/src/handlers/structure/readonly/handleGetStructuresList.ts
+++ b/src/handlers/structure/readonly/handleGetStructuresList.ts
@@ -144,6 +144,10 @@ export async function handleGetStructuresList(
   try {
     const { structure_name, version = 'active' } = args;
     const includeExtensions = args.include_extensions !== false;
+    // Set when the append where-used lookup fails for every resolved
+    // object_type, so the response can flag that appends could not be
+    // determined (≠ "no appends"). #128
+    let appendsUnavailable = false;
     if (!structure_name)
       return return_error(new Error('structure_name is required'));
 
@@ -187,24 +191,48 @@ export async function handleGetStructuresList(
      */
     const findExtensions = async (baseName: string): Promise<EmbeddedRef[]> => {
       if (!includeExtensions) return [];
-      // Use getWhereUsedList with enableAllTypes: the DEFAULT where-used scope
-      // leaves some object types unselected, so an extension's type may be
-      // excluded and the search returns nothing useful. enableAllTypes selects
-      // every type, and the result is already parsed into { name, type } refs.
+      // Scope the where-used search to append structures only
+      // (enableOnlyTypes: ['TABL/DS']). where-used caps the number of returned
+      // records, so with the default/all-types scope a heavily-used base has
+      // its append (structure) records crowded out by other reference types and
+      // dropped → 0 appends. Restricting the search to TABL/DS server-side keeps
+      // the appends within the cap. An append is always a structure (TABL/DS),
+      // not a table, so TABL/DS is the only type we need here.
+      //
+      // The base may be defined as a structure OR a table; where-used needs the
+      // matching object_type to build the URI (a structures URI 404s for a table
+      // and vice-versa). adt-clients deliberately does not auto-fallback (it
+      // would hide a wrong object_type), so resolve it here like readDdl does:
+      // try 'structure', fall back to 'table'. (#128, adt-clients #54)
       let references: Array<{ name?: string; type?: string }> = [];
-      try {
-        const wu = await utils.getWhereUsedList({
-          object_name: baseName,
-          object_type: 'structure',
-          enableAllTypes: true,
-        } as any);
-        references = (wu?.references ?? []) as Array<{
-          name?: string;
-          type?: string;
-        }>;
-      } catch (e: any) {
+      let resolved = false;
+      let lastErr: unknown;
+      for (const objectType of ['structure', 'table'] as const) {
+        try {
+          const wu = await utils.getWhereUsedList({
+            object_name: baseName,
+            object_type: objectType,
+            enableOnlyTypes: ['TABL/DS'],
+          } as any);
+          references = (wu?.references ?? []) as Array<{
+            name?: string;
+            type?: string;
+          }>;
+          resolved = true;
+          break;
+        } catch (e) {
+          lastErr = e;
+        }
+      }
+      if (!resolved) {
+        // Do NOT swallow the failure into an empty result — flag the response
+        // as degraded so callers can tell "could not determine appends" apart
+        // from "no appends".
+        appendsUnavailable = true;
         logger?.warn(
-          `where-used failed for ${baseName}: ${e?.message ?? String(e)}`,
+          `where-used failed for ${baseName}: ${
+            (lastErr as any)?.message ?? String(lastErr)
+          }`,
         );
         return [];
       }
@@ -290,6 +318,11 @@ export async function handleGetStructuresList(
         {
           success: true,
           structure_name: rootName,
+          // True when a where-used lookup failed, so appends could not be
+          // determined and the tree may be missing them (≠ "no appends"). #128
+          ...(includeExtensions && appendsUnavailable
+            ? { appends_unavailable: true }
+            : {}),
           tree,
         },
         null,


### PR DESCRIPTION
Closes #128.

## Cause
`GetStructuresList` finds append (extension) structures via where-used. where-used **caps the number of returned records**; with the all-types scope, on a heavily-referenced base (e.g. a standard S/4 table used in many places) the append (structure) records get crowded out by other reference types and dropped — so the tool returned **0 appends** with `success: true`, indistinguishable from "genuinely no appends". (Not an endpoint/404 bug — see adt-clients #54, closed won't-fix.)

## Fix (consumer-level)
- **Scope the append search to append structures only** — `enableOnlyTypes: ['TABL/DS']`. An append is always a structure (`TABL/DS`), so the capped result set now contains only appends and they are no longer crowded out.
- **Resolve the base `object_type` here** — try `structure`, fall back to `table` (mirrors the source-read `readDdl` fallback). adt-clients deliberately does not auto-fallback (it would mask a wrong `object_type`), so a table base no longer 404s on a `/ddic/structures/` URI.
- **Do not swallow failures** — when where-used fails for every resolved `object_type`, the response sets `appends_unavailable: true` so callers can tell "could not determine appends" apart from "no appends".

## Verification
- `npm run build`, `npm run test:check` — green.
- New SAP-free unit test `handleGetStructuresListAppends.test.ts` (4 cases): TABL/DS scope + structure-first, structure→table fallback, degraded flag on total failure, no where-used when `include_extensions: false`.
- Real-system behaviour (VBAK appends) verified by the maintainer.

Patch bump **8.1.0 → 8.1.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)