### PR TITLE
feat: migrate to adt-clients 7.0.1 + object history tools (8.2.0, #30)

### DIFF
--- a/.sdd-report.md
+++ b/.sdd-report.md
@@ -1,0 +1,53 @@
+# Object History tools (#30) — implementation report
+
+## Summary
+Added two read-only MCP tools backed by the adt-clients 7.0.1 per-object
+version API (`IAdtObject.getVersions` / `getVersionSource`):
+
+- **GetObjectVersions** — `object_type` + `object_name` (+ `function_group_name`
+  for `function_module`) → `{ success, object_type, object_name, versions }`
+  where `versions` is `IObjectVersion[]` (each entry carries its opaque
+  `contentUri`).
+- **GetObjectVersionSource** — `object_type` + `content_uri` → `{ success,
+  content_uri, source }`.
+
+## Files added
+- `src/handlers/common/readonly/resolveVersionedObject.ts` — shared
+  object_type → IAdtObject resolver + config, plus `VERSIONED_OBJECT_TYPES`.
+  Mirrors handleLockObject's switch exactly (same getX() accessors, same config
+  name keys).
+- `src/handlers/common/readonly/handleGetObjectVersions.ts`
+- `src/handlers/common/readonly/handleGetObjectVersionSource.ts`
+- `src/__tests__/unit/handleObjectVersions.test.ts` — SAP-free, mocks
+  `../../lib/clients` createAdtClient.
+
+## Files changed
+- `src/lib/handlers/groups/ReadOnlyHandlersGroup.ts` — imported + registered
+  both tools (mirroring GetStructuresList).
+- `docs/user-guide/AVAILABLE_TOOLS*.md` — regenerated via `npm run docs:tools`.
+
+## Supported object_type set (13, identical to LockObject)
+class, program, interface, function_group, function_module, table, structure,
+ddl, domain, data_element, package, behavior_definition, metadata_extension.
+
+`function_module` identity needs the owning group: passed via
+`function_group_name` or `GROUP|FM_NAME` (same as LockObject). No object_type
+from the LockObject switch was dropped; all 13 mapped. Unknown/unsupported
+object_type → clear error; `AdtOperationError(UNSUPPORTED_OPERATION)` from the
+client is turned into a clear "version history not supported" message (no raw
+HTTP leaked).
+
+## Gate output
+- `npm run build` — exit 0 (biome + tsc).
+- `npm run test:check` — exit 0 (tsc --noEmit on test project).
+- `npx jest handleObjectVersions` — 4 passed / 4.
+- `npm run docs:tools` — regenerated; both tools present in
+  `docs/user-guide/AVAILABLE_TOOLS_READONLY.md`, `AVAILABLE_TOOLS_LEGACY.md`,
+  `AVAILABLE_TOOLS.md`.
+
+## Concerns
+- `available_in: ['onprem','cloud','legacy']` set for both tools (registers in
+  hard mode); not yet exercised against a live SAP system — version retrieval
+  per object_type is unverified on a real backend.
+- `GetObjectVersionSource` only needs the IAdtObject instance (the content_uri
+  carries full identity), so it resolves with a placeholder name `'X'`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [8.2.0] - 2026-06-28
+
+### Added
+- **Object history tools (#30).** Two read-only tools backed by `@mcp-abap-adt/adt-clients` 7.0.0's version-history API: `GetObjectVersions` (lists an object's SAP version history — `versionId`, `author`, `updatedAt`, `title`, and an opaque `contentUri` per entry) and `GetObjectVersionSource` (fetches the source of a specific version by its `contentUri`). Both dispatch by `object_type` across the same 13 object types as the generic object tools (class, program, interface, function_group, function_module, table, structure, ddl, domain, data_element, package, behavior_definition, metadata_extension); object types without a version endpoint return a clear `UNSUPPORTED_OPERATION` error rather than raw HTTP.
+
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^7.0.1` and `@mcp-abap-adt/interfaces@^9.0.0`** (from `^6.1.0` / `^7.2.0`). 7.0.1 also makes where-used resilient on S/4 systems whose `/usageReferences/scope` sub-resource returns 404 — the library now falls back to an unscoped search with client-side type narrowing, hardening the append detection in `GetStructuresList` (#128) at the library level. No mcp-abap-adt tool contract changed by the migration.
+
 ## [8.1.1] - 2026-06-27
 
 ### Fixed

--- a/docs/user-guide/AVAILABLE_TOOLS.md
+++ b/docs/user-guide/AVAILABLE_TOOLS.md
@@ -4,8 +4,8 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ## Summary
 
-- Total tools: 313
-- Read-only tools: 59
+- Total tools: 315
+- Read-only tools: 61
 - High-level tools: 130
 - Low-level tools: 124
 
@@ -28,6 +28,9 @@ Generated from code in `src/handlers/**` (not from docs).
     - [ReadBehaviorImplementation](#readbehaviorimplementation-read-only-behavior-implementation)
   - [Class](#read-only-class)
     - [ReadClass](#readclass-read-only-class)
+  - [Common](#read-only-common)
+    - [GetObjectVersions](#getobjectversions-read-only-common)
+    - [GetObjectVersionSource](#getobjectversionsource-read-only-common)
   - [Data Element](#read-only-data-element)
     - [ReadDataElement](#readdataelement-read-only-data-element)
   - [Ddl](#read-only-ddl)
@@ -449,6 +452,34 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `class_name` (string, required) - Class name (e.g., ZCL_MY_CLASS).
 - `version` (string, optional (default: active)) - Version to read: "active" (default) or "inactive".
+
+---
+
+<a id="read-only-common"></a>
+### Read-Only / Common
+
+<a id="getobjectversions-read-only-common"></a>
+#### GetObjectVersions (Read-Only / Common)
+**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version source via GetObjectVersionSource.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersions.ts`
+
+**Parameters:**
+- `function_group_name` (string, optional) - Owning function group name. Required when object_type is function_module.
+- `object_name` (string, required) - Object name (e.g., ZCL_MY_CLASS, ZIF_MY_INTERFACE, Z_MY_TABLE).
+- `object_type` (string, required) - Object type.
+
+---
+
+<a id="getobjectversionsource-read-only-common"></a>
+#### GetObjectVersionSource (Read-Only / Common)
+**Description:** [read-only] Fetch the source code of a specific object version. Pass the opaque content_uri from a GetObjectVersions entry.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersionSource.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetObjectVersions version entry.
+- `object_type` (string, required) - Object type (same value used in GetObjectVersions).
 
 ---
 
@@ -1298,6 +1329,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `activate` (boolean, optional) - Activate after creation. Default: true
 - `description` (string, optional) - Description
 - `implementation_type` (string, required) - Implementation type: 'Managed', 'Unmanaged', 'Abstract', 'Projection'
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `name` (string, required) - Behavior Definition name (usually same as Root Entity name)
 - `package_name` (string, required) - Package name
 - `root_entity` (string, required) - Root Entity name (CDS View name)
@@ -1429,6 +1461,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `create_protected` (boolean, optional) - Protected constructor. Default: false
 - `description` (string, optional) - Class description (defaults to class_name).
 - `final` (boolean, optional) - Mark class as final. Default: false
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP).
 - `superclass` (string, optional) - Optional superclass name.
 - `transport_request` (string, optional) - Transport request number (required for transportable packages).
@@ -2117,6 +2150,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `heading_label` (string, optional) - Heading field label (max 55 chars). Applied during update step after creation.
 - `length` (number, optional (default: 100)) - Data type length. Usually inherited from domain.
 - `long_label` (string, optional) - Long field label (max 40 chars). Applied during update step after creation.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `medium_label` (string, optional) - Medium field label (max 20 chars). Applied during update step after creation.
 - `package_name` (string, required) - Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `search_help` (string, optional) - Search help name. Applied during update step after creation.
@@ -2205,6 +2239,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `ddl_name` (string, required) - DDL source name (e.g., ZOK_R_TEST_0002, Z_I_MY_VIEW).
 - `description` (string, optional) - Optional description (defaults to ddl_name).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (required for transportable packages).
 
@@ -2271,6 +2306,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `activate` (boolean, optional) - Activate after creation. Default: true
 - `description` (string, optional) - Description
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `name` (string, required) - Metadata Extension name
 - `package_name` (string, required) - Package name
 - `transport_request` (string, optional) - Transport request number
@@ -2322,6 +2358,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `fixed_values` (array, optional) - (optional) Array of fixed values for domain value range
 - `length` (number, optional (default: 100)) - (optional) Field length (max depends on datatype)
 - `lowercase` (boolean, optional (default: false)) - (optional) Allow lowercase input
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, optional) - (optional) Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `sign_exists` (boolean, optional (default: false)) - (optional) Field has sign (+/-)
 - `transport_request` (string, optional) - (optional) Transport request number (e.g., E19K905635). Required for transportable packages.
@@ -2413,6 +2450,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `activate` (boolean, optional) - Activate function group after creation. Default: true. Set to false for batch operations.
 - `description` (string, optional) - Function group description. If not provided, function_group_name will be used.
 - `function_group_name` (string, required) - Function group name (e.g., ZTEST_FG_001). Must follow SAP naming conventions (start with Z or Y, max 26 chars).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
 
@@ -2584,6 +2622,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `description` (string, optional) - Interface description. If not provided, interface_name will be used.
 - `interface_name` (string, required) - Interface name (e.g., ZIF_TEST_INTERFACE_001). Must follow SAP naming conventions (start with Z or Y).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
 
@@ -2715,6 +2754,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `application` (string, optional) - Application area (e.g., 'S' for System, 'M' for Materials Management). Default: '*'
 - `description` (string, optional) - Program description. If not provided, program_name will be used.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `program_name` (string, required) - Program name (e.g., Z_TEST_PROGRAM_001). Must follow SAP naming conventions (start with Z or Y).
 - `program_type` (string, optional) - Program type: 'executable' (Report), 'include', 'module_pool', 'function_group', 'class_pool', 'interface_pool'. Default: 'executable'
@@ -2773,6 +2813,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `activate` (boolean, optional (default: true)) - Activate service binding after create. Default: true.
 - `binding_variant` (string, optional (default: ODATA_V4_UI)) - Service binding variant. ODATA_V4_UI = OData V4 for Fiori Elements, ODATA_V4_WEB_API = OData V4 Web API, ODATA_V2_UI = OData V2 for Fiori Elements, ODATA_V2_WEB_API = OData V2 Web API.
 - `description` (string, optional) - Optional description. Defaults to service_binding_name when omitted.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - ABAP package name.
 - `response_format` (string, optional (default: xml)) - 
 - `service_binding_name` (string, required) - Service binding name.
@@ -2862,6 +2903,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `activate` (boolean, optional) - Activate service definition after creation. Default: true.
 - `description` (string, optional) - Service definition description. If not provided, service_definition_name will be used.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `service_definition_name` (string, required) - Service definition name (e.g., ZSD_MY_SERVICE). Must follow SAP naming conventions (start with Z or Y).
 - `source_code` (string, optional) - Service definition source code (optional). If not provided, a minimal template will be created.
@@ -2934,6 +2976,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `description` (string, optional) - Structure description. If not provided, structure_name will be used.
 - `fields` (array, required (default: 0)) - Array of structure fields
 - `includes` (array, optional) - Include other structures in this structure
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `structure_name` (string, required) - Structure name (e.g., ZZ_S_TEST_001). Must follow SAP naming conventions.
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
@@ -3020,6 +3063,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `description` (string, optional) - Table description for validation and creation.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `table_name` (string, required) - Table name (e.g., ZZ_TEST_TABLE_001). Must follow SAP naming conventions.
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
@@ -5088,4 +5132,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-26*
+*Last updated: 2026-06-28*

--- a/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
@@ -596,4 +596,4 @@ Preferred dedicated compact tools and minimal payloads:
 
 ---
 
-*Last updated: 2026-06-26*
+*Last updated: 2026-06-28*

--- a/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
@@ -192,6 +192,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `activate` (boolean, optional) - Activate after creation. Default: true
 - `description` (string, optional) - Description
 - `implementation_type` (string, required) - Implementation type: 'Managed', 'Unmanaged', 'Abstract', 'Projection'
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `name` (string, required) - Behavior Definition name (usually same as Root Entity name)
 - `package_name` (string, required) - Package name
 - `root_entity` (string, required) - Root Entity name (CDS View name)
@@ -323,6 +324,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `create_protected` (boolean, optional) - Protected constructor. Default: false
 - `description` (string, optional) - Class description (defaults to class_name).
 - `final` (boolean, optional) - Mark class as final. Default: false
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP).
 - `superclass` (string, optional) - Optional superclass name.
 - `transport_request` (string, optional) - Transport request number (required for transportable packages).
@@ -1011,6 +1013,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `heading_label` (string, optional) - Heading field label (max 55 chars). Applied during update step after creation.
 - `length` (number, optional (default: 100)) - Data type length. Usually inherited from domain.
 - `long_label` (string, optional) - Long field label (max 40 chars). Applied during update step after creation.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `medium_label` (string, optional) - Medium field label (max 20 chars). Applied during update step after creation.
 - `package_name` (string, required) - Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `search_help` (string, optional) - Search help name. Applied during update step after creation.
@@ -1099,6 +1102,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `ddl_name` (string, required) - DDL source name (e.g., ZOK_R_TEST_0002, Z_I_MY_VIEW).
 - `description` (string, optional) - Optional description (defaults to ddl_name).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (required for transportable packages).
 
@@ -1165,6 +1169,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `activate` (boolean, optional) - Activate after creation. Default: true
 - `description` (string, optional) - Description
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `name` (string, required) - Metadata Extension name
 - `package_name` (string, required) - Package name
 - `transport_request` (string, optional) - Transport request number
@@ -1216,6 +1221,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `fixed_values` (array, optional) - (optional) Array of fixed values for domain value range
 - `length` (number, optional (default: 100)) - (optional) Field length (max depends on datatype)
 - `lowercase` (boolean, optional (default: false)) - (optional) Allow lowercase input
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, optional) - (optional) Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `sign_exists` (boolean, optional (default: false)) - (optional) Field has sign (+/-)
 - `transport_request` (string, optional) - (optional) Transport request number (e.g., E19K905635). Required for transportable packages.
@@ -1307,6 +1313,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `activate` (boolean, optional) - Activate function group after creation. Default: true. Set to false for batch operations.
 - `description` (string, optional) - Function group description. If not provided, function_group_name will be used.
 - `function_group_name` (string, required) - Function group name (e.g., ZTEST_FG_001). Must follow SAP naming conventions (start with Z or Y, max 26 chars).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
 
@@ -1478,6 +1485,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `description` (string, optional) - Interface description. If not provided, interface_name will be used.
 - `interface_name` (string, required) - Interface name (e.g., ZIF_TEST_INTERFACE_001). Must follow SAP naming conventions (start with Z or Y).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
 
@@ -1609,6 +1617,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `application` (string, optional) - Application area (e.g., 'S' for System, 'M' for Materials Management). Default: '*'
 - `description` (string, optional) - Program description. If not provided, program_name will be used.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `program_name` (string, required) - Program name (e.g., Z_TEST_PROGRAM_001). Must follow SAP naming conventions (start with Z or Y).
 - `program_type` (string, optional) - Program type: 'executable' (Report), 'include', 'module_pool', 'function_group', 'class_pool', 'interface_pool'. Default: 'executable'
@@ -1667,6 +1676,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `activate` (boolean, optional (default: true)) - Activate service binding after create. Default: true.
 - `binding_variant` (string, optional (default: ODATA_V4_UI)) - Service binding variant. ODATA_V4_UI = OData V4 for Fiori Elements, ODATA_V4_WEB_API = OData V4 Web API, ODATA_V2_UI = OData V2 for Fiori Elements, ODATA_V2_WEB_API = OData V2 Web API.
 - `description` (string, optional) - Optional description. Defaults to service_binding_name when omitted.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - ABAP package name.
 - `response_format` (string, optional (default: xml)) - 
 - `service_binding_name` (string, required) - Service binding name.
@@ -1756,6 +1766,7 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `activate` (boolean, optional) - Activate service definition after creation. Default: true.
 - `description` (string, optional) - Service definition description. If not provided, service_definition_name will be used.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `service_definition_name` (string, required) - Service definition name (e.g., ZSD_MY_SERVICE). Must follow SAP naming conventions (start with Z or Y).
 - `source_code` (string, optional) - Service definition source code (optional). If not provided, a minimal template will be created.
@@ -1828,6 +1839,7 @@ Generated from code in `src/handlers/**` (not from docs).
 - `description` (string, optional) - Structure description. If not provided, structure_name will be used.
 - `fields` (array, required (default: 0)) - Array of structure fields
 - `includes` (array, optional) - Include other structures in this structure
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `structure_name` (string, required) - Structure name (e.g., ZZ_S_TEST_001). Must follow SAP naming conventions.
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
@@ -1914,6 +1926,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `description` (string, optional) - Table description for validation and creation.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LOCAL, $TMP for local objects)
 - `table_name` (string, required) - Table name (e.g., ZZ_TEST_TABLE_001). Must follow SAP naming conventions.
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
@@ -2144,4 +2157,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-26*
+*Last updated: 2026-06-28*

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -5,8 +5,8 @@ Generated from code in `src/handlers/**` (not from docs).
 Tools available on legacy SAP systems (BASIS < 7.50).
 Legacy systems support a subset of tools — primarily Class, Interface, View, Program, Function Group/Module, Package (read/update/delete), Include, Unit Test, and common utilities.
 
-- Total tools: 141
-- Read-Only: 15
+- Total tools: 143
+- Read-Only: 17
 - High-Level: 65
 - Low-Level: 61
 
@@ -15,6 +15,9 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 - [Read-Only Group](#read-only-group)
   - [Class](#read-only-class)
     - [ReadClass](#readclass-read-only-class)
+  - [Common](#read-only-common)
+    - [GetObjectVersions](#getobjectversions-read-only-common)
+    - [GetObjectVersionSource](#getobjectversionsource-read-only-common)
   - [Ddl](#read-only-ddl)
     - [ReadDdl](#readddl-read-only-ddl)
   - [Function Group](#read-only-function-group)
@@ -206,6 +209,38 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 **Parameters:**
 - `class_name` (string, required) - Class name (e.g., ZCL_MY_CLASS).
 - `version` (string, optional (default: active)) - Version to read: "active" (default) or "inactive".
+
+---
+
+<a id="read-only-common"></a>
+### Read-Only / Common
+
+<a id="getobjectversions-read-only-common"></a>
+#### GetObjectVersions (Read-Only / Common)
+**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version source via GetObjectVersionSource.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersions.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `function_group_name` (string, optional) - Owning function group name. Required when object_type is function_module.
+- `object_name` (string, required) - Object name (e.g., ZCL_MY_CLASS, ZIF_MY_INTERFACE, Z_MY_TABLE).
+- `object_type` (string, required) - Object type.
+
+---
+
+<a id="getobjectversionsource-read-only-common"></a>
+#### GetObjectVersionSource (Read-Only / Common)
+**Description:** [read-only] Fetch the source code of a specific object version. Pass the opaque content_uri from a GetObjectVersions entry.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersionSource.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetObjectVersions version entry.
+- `object_type` (string, required) - Object type (same value used in GetObjectVersions).
 
 ---
 
@@ -471,6 +506,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 - `create_protected` (boolean, optional) - Protected constructor. Default: false
 - `description` (string, optional) - Class description (defaults to class_name).
 - `final` (boolean, optional) - Mark class as final. Default: false
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP).
 - `superclass` (string, optional) - Optional superclass name.
 - `transport_request` (string, optional) - Transport request number (required for transportable packages).
@@ -910,6 +946,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 **Parameters:**
 - `ddl_name` (string, required) - DDL source name (e.g., ZOK_R_TEST_0002, Z_I_MY_VIEW).
 - `description` (string, optional) - Optional description (defaults to ddl_name).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (required for transportable packages).
 
@@ -1002,6 +1039,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 - `activate` (boolean, optional) - Activate function group after creation. Default: true. Set to false for batch operations.
 - `description` (string, optional) - Function group description. If not provided, function_group_name will be used.
 - `function_group_name` (string, required) - Function group name (e.g., ZTEST_FG_001). Must follow SAP naming conventions (start with Z or Y, max 26 chars).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
 
@@ -1197,6 +1235,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 **Parameters:**
 - `description` (string, optional) - Interface description. If not provided, interface_name will be used.
 - `interface_name` (string, required) - Interface name (e.g., ZIF_TEST_INTERFACE_001). Must follow SAP naming conventions (start with Z or Y).
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable packages.
 
@@ -1304,6 +1343,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 **Parameters:**
 - `application` (string, optional) - Application area (e.g., 'S' for System, 'M' for Materials Management). Default: '*'
 - `description` (string, optional) - Program description. If not provided, program_name will be used.
+- `master_language` (string, optional) - Optional master/original language for the created object (e.g. "EN", "DE", "ZH"). Defaults to the session language (SAP_LANGUAGE) or EN.
 - `package_name` (string, required) - Package name (e.g., ZOK_LAB, $TMP for local objects)
 - `program_name` (string, required) - Program name (e.g., Z_TEST_PROGRAM_001). Must follow SAP naming conventions (start with Z or Y).
 - `program_type` (string, optional) - Program type: 'executable' (Report), 'include', 'module_pool', 'function_group', 'class_pool', 'interface_pool'. Default: 'executable'
@@ -2564,4 +2604,4 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
-*Last updated: 2026-06-26*
+*Last updated: 2026-06-28*

--- a/docs/user-guide/AVAILABLE_TOOLS_LOW.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LOW.md
@@ -1991,4 +1991,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-26*
+*Last updated: 2026-06-28*

--- a/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
@@ -3,7 +3,7 @@
 Generated from code in `src/handlers/**` (not from docs).
 
 - Level: Read-Only
-- Total tools: 59
+- Total tools: 61
 
 ## Navigation
 
@@ -14,6 +14,9 @@ Generated from code in `src/handlers/**` (not from docs).
     - [ReadBehaviorImplementation](#readbehaviorimplementation-read-only-behavior-implementation)
   - [Class](#read-only-class)
     - [ReadClass](#readclass-read-only-class)
+  - [Common](#read-only-common)
+    - [GetObjectVersions](#getobjectversions-read-only-common)
+    - [GetObjectVersionSource](#getobjectversionsource-read-only-common)
   - [Data Element](#read-only-data-element)
     - [ReadDataElement](#readdataelement-read-only-data-element)
   - [Ddl](#read-only-ddl)
@@ -137,6 +140,34 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `class_name` (string, required) - Class name (e.g., ZCL_MY_CLASS).
 - `version` (string, optional (default: active)) - Version to read: "active" (default) or "inactive".
+
+---
+
+<a id="read-only-common"></a>
+### Read-Only / Common
+
+<a id="getobjectversions-read-only-common"></a>
+#### GetObjectVersions (Read-Only / Common)
+**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version source via GetObjectVersionSource.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersions.ts`
+
+**Parameters:**
+- `function_group_name` (string, optional) - Owning function group name. Required when object_type is function_module.
+- `object_name` (string, required) - Object name (e.g., ZCL_MY_CLASS, ZIF_MY_INTERFACE, Z_MY_TABLE).
+- `object_type` (string, required) - Object type.
+
+---
+
+<a id="getobjectversionsource-read-only-common"></a>
+#### GetObjectVersionSource (Read-Only / Common)
+**Description:** [read-only] Fetch the source code of a specific object version. Pass the opaque content_uri from a GetObjectVersions entry.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersionSource.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetObjectVersions version entry.
+- `object_type` (string, required) - Object type (same value used in GetObjectVersions).
 
 ---
 
@@ -959,4 +990,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-26*
+*Last updated: 2026-06-28*

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^6.1.0",
+        "@mcp-abap-adt/adt-clients": "^7.0.1",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
         "@mcp-abap-adt/connection": "^1.9.1",
         "@mcp-abap-adt/header-validator": "^0.1.8",
-        "@mcp-abap-adt/interfaces": "^7.2.0",
+        "@mcp-abap-adt/interfaces": "^9.0.0",
         "@mcp-abap-adt/logger": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.14.0",
@@ -225,26 +225,17 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-6.1.0.tgz",
-      "integrity": "sha512-F4xqH3eyLljAfVWjHThpr/xpRBN3yJoolwjulCYoOw7hWooaqMxvkPR0uvZS107FF8wuxY41zi9kwDiJaEjUQw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.0.1.tgz",
+      "integrity": "sha512-Or3HSbeGVT/kYaOWKnJioh0XdZ9KYAQAOM+Ui5H/INqsIjtiKUpfhiEpKqNxLVPWNXNRiLdLLs+yEx1jDlu54A==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^7.3.0",
+        "@mcp-abap-adt/interfaces": "^9.0.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.13.6",
         "fast-xml-parser": "^5.4.1",
         "yaml": "^2.3.4"
       },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@mcp-abap-adt/adt-clients/node_modules/@mcp-abap-adt/interfaces": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-7.3.0.tgz",
-      "integrity": "sha512-9Q7L/min183Zq/0WUoHXyzB4QzeYMoizYsyDlechk9CoAq8VGJ7AYxh/EUQIS8y6lPpugtAK9McKgolImnefVA==",
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -350,6 +341,15 @@
       "optionalDependencies": {
         "@mcp-abap-adt/sap-rfc-lite": "^0.1.0",
         "kerberos": "^2.1.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/@mcp-abap-adt/interfaces": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-7.3.0.tgz",
+      "integrity": "sha512-9Q7L/min183Zq/0WUoHXyzB4QzeYMoizYsyDlechk9CoAq8VGJ7AYxh/EUQIS8y6lPpugtAK9McKgolImnefVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@mcp-abap-adt/connection/node_modules/kerberos": {
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-7.2.0.tgz",
-      "integrity": "sha512-FRseCM93MQVY0khjaw7yRhrNnqjdpmQG89i+p4ActsfzhV8hKFKhC/3vWyhgr4DsBTCcRQr05zDoBlNU00hLgQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.0.0.tgz",
+      "integrity": "sha512-jXRdXIMFnXfkK8mTARUEc7HMiQezesnGo9PxKMtF/mc98PdsPCYMxGEJXXrnyRLqErelfElJx3E6b1JhWs7rpA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.1.1",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -137,13 +137,13 @@
     "yaml": "^2.8.1"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^6.1.0",
+    "@mcp-abap-adt/adt-clients": "^7.0.1",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",
     "@mcp-abap-adt/connection": "^1.9.1",
     "@mcp-abap-adt/header-validator": "^0.1.8",
-    "@mcp-abap-adt/interfaces": "^7.2.0",
+    "@mcp-abap-adt/interfaces": "^9.0.0",
     "@mcp-abap-adt/logger": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.1.1",
+  "version": "8.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.1.1",
+      "version": "8.2.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/unit/handleObjectVersions.test.ts
+++ b/src/__tests__/unit/handleObjectVersions.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests (#30): GetObjectVersions + GetObjectVersionSource.
+ *  - GetObjectVersions dispatches to the right client accessor per object_type
+ *    and returns the version list;
+ *  - GetObjectVersionSource forwards content_uri to getVersionSource;
+ *  - an unknown object_type returns an error.
+ * SAP-free via a mocked AdtClient.
+ */
+
+const mockClassGetVersions = jest.fn();
+const mockClassGetVersionSource = jest.fn();
+const mockTableGetVersions = jest.fn();
+const mockGetClass = jest.fn();
+const mockGetTable = jest.fn();
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getClass: mockGetClass,
+    getTable: mockGetTable,
+  }),
+}));
+
+import { handleGetObjectVersionSource } from '../../handlers/common/readonly/handleGetObjectVersionSource';
+import { handleGetObjectVersions } from '../../handlers/common/readonly/handleGetObjectVersions';
+
+const ctx = { connection: {}, logger: undefined } as any;
+
+function payload(result: any) {
+  const text =
+    (result.content.find((c: any) => c.type === 'text') as any)?.text || '';
+  return JSON.parse(text);
+}
+
+describe('GetObjectVersions / GetObjectVersionSource (#30)', () => {
+  beforeEach(() => {
+    mockClassGetVersions.mockReset();
+    mockClassGetVersionSource.mockReset();
+    mockTableGetVersions.mockReset();
+    mockGetClass.mockReset();
+    mockGetTable.mockReset();
+    mockGetClass.mockReturnValue({
+      getVersions: mockClassGetVersions,
+      getVersionSource: mockClassGetVersionSource,
+    });
+    mockGetTable.mockReturnValue({
+      getVersions: mockTableGetVersions,
+      getVersionSource: jest.fn(),
+    });
+  });
+
+  it('dispatches a class to getClass().getVersions with className', async () => {
+    const versions = [
+      {
+        versionId: '00001',
+        author: 'DEV',
+        updatedAt: '2026-01-01T00:00:00Z',
+        title: 'Version List',
+        contentUri: '/sap/bc/adt/...;version=00001',
+      },
+    ];
+    mockClassGetVersions.mockResolvedValue(versions);
+
+    const result = await handleGetObjectVersions(ctx, {
+      object_type: 'class',
+      object_name: 'zcl_my_class',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockGetClass).toHaveBeenCalled();
+    expect(mockClassGetVersions).toHaveBeenCalledWith({
+      className: 'ZCL_MY_CLASS',
+    });
+    const data = payload(result);
+    expect(data.success).toBe(true);
+    expect(data.object_type).toBe('class');
+    expect(data.object_name).toBe('ZCL_MY_CLASS');
+    expect(data.versions).toEqual(versions);
+  });
+
+  it('dispatches a table to getTable().getVersions with tableName', async () => {
+    mockTableGetVersions.mockResolvedValue([]);
+
+    const result = await handleGetObjectVersions(ctx, {
+      object_type: 'table',
+      object_name: 'zmy_table',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockGetTable).toHaveBeenCalled();
+    expect(mockTableGetVersions).toHaveBeenCalledWith({
+      tableName: 'ZMY_TABLE',
+    });
+    expect(payload(result).versions).toEqual([]);
+  });
+
+  it('forwards content_uri to getVersionSource', async () => {
+    mockClassGetVersionSource.mockResolvedValue('CLASS zcl_x DEFINITION.');
+
+    const result = await handleGetObjectVersionSource(ctx, {
+      object_type: 'class',
+      content_uri: '/sap/bc/adt/oo/classes/zcl_x/source/main?version=00001',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockClassGetVersionSource).toHaveBeenCalledWith(
+      '/sap/bc/adt/oo/classes/zcl_x/source/main?version=00001',
+    );
+    const data = payload(result);
+    expect(data.success).toBe(true);
+    expect(data.source).toBe('CLASS zcl_x DEFINITION.');
+  });
+
+  it('returns an error for an unknown object_type', async () => {
+    const result = await handleGetObjectVersions(ctx, {
+      object_type: 'nonsense',
+      object_name: 'X',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockClassGetVersions).not.toHaveBeenCalled();
+  });
+});

--- a/src/handlers/common/readonly/handleGetObjectVersionSource.ts
+++ b/src/handlers/common/readonly/handleGetObjectVersionSource.ts
@@ -1,0 +1,102 @@
+/**
+ * GetObjectVersionSource Handler - read-only fetch of one version's source.
+ *
+ * Takes an opaque content_uri from a GetObjectVersions entry plus the
+ * object_type (needed to obtain an IAdtObject instance) and calls
+ * getVersionSource(content_uri). Closes #30.
+ */
+
+import { AdtObjectErrorCodes } from '@mcp-abap-adt/interfaces';
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+import {
+  resolveVersionedObject,
+  VERSIONED_OBJECT_TYPES,
+} from './resolveVersionedObject';
+
+export const TOOL_DEFINITION = {
+  name: 'GetObjectVersionSource',
+  available_in: ['onprem', 'cloud', 'legacy'] as const,
+  description:
+    '[read-only] Fetch the source code of a specific object version. Pass the opaque content_uri from a GetObjectVersions entry.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      object_type: {
+        type: 'string',
+        description: 'Object type (same value used in GetObjectVersions).',
+        enum: [...VERSIONED_OBJECT_TYPES],
+      },
+      content_uri: {
+        type: 'string',
+        description:
+          'Opaque content_uri taken from a GetObjectVersions version entry.',
+      },
+    },
+    required: ['object_type', 'content_uri'],
+  },
+} as const;
+
+interface GetObjectVersionSourceArgs {
+  object_type: string;
+  content_uri: string;
+}
+
+export async function handleGetObjectVersionSource(
+  context: HandlerContext,
+  args: GetObjectVersionSourceArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const { content_uri } = args;
+    const object_type = (args.object_type || '').toLowerCase();
+
+    if (!object_type || !content_uri) {
+      return return_error(
+        new Error('object_type and content_uri are required'),
+      );
+    }
+    if (!VERSIONED_OBJECT_TYPES.includes(object_type as any)) {
+      return return_error(
+        new Error(
+          `Invalid object_type. Must be one of: ${VERSIONED_OBJECT_TYPES.join(', ')}`,
+        ),
+      );
+    }
+
+    const client = createAdtClient(connection, logger);
+    // content_uri carries the full object identity; a placeholder name is only
+    // needed to obtain the right IAdtObject instance.
+    const resolved = resolveVersionedObject(client, object_type, 'X', 'X');
+    if (!resolved) {
+      return return_error(
+        new Error(`Unsupported object_type: ${args.object_type}`),
+      );
+    }
+
+    try {
+      const source = await resolved.obj.getVersionSource(content_uri);
+      return return_response({
+        data: JSON.stringify({ success: true, content_uri, source }, null, 2),
+      } as AxiosResponse);
+    } catch (error: any) {
+      if (error?.code === AdtObjectErrorCodes.UNSUPPORTED_OPERATION) {
+        return return_error(
+          new Error(
+            `Version source is not supported for object_type '${object_type}'.`,
+          ),
+        );
+      }
+      return return_error(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/common/readonly/handleGetObjectVersions.ts
+++ b/src/handlers/common/readonly/handleGetObjectVersions.ts
@@ -1,0 +1,125 @@
+/**
+ * GetObjectVersions Handler - read-only version history of an ABAP object.
+ *
+ * Dispatches on object_type to the matching adt-clients IAdtObject and calls
+ * getVersions(config). Returns the IObjectVersion[] (each entry carries its
+ * opaque contentUri, to be passed to GetObjectVersionSource). Closes #30.
+ */
+
+import { AdtObjectErrorCodes } from '@mcp-abap-adt/interfaces';
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+import {
+  resolveVersionedObject,
+  VERSIONED_OBJECT_TYPES,
+} from './resolveVersionedObject';
+
+export const TOOL_DEFINITION = {
+  name: 'GetObjectVersions',
+  available_in: ['onprem', 'cloud', 'legacy'] as const,
+  description:
+    '[read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version source via GetObjectVersionSource.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      object_type: {
+        type: 'string',
+        description: 'Object type.',
+        enum: [...VERSIONED_OBJECT_TYPES],
+      },
+      object_name: {
+        type: 'string',
+        description:
+          'Object name (e.g., ZCL_MY_CLASS, ZIF_MY_INTERFACE, Z_MY_TABLE).',
+      },
+      function_group_name: {
+        type: 'string',
+        description:
+          'Owning function group name. Required when object_type is function_module.',
+      },
+    },
+    required: ['object_type', 'object_name'],
+  },
+} as const;
+
+interface GetObjectVersionsArgs {
+  object_type: string;
+  object_name: string;
+  function_group_name?: string;
+}
+
+export async function handleGetObjectVersions(
+  context: HandlerContext,
+  args: GetObjectVersionsArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const { object_name, function_group_name } = args;
+    const object_type = (args.object_type || '').toLowerCase();
+
+    if (!object_type || !object_name) {
+      return return_error(
+        new Error('object_type and object_name are required'),
+      );
+    }
+    if (!VERSIONED_OBJECT_TYPES.includes(object_type as any)) {
+      return return_error(
+        new Error(
+          `Invalid object_type. Must be one of: ${VERSIONED_OBJECT_TYPES.join(', ')}`,
+        ),
+      );
+    }
+
+    const client = createAdtClient(connection, logger);
+    let resolved: ReturnType<typeof resolveVersionedObject>;
+    try {
+      resolved = resolveVersionedObject(
+        client,
+        object_type,
+        object_name,
+        function_group_name,
+      );
+    } catch (e: any) {
+      return return_error(e instanceof Error ? e : new Error(String(e)));
+    }
+    if (!resolved) {
+      return return_error(
+        new Error(`Unsupported object_type: ${args.object_type}`),
+      );
+    }
+
+    try {
+      const versions = await resolved.obj.getVersions(resolved.config);
+      return return_response({
+        data: JSON.stringify(
+          {
+            success: true,
+            object_type,
+            object_name: object_name.toUpperCase(),
+            versions,
+          },
+          null,
+          2,
+        ),
+      } as AxiosResponse);
+    } catch (error: any) {
+      if (error?.code === AdtObjectErrorCodes.UNSUPPORTED_OPERATION) {
+        return return_error(
+          new Error(
+            `Version history is not supported for object_type '${object_type}' (${object_name}).`,
+          ),
+        );
+      }
+      return return_error(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/common/readonly/resolveVersionedObject.ts
+++ b/src/handlers/common/readonly/resolveVersionedObject.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared object_type → IAdtObject resolver for the read-only version-history
+ * handlers (GetObjectVersions / GetObjectVersionSource).
+ *
+ * Mirrors the switch in handleLockObject EXACTLY: the SAME object_type values,
+ * the SAME client.getX() accessors, and the SAME config name keys. Instead of
+ * calling .lock(...), callers use the returned IAdtObject to call
+ * .getVersions(config) / .getVersionSource(contentUri).
+ */
+
+import type { AdtClient } from '@mcp-abap-adt/adt-clients';
+import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+
+/** object_type values supported for version history (same set as LockObject). */
+export const VERSIONED_OBJECT_TYPES = [
+  'class',
+  'program',
+  'interface',
+  'function_group',
+  'function_module',
+  'table',
+  'structure',
+  'ddl',
+  'domain',
+  'data_element',
+  'package',
+  'behavior_definition',
+  'metadata_extension',
+] as const;
+
+export interface ResolvedVersionedObject {
+  /** The IAdtObject instance to call getVersions/getVersionSource on. */
+  obj: IAdtObject<any, any>;
+  /** Identity config to pass to getVersions(config). */
+  config: Record<string, unknown>;
+}
+
+/**
+ * Resolve an object_type + name into an IAdtObject instance and its identity
+ * config. Returns null for an unknown object_type (caller emits the error).
+ *
+ * @throws Error for a malformed function_module identity (missing group name).
+ */
+export function resolveVersionedObject(
+  client: AdtClient,
+  objectType: string,
+  objectName: string,
+  functionGroupName?: string,
+): ResolvedVersionedObject | null {
+  const name = objectName.toUpperCase();
+  switch (objectType) {
+    case 'class':
+      return { obj: client.getClass(), config: { className: name } };
+    case 'program':
+      return { obj: client.getProgram(), config: { programName: name } };
+    case 'interface':
+      return { obj: client.getInterface(), config: { interfaceName: name } };
+    case 'function_group':
+      return {
+        obj: client.getFunctionGroup(),
+        config: { functionGroupName: name },
+      };
+    case 'function_module': {
+      // Identity is the FM name + its owning function group. The group can be
+      // passed explicitly (function_group_name) or via GROUP|FM_NAME, as the
+      // lock handler accepts.
+      let groupName = functionGroupName?.toUpperCase();
+      let fmName = name;
+      if (name.includes('|')) {
+        const [g, fm] = name.split('|');
+        groupName = (functionGroupName?.toUpperCase() || g).toUpperCase();
+        fmName = fm;
+      }
+      if (!groupName) {
+        throw new Error(
+          'function_group_name is required for function_module (or use GROUP|FM_NAME).',
+        );
+      }
+      return {
+        obj: client.getFunctionModule(),
+        config: { functionGroupName: groupName, functionModuleName: fmName },
+      };
+    }
+    case 'table':
+      return { obj: client.getTable(), config: { tableName: name } };
+    case 'structure':
+      return { obj: client.getStructure(), config: { structureName: name } };
+    case 'ddl':
+      return { obj: client.getDdl(), config: { ddlName: name } };
+    case 'domain':
+      return { obj: client.getDomain(), config: { domainName: name } };
+    case 'data_element':
+      return {
+        obj: client.getDataElement(),
+        config: { dataElementName: name },
+      };
+    case 'behavior_definition':
+      return { obj: client.getBehaviorDefinition(), config: { name } };
+    case 'metadata_extension':
+      return { obj: client.getMetadataExtension(), config: { name } };
+    case 'package':
+      return { obj: client.getPackage(), config: { packageName: name } };
+    default:
+      return null;
+  }
+}

--- a/src/lib/handlers/groups/ReadOnlyHandlersGroup.ts
+++ b/src/lib/handlers/groups/ReadOnlyHandlersGroup.ts
@@ -11,6 +11,14 @@ import {
   TOOL_DEFINITION as ReadClass_Tool,
 } from '../../../handlers/class/readonly/handleReadClass';
 import {
+  TOOL_DEFINITION as GetObjectVersionSource_Tool,
+  handleGetObjectVersionSource,
+} from '../../../handlers/common/readonly/handleGetObjectVersionSource';
+import {
+  TOOL_DEFINITION as GetObjectVersions_Tool,
+  handleGetObjectVersions,
+} from '../../../handlers/common/readonly/handleGetObjectVersions';
+import {
   handleReadDataElement,
   TOOL_DEFINITION as ReadDataElement_Tool,
 } from '../../../handlers/data_element/readonly/handleReadDataElement';
@@ -218,6 +226,15 @@ export class ReadOnlyHandlersGroup extends BaseHandlerGroup {
       {
         toolDefinition: GetStructuresList_Tool,
         handler: (args: any) => handleGetStructuresList(this.context, args),
+      },
+      {
+        toolDefinition: GetObjectVersions_Tool,
+        handler: (args: any) => handleGetObjectVersions(this.context, args),
+      },
+      {
+        toolDefinition: GetObjectVersionSource_Tool,
+        handler: (args: any) =>
+          handleGetObjectVersionSource(this.context, args),
       },
       {
         toolDefinition: ReadDdl_Tool,


### PR DESCRIPTION
Closes #30. Hardens #128 at the library level.

## Migration
- `@mcp-abap-adt/adt-clients` `^6.1.0` → **`^7.0.1`**, `@mcp-abap-adt/interfaces` `^7.2.0` → **`^9.0.0`** (adt-clients 7.0.0 requires interfaces ^9.0.0 for the new `getVersions`/`getVersionSource` on `IAdtObject`). mcp-abap-adt is a pure consumer (does not implement `IAdtObject`), so the build is clean — no tool contract changed by the migration.
- adt-clients **7.0.1** also makes where-used resilient on S/4 systems whose `/usageReferences/scope` returns 404 (falls back to an unscoped search + client-side type narrowing). This hardens `GetStructuresList` append detection (#128) at the library level, complementing the consumer-side `TABL/DS` scoping shipped in 8.1.1.

## New tools (read-only) — Object history (#30)
- **`GetObjectVersions`** (`object_type`, `object_name`[, `function_group_name`]) → the object's SAP version history: `versionId`, `author`, `updatedAt`, `title`, and an opaque `contentUri` per entry.
- **`GetObjectVersionSource`** (`object_type`, `content_uri`) → the source of a specific version (the `content_uri` is forwarded opaque; `object_type` only selects the client).
- Dispatch mirrors the generic object tools (`LockObject` etc.) across the same 13 object types. Object types without a version endpoint return a clean `UNSUPPORTED_OPERATION` error, never raw HTTP.
- These cover #30's "get an object's history" + "get the code at a specific version"; a two-version diff can be produced by the caller from two `GetObjectVersionSource` results (a dedicated `GetDiff` tool can follow if wanted).

## Verification
- `npm run build`, `npm run test:check` — green. New SAP-free unit test `handleObjectVersions.test.ts` (4 cases: dispatch to class/table accessors with the right name key, `content_uri` forwarding, unknown-type error). `AVAILABLE_TOOLS*.md` regenerated.
- Not yet exercised against a live SAP backend (per the team workflow, verified via cloud-llm-hub after publish).

## Known minor (non-blocking, from review)
- `package` version lookup uses `{ packageName }` (no `superPackage`) — read-only version history does not need the lock transaction anchor; no package-type unit case.
- A defensive `!resolved` guard after the `object_type` allow-list check is dead in practice but harmless.

Minor bump **8.1.1 → 8.2.0** (additive tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)