### PR TITLE
feat(history): per-object high-level version tools (8.3.0, #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.3.0] - 2026-06-29
+
+### Added
+- **Per-object high-level version tools (#30).** Added `Get<Object>Versions` and `Get<Object>VersionSource` for the 13 versioned object types (class, program, interface, function_group, function_module, table, structure, ddl, domain, data_element, package, behavior_definition, metadata_extension) to the **HighLevel** group — e.g. `GetProgramVersions`/`GetProgramVersionSource`, `GetClassVersions`/`GetClassVersionSource`. These mirror the per-object `Get<Object>` read tools (the way `GetProgram` coexists with the read-only `ReadProgram`), so development clients that run with the ReadOnly analytics group disabled still get object version history. Each tool's `available_in` matches its `Get<Object>` counterpart (e.g. `GetProgramVersions` is onprem/legacy only). The generic `GetObjectVersions`/`GetObjectVersionSource` in the ReadOnly group are unchanged.
+
 ## [8.2.0] - 2026-06-28
 
 ### Added

--- a/docs/user-guide/AVAILABLE_TOOLS.md
+++ b/docs/user-guide/AVAILABLE_TOOLS.md
@@ -4,9 +4,9 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ## Summary
 
-- Total tools: 315
+- Total tools: 341
 - Read-only tools: 61
-- High-level tools: 130
+- High-level tools: 156
 - Low-level tools: 124
 
 - Compact tools: 22 (included in High-level group)
@@ -138,6 +138,32 @@ Generated from code in `src/handlers/**` (not from docs).
     - [UpdateLocalTypes](#updatelocaltypes-high-level-class)
   - [Common](#high-level-common)
     - [ActivateObjects](#activateobjects-high-level-common)
+    - [GetBehaviorDefinitionVersions](#getbehaviordefinitionversions-high-level-common)
+    - [GetBehaviorDefinitionVersionSource](#getbehaviordefinitionversionsource-high-level-common)
+    - [GetClassVersions](#getclassversions-high-level-common)
+    - [GetClassVersionSource](#getclassversionsource-high-level-common)
+    - [GetDataElementVersions](#getdataelementversions-high-level-common)
+    - [GetDataElementVersionSource](#getdataelementversionsource-high-level-common)
+    - [GetDdlVersions](#getddlversions-high-level-common)
+    - [GetDdlVersionSource](#getddlversionsource-high-level-common)
+    - [GetDomainVersions](#getdomainversions-high-level-common)
+    - [GetDomainVersionSource](#getdomainversionsource-high-level-common)
+    - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
+    - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
+    - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
+    - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
+    - [GetInterfaceVersions](#getinterfaceversions-high-level-common)
+    - [GetInterfaceVersionSource](#getinterfaceversionsource-high-level-common)
+    - [GetMetadataExtensionVersions](#getmetadataextensionversions-high-level-common)
+    - [GetMetadataExtensionVersionSource](#getmetadataextensionversionsource-high-level-common)
+    - [GetPackageVersions](#getpackageversions-high-level-common)
+    - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
+    - [GetProgramVersions](#getprogramversions-high-level-common)
+    - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
+    - [GetStructureVersions](#getstructureversions-high-level-common)
+    - [GetStructureVersionSource](#getstructureversionsource-high-level-common)
+    - [GetTableVersions](#gettableversions-high-level-common)
+    - [GetTableVersionSource](#gettableversionsource-high-level-common)
   - [Compact](#high-level-compact)
     - [HandlerActivate](#handleractivate-high-level-compact)
     - [HandlerCdsUnitTestResult](#handlercdsunittestresult-high-level-compact)
@@ -1674,6 +1700,293 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `objects` (array, required) - Array of objects to activate. Each object must have 'name' and 'type'.
 - `preaudit` (boolean, optional) - Request pre-audit before activation. Default: true
+
+---
+
+<a id="getbehaviordefinitionversions-high-level-common"></a>
+#### GetBehaviorDefinitionVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a RAP behavior definition. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetBehaviorDefinitionVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `behavior_definition_name` (string, required) - RAP behavior definition name.
+
+---
+
+<a id="getbehaviordefinitionversionsource-high-level-common"></a>
+#### GetBehaviorDefinitionVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific RAP behavior definition version by its content_uri (taken from a GetBehaviorDefinitionVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetBehaviorDefinitionVersions entry.
+
+---
+
+<a id="getclassversions-high-level-common"></a>
+#### GetClassVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetClassVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `class_name` (string, required) - ABAP class name.
+
+---
+
+<a id="getclassversionsource-high-level-common"></a>
+#### GetClassVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP class version by its content_uri (taken from a GetClassVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetClassVersions entry.
+
+---
+
+<a id="getdataelementversions-high-level-common"></a>
+#### GetDataElementVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `data_element_name` (string, required) - ABAP data element name.
+
+---
+
+<a id="getdataelementversionsource-high-level-common"></a>
+#### GetDataElementVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP data element version by its content_uri (taken from a GetDataElementVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetDataElementVersions entry.
+
+---
+
+<a id="getddlversions-high-level-common"></a>
+#### GetDdlVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `ddl_name` (string, required) - CDS view (DDL source) name.
+
+---
+
+<a id="getddlversionsource-high-level-common"></a>
+#### GetDdlVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific CDS view (DDL source) version by its content_uri (taken from a GetDdlVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetDdlVersions entry.
+
+---
+
+<a id="getdomainversions-high-level-common"></a>
+#### GetDomainVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `domain_name` (string, required) - ABAP domain name.
+
+---
+
+<a id="getdomainversionsource-high-level-common"></a>
+#### GetDomainVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP domain version by its content_uri (taken from a GetDomainVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetDomainVersions entry.
+
+---
+
+<a id="getfunctiongroupversions-high-level-common"></a>
+#### GetFunctionGroupVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `function_group_name` (string, required) - ABAP function group name.
+
+---
+
+<a id="getfunctiongroupversionsource-high-level-common"></a>
+#### GetFunctionGroupVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP function group version by its content_uri (taken from a GetFunctionGroupVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
+
+---
+
+<a id="getfunctionmoduleversions-high-level-common"></a>
+#### GetFunctionModuleVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `function_group_name` (string, required) - Owning function group name (required).
+- `function_module_name` (string, required) - ABAP function module name.
+
+---
+
+<a id="getfunctionmoduleversionsource-high-level-common"></a>
+#### GetFunctionModuleVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP function module version by its content_uri (taken from a GetFunctionModuleVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionModuleVersions entry.
+
+---
+
+<a id="getinterfaceversions-high-level-common"></a>
+#### GetInterfaceVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `interface_name` (string, required) - ABAP interface name.
+
+---
+
+<a id="getinterfaceversionsource-high-level-common"></a>
+#### GetInterfaceVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP interface version by its content_uri (taken from a GetInterfaceVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetInterfaceVersions entry.
+
+---
+
+<a id="getmetadataextensionversions-high-level-common"></a>
+#### GetMetadataExtensionVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a CDS metadata extension. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetMetadataExtensionVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `metadata_extension_name` (string, required) - CDS metadata extension name.
+
+---
+
+<a id="getmetadataextensionversionsource-high-level-common"></a>
+#### GetMetadataExtensionVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific CDS metadata extension version by its content_uri (taken from a GetMetadataExtensionVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetMetadataExtensionVersions entry.
+
+---
+
+<a id="getpackageversions-high-level-common"></a>
+#### GetPackageVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `package_name` (string, required) - ABAP package name.
+
+---
+
+<a id="getpackageversionsource-high-level-common"></a>
+#### GetPackageVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP package version by its content_uri (taken from a GetPackageVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
+
+---
+
+<a id="getprogramversions-high-level-common"></a>
+#### GetProgramVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `program_name` (string, required) - ABAP program name.
+
+---
+
+<a id="getprogramversionsource-high-level-common"></a>
+#### GetProgramVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP program version by its content_uri (taken from a GetProgramVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetProgramVersions entry.
+
+---
+
+<a id="getstructureversions-high-level-common"></a>
+#### GetStructureVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP structure. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetStructureVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `structure_name` (string, required) - ABAP structure name.
+
+---
+
+<a id="getstructureversionsource-high-level-common"></a>
+#### GetStructureVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP structure version by its content_uri (taken from a GetStructureVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetStructureVersions entry.
+
+---
+
+<a id="gettableversions-high-level-common"></a>
+#### GetTableVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP table. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetTableVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `table_name` (string, required) - ABAP table name.
+
+---
+
+<a id="gettableversionsource-high-level-common"></a>
+#### GetTableVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP table version by its content_uri (taken from a GetTableVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetTableVersions entry.
 
 ---
 

--- a/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
@@ -3,7 +3,7 @@
 Generated from code in `src/handlers/**` (not from docs).
 
 - Level: High-Level
-- Total tools: 130
+- Total tools: 156
 
 ## Navigation
 
@@ -39,6 +39,32 @@ Generated from code in `src/handlers/**` (not from docs).
     - [UpdateLocalTypes](#updatelocaltypes-high-level-class)
   - [Common](#high-level-common)
     - [ActivateObjects](#activateobjects-high-level-common)
+    - [GetBehaviorDefinitionVersions](#getbehaviordefinitionversions-high-level-common)
+    - [GetBehaviorDefinitionVersionSource](#getbehaviordefinitionversionsource-high-level-common)
+    - [GetClassVersions](#getclassversions-high-level-common)
+    - [GetClassVersionSource](#getclassversionsource-high-level-common)
+    - [GetDataElementVersions](#getdataelementversions-high-level-common)
+    - [GetDataElementVersionSource](#getdataelementversionsource-high-level-common)
+    - [GetDdlVersions](#getddlversions-high-level-common)
+    - [GetDdlVersionSource](#getddlversionsource-high-level-common)
+    - [GetDomainVersions](#getdomainversions-high-level-common)
+    - [GetDomainVersionSource](#getdomainversionsource-high-level-common)
+    - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
+    - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
+    - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
+    - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
+    - [GetInterfaceVersions](#getinterfaceversions-high-level-common)
+    - [GetInterfaceVersionSource](#getinterfaceversionsource-high-level-common)
+    - [GetMetadataExtensionVersions](#getmetadataextensionversions-high-level-common)
+    - [GetMetadataExtensionVersionSource](#getmetadataextensionversionsource-high-level-common)
+    - [GetPackageVersions](#getpackageversions-high-level-common)
+    - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
+    - [GetProgramVersions](#getprogramversions-high-level-common)
+    - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
+    - [GetStructureVersions](#getstructureversions-high-level-common)
+    - [GetStructureVersionSource](#getstructureversionsource-high-level-common)
+    - [GetTableVersions](#gettableversions-high-level-common)
+    - [GetTableVersionSource](#gettableversionsource-high-level-common)
   - [Compact](#high-level-compact)
     - [HandlerActivate](#handleractivate-high-level-compact)
     - [HandlerCdsUnitTestResult](#handlercdsunittestresult-high-level-compact)
@@ -537,6 +563,293 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `objects` (array, required) - Array of objects to activate. Each object must have 'name' and 'type'.
 - `preaudit` (boolean, optional) - Request pre-audit before activation. Default: true
+
+---
+
+<a id="getbehaviordefinitionversions-high-level-common"></a>
+#### GetBehaviorDefinitionVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a RAP behavior definition. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetBehaviorDefinitionVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `behavior_definition_name` (string, required) - RAP behavior definition name.
+
+---
+
+<a id="getbehaviordefinitionversionsource-high-level-common"></a>
+#### GetBehaviorDefinitionVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific RAP behavior definition version by its content_uri (taken from a GetBehaviorDefinitionVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetBehaviorDefinitionVersions entry.
+
+---
+
+<a id="getclassversions-high-level-common"></a>
+#### GetClassVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetClassVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `class_name` (string, required) - ABAP class name.
+
+---
+
+<a id="getclassversionsource-high-level-common"></a>
+#### GetClassVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP class version by its content_uri (taken from a GetClassVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetClassVersions entry.
+
+---
+
+<a id="getdataelementversions-high-level-common"></a>
+#### GetDataElementVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `data_element_name` (string, required) - ABAP data element name.
+
+---
+
+<a id="getdataelementversionsource-high-level-common"></a>
+#### GetDataElementVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP data element version by its content_uri (taken from a GetDataElementVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetDataElementVersions entry.
+
+---
+
+<a id="getddlversions-high-level-common"></a>
+#### GetDdlVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `ddl_name` (string, required) - CDS view (DDL source) name.
+
+---
+
+<a id="getddlversionsource-high-level-common"></a>
+#### GetDdlVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific CDS view (DDL source) version by its content_uri (taken from a GetDdlVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetDdlVersions entry.
+
+---
+
+<a id="getdomainversions-high-level-common"></a>
+#### GetDomainVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `domain_name` (string, required) - ABAP domain name.
+
+---
+
+<a id="getdomainversionsource-high-level-common"></a>
+#### GetDomainVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP domain version by its content_uri (taken from a GetDomainVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetDomainVersions entry.
+
+---
+
+<a id="getfunctiongroupversions-high-level-common"></a>
+#### GetFunctionGroupVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `function_group_name` (string, required) - ABAP function group name.
+
+---
+
+<a id="getfunctiongroupversionsource-high-level-common"></a>
+#### GetFunctionGroupVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP function group version by its content_uri (taken from a GetFunctionGroupVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
+
+---
+
+<a id="getfunctionmoduleversions-high-level-common"></a>
+#### GetFunctionModuleVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `function_group_name` (string, required) - Owning function group name (required).
+- `function_module_name` (string, required) - ABAP function module name.
+
+---
+
+<a id="getfunctionmoduleversionsource-high-level-common"></a>
+#### GetFunctionModuleVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP function module version by its content_uri (taken from a GetFunctionModuleVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionModuleVersions entry.
+
+---
+
+<a id="getinterfaceversions-high-level-common"></a>
+#### GetInterfaceVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `interface_name` (string, required) - ABAP interface name.
+
+---
+
+<a id="getinterfaceversionsource-high-level-common"></a>
+#### GetInterfaceVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP interface version by its content_uri (taken from a GetInterfaceVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetInterfaceVersions entry.
+
+---
+
+<a id="getmetadataextensionversions-high-level-common"></a>
+#### GetMetadataExtensionVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a CDS metadata extension. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetMetadataExtensionVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `metadata_extension_name` (string, required) - CDS metadata extension name.
+
+---
+
+<a id="getmetadataextensionversionsource-high-level-common"></a>
+#### GetMetadataExtensionVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific CDS metadata extension version by its content_uri (taken from a GetMetadataExtensionVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetMetadataExtensionVersions entry.
+
+---
+
+<a id="getpackageversions-high-level-common"></a>
+#### GetPackageVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `package_name` (string, required) - ABAP package name.
+
+---
+
+<a id="getpackageversionsource-high-level-common"></a>
+#### GetPackageVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP package version by its content_uri (taken from a GetPackageVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
+
+---
+
+<a id="getprogramversions-high-level-common"></a>
+#### GetProgramVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `program_name` (string, required) - ABAP program name.
+
+---
+
+<a id="getprogramversionsource-high-level-common"></a>
+#### GetProgramVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP program version by its content_uri (taken from a GetProgramVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetProgramVersions entry.
+
+---
+
+<a id="getstructureversions-high-level-common"></a>
+#### GetStructureVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP structure. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetStructureVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `structure_name` (string, required) - ABAP structure name.
+
+---
+
+<a id="getstructureversionsource-high-level-common"></a>
+#### GetStructureVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP structure version by its content_uri (taken from a GetStructureVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetStructureVersions entry.
+
+---
+
+<a id="gettableversions-high-level-common"></a>
+#### GetTableVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP table. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetTableVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `table_name` (string, required) - ABAP table name.
+
+---
+
+<a id="gettableversionsource-high-level-common"></a>
+#### GetTableVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP table version by its content_uri (taken from a GetTableVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetTableVersions entry.
 
 ---
 

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -5,9 +5,9 @@ Generated from code in `src/handlers/**` (not from docs).
 Tools available on legacy SAP systems (BASIS < 7.50).
 Legacy systems support a subset of tools — primarily Class, Interface, View, Program, Function Group/Module, Package (read/update/delete), Include, Unit Test, and common utilities.
 
-- Total tools: 143
+- Total tools: 157
 - Read-Only: 17
-- High-Level: 65
+- High-Level: 79
 - Low-Level: 61
 
 ## Navigation
@@ -63,6 +63,20 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
     - [UpdateLocalTypes](#updatelocaltypes-high-level-class)
   - [Common](#high-level-common)
     - [ActivateObjects](#activateobjects-high-level-common)
+    - [GetClassVersions](#getclassversions-high-level-common)
+    - [GetClassVersionSource](#getclassversionsource-high-level-common)
+    - [GetDdlVersions](#getddlversions-high-level-common)
+    - [GetDdlVersionSource](#getddlversionsource-high-level-common)
+    - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
+    - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
+    - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
+    - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
+    - [GetInterfaceVersions](#getinterfaceversions-high-level-common)
+    - [GetInterfaceVersionSource](#getinterfaceversionsource-high-level-common)
+    - [GetPackageVersions](#getpackageversions-high-level-common)
+    - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
+    - [GetProgramVersions](#getprogramversions-high-level-common)
+    - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
   - [Compact](#high-level-compact)
     - [HandlerCreate](#handlercreate-high-level-compact)
     - [HandlerDelete](#handlerdelete-high-level-compact)
@@ -751,6 +765,189 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 **Parameters:**
 - `objects` (array, required) - Array of objects to activate. Each object must have 'name' and 'type'.
 - `preaudit` (boolean, optional) - Request pre-audit before activation. Default: true
+
+---
+
+<a id="getclassversions-high-level-common"></a>
+#### GetClassVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetClassVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `class_name` (string, required) - ABAP class name.
+
+---
+
+<a id="getclassversionsource-high-level-common"></a>
+#### GetClassVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP class version by its content_uri (taken from a GetClassVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetClassVersions entry.
+
+---
+
+<a id="getddlversions-high-level-common"></a>
+#### GetDdlVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `ddl_name` (string, required) - CDS view (DDL source) name.
+
+---
+
+<a id="getddlversionsource-high-level-common"></a>
+#### GetDdlVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific CDS view (DDL source) version by its content_uri (taken from a GetDdlVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetDdlVersions entry.
+
+---
+
+<a id="getfunctiongroupversions-high-level-common"></a>
+#### GetFunctionGroupVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `function_group_name` (string, required) - ABAP function group name.
+
+---
+
+<a id="getfunctiongroupversionsource-high-level-common"></a>
+#### GetFunctionGroupVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP function group version by its content_uri (taken from a GetFunctionGroupVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
+
+---
+
+<a id="getfunctionmoduleversions-high-level-common"></a>
+#### GetFunctionModuleVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `function_group_name` (string, required) - Owning function group name (required).
+- `function_module_name` (string, required) - ABAP function module name.
+
+---
+
+<a id="getfunctionmoduleversionsource-high-level-common"></a>
+#### GetFunctionModuleVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP function module version by its content_uri (taken from a GetFunctionModuleVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionModuleVersions entry.
+
+---
+
+<a id="getinterfaceversions-high-level-common"></a>
+#### GetInterfaceVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `interface_name` (string, required) - ABAP interface name.
+
+---
+
+<a id="getinterfaceversionsource-high-level-common"></a>
+#### GetInterfaceVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP interface version by its content_uri (taken from a GetInterfaceVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetInterfaceVersions entry.
+
+---
+
+<a id="getpackageversions-high-level-common"></a>
+#### GetPackageVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `package_name` (string, required) - ABAP package name.
+
+---
+
+<a id="getpackageversionsource-high-level-common"></a>
+#### GetPackageVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP package version by its content_uri (taken from a GetPackageVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
+
+---
+
+<a id="getprogramversions-high-level-common"></a>
+#### GetProgramVersions (High-Level / Common)
+**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `legacy`
+
+**Parameters:**
+- `program_name` (string, required) - ABAP program name.
+
+---
+
+<a id="getprogramversionsource-high-level-common"></a>
+#### GetProgramVersionSource (High-Level / Common)
+**Description:** [read-only] Fetch the source of a specific ABAP program version by its content_uri (taken from a GetProgramVersions entry).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `legacy`
+
+**Parameters:**
+- `content_uri` (string, required) - Opaque content_uri taken from a GetProgramVersions entry.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.2.0",
+  "version": "8.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/unit/objectVersionToolsHigh.test.ts
+++ b/src/__tests__/unit/objectVersionToolsHigh.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests (#30): per-object HIGH-LEVEL version tools.
+ *  - Get<Display>Versions dispatches to the right client accessor per type and
+ *    forwards the natural name param as the resolver config;
+ *  - Get<Display>VersionSource forwards content_uri to getVersionSource;
+ *  - the factory registers all 26 expected tool names with the per-type
+ *    available_in copied from each high-level Get<X> (program is onprem/legacy).
+ * SAP-free via a mocked AdtClient.
+ */
+
+const mockClassGetVersions = jest.fn();
+const mockTableGetVersions = jest.fn();
+const mockTableGetVersionSource = jest.fn();
+const mockFmGetVersions = jest.fn();
+const mockGetClass = jest.fn();
+const mockGetTable = jest.fn();
+const mockGetFunctionModule = jest.fn();
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getClass: mockGetClass,
+    getTable: mockGetTable,
+    getFunctionModule: mockGetFunctionModule,
+  }),
+}));
+
+import { buildObjectVersionTools } from '../../handlers/common/high/objectVersionTools';
+import { HighLevelHandlersGroup } from '../../lib/handlers/groups/HighLevelHandlersGroup';
+
+const ctx = { connection: {}, logger: undefined } as any;
+
+function payload(result: any) {
+  const text =
+    (result.content.find((c: any) => c.type === 'text') as any)?.text || '';
+  return JSON.parse(text);
+}
+
+function tool(name: string) {
+  const entry = buildObjectVersionTools().find(
+    (e) => e.toolDefinition.name === name,
+  );
+  if (!entry) throw new Error(`tool ${name} not found`);
+  return entry;
+}
+
+beforeEach(() => {
+  mockClassGetVersions.mockReset();
+  mockTableGetVersions.mockReset();
+  mockTableGetVersionSource.mockReset();
+  mockFmGetVersions.mockReset();
+  mockGetClass.mockReset();
+  mockGetTable.mockReset();
+  mockGetFunctionModule.mockReset();
+  mockGetClass.mockReturnValue({ getVersions: mockClassGetVersions });
+  mockGetTable.mockReturnValue({
+    getVersions: mockTableGetVersions,
+    getVersionSource: mockTableGetVersionSource,
+  });
+  mockGetFunctionModule.mockReturnValue({ getVersions: mockFmGetVersions });
+});
+
+describe('per-object high-level version tools (#30)', () => {
+  it('GetClassVersions dispatches to getClass().getVersions({ className })', async () => {
+    const versions = [{ versionId: '00001', contentUri: '/x;version=00001' }];
+    mockClassGetVersions.mockResolvedValue(versions);
+
+    const result = await tool('GetClassVersions').handler(ctx, {
+      class_name: 'zcl_my_class',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockGetClass).toHaveBeenCalled();
+    expect(mockClassGetVersions).toHaveBeenCalledWith({
+      className: 'ZCL_MY_CLASS',
+    });
+    const data = payload(result);
+    expect(data.success).toBe(true);
+    expect(data.object_type).toBe('class');
+    expect(data.object_name).toBe('ZCL_MY_CLASS');
+    expect(data.versions).toEqual(versions);
+  });
+
+  it('GetFunctionModuleVersions threads function_group_name through', async () => {
+    mockFmGetVersions.mockResolvedValue([]);
+
+    const result = await tool('GetFunctionModuleVersions').handler(ctx, {
+      function_module_name: 'z_my_fm',
+      function_group_name: 'z_my_grp',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockFmGetVersions).toHaveBeenCalledWith({
+      functionGroupName: 'Z_MY_GRP',
+      functionModuleName: 'Z_MY_FM',
+    });
+  });
+
+  it('GetFunctionModuleVersions errors without function_group_name', async () => {
+    const result = await tool('GetFunctionModuleVersions').handler(ctx, {
+      function_module_name: 'z_my_fm',
+    });
+    expect(result.isError).toBe(true);
+    expect(mockFmGetVersions).not.toHaveBeenCalled();
+  });
+
+  it('GetTableVersionSource forwards content_uri to getVersionSource', async () => {
+    mockTableGetVersionSource.mockResolvedValue('DEFINE TABLE zmy_table.');
+
+    const result = await tool('GetTableVersionSource').handler(ctx, {
+      content_uri:
+        '/sap/bc/adt/ddic/tables/zmy_table/source/main?version=00001',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockTableGetVersionSource).toHaveBeenCalledWith(
+      '/sap/bc/adt/ddic/tables/zmy_table/source/main?version=00001',
+    );
+    const data = payload(result);
+    expect(data.success).toBe(true);
+    expect(data.source).toBe('DEFINE TABLE zmy_table.');
+  });
+
+  it('registers all 26 expected tool names', () => {
+    const names = buildObjectVersionTools().map((e) => e.toolDefinition.name);
+    const displays = [
+      'Class',
+      'Program',
+      'Interface',
+      'FunctionGroup',
+      'FunctionModule',
+      'Table',
+      'Structure',
+      'Ddl',
+      'Domain',
+      'DataElement',
+      'Package',
+      'BehaviorDefinition',
+      'MetadataExtension',
+    ];
+    const expected = displays.flatMap((d) => [
+      `Get${d}Versions`,
+      `Get${d}VersionSource`,
+    ]);
+    expect(names.sort()).toEqual(expected.sort());
+    expect(new Set(names).size).toBe(26);
+  });
+
+  it('the registered HighLevel group contains all 26 version tools (no dups)', () => {
+    const group = new HighLevelHandlersGroup({
+      connection: {},
+      logger: undefined,
+    } as any);
+    const registered = group.getHandlers().map((e) => e.toolDefinition.name);
+    const expected = buildObjectVersionTools().map(
+      (e) => e.toolDefinition.name,
+    );
+    for (const name of expected) {
+      expect(registered).toContain(name);
+    }
+    // no duplicate tool names in the whole HighLevel group
+    expect(new Set(registered).size).toBe(registered.length);
+    // program version tools are onprem/legacy-gated in the registered set
+    const prog = group
+      .getHandlers()
+      .find((e) => e.toolDefinition.name === 'GetProgramVersions');
+    expect(prog?.toolDefinition.available_in).toEqual(['onprem', 'legacy']);
+  });
+
+  it('program version tools are onprem/legacy-gated (mirrors GetProgram)', () => {
+    for (const name of ['GetProgramVersions', 'GetProgramVersionSource']) {
+      expect(tool(name).toolDefinition.available_in).toEqual([
+        'onprem',
+        'legacy',
+      ]);
+    }
+    // class is all three (mirrors GetClass)
+    expect(tool('GetClassVersions').toolDefinition.available_in).toEqual([
+      'onprem',
+      'cloud',
+      'legacy',
+    ]);
+    // table omits legacy (mirrors GetTable)
+    expect(tool('GetTableVersions').toolDefinition.available_in).toEqual([
+      'onprem',
+      'cloud',
+    ]);
+  });
+});

--- a/src/handlers/common/high/objectVersionTools.ts
+++ b/src/handlers/common/high/objectVersionTools.ts
@@ -1,0 +1,320 @@
+/**
+ * Per-object HIGH-LEVEL version-history tools (#30).
+ *
+ * For each versioned object_type this factory builds a pair of tools that
+ * mirror the existing high-level Get<X> accessor (e.g. GetClass → GetClassVersions
+ * / GetClassVersionSource), so development (HighLevel) clients can read version
+ * history without enabling the generic ReadOnly group.
+ *
+ *   Get<Display>Versions       — version history of that object.
+ *   Get<Display>VersionSource  — source of one version, by its opaque content_uri.
+ *
+ * Both delegate to the SAME resolveVersionedObject dispatch + IAdtObject methods
+ * (getVersions / getVersionSource) used by the generic ReadOnly handlers, so the
+ * wire behaviour is identical. The generic GetObjectVersions/GetObjectVersionSource
+ * (ReadOnly group) stay; these are HighLevel-only per-type equivalents.
+ */
+
+import { AdtObjectErrorCodes } from '@mcp-abap-adt/interfaces';
+import { createAdtClient } from '../../../lib/clients';
+import type {
+  HandlerContext,
+  SapEnvironment,
+  ToolDefinition,
+} from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+import { resolveVersionedObject } from '../readonly/resolveVersionedObject';
+
+/** Handler signature before context injection (the group wraps with withContext). */
+type RawHandler = (context: HandlerContext, args: any) => Promise<any>;
+
+export interface ObjectVersionToolEntry {
+  toolDefinition: ToolDefinition;
+  handler: RawHandler;
+}
+
+interface VersionedTypeRow {
+  /** object_type key for resolveVersionedObject (same set as VERSIONED_OBJECT_TYPES). */
+  object_type: string;
+  /** PascalCase display matching the existing high-level Get<Display> tool. */
+  display: string;
+  /** The natural name input param (e.g. class_name) — required on the Versions tool. */
+  nameParam: string;
+  /** Human label used in descriptions (e.g. "ABAP class", "CDS view"). */
+  label: string;
+  /** Environments — MUST match this type's existing high-level Get<X> TOOL_DEFINITION. */
+  available_in?: readonly SapEnvironment[];
+}
+
+/**
+ * One row per versioned object_type. `available_in` is copied from each type's
+ * existing high-level Get<X> handler (src/handlers/<type>/high/handleGet<X>.ts).
+ */
+export const VERSIONED_TYPES: VersionedTypeRow[] = [
+  {
+    object_type: 'class',
+    display: 'Class',
+    nameParam: 'class_name',
+    label: 'ABAP class',
+    available_in: ['onprem', 'cloud', 'legacy'],
+  },
+  {
+    object_type: 'program',
+    display: 'Program',
+    nameParam: 'program_name',
+    label: 'ABAP program',
+    available_in: ['onprem', 'legacy'],
+  },
+  {
+    object_type: 'interface',
+    display: 'Interface',
+    nameParam: 'interface_name',
+    label: 'ABAP interface',
+    available_in: ['onprem', 'cloud', 'legacy'],
+  },
+  {
+    object_type: 'function_group',
+    display: 'FunctionGroup',
+    nameParam: 'function_group_name',
+    label: 'ABAP function group',
+    available_in: ['onprem', 'cloud', 'legacy'],
+  },
+  {
+    object_type: 'function_module',
+    display: 'FunctionModule',
+    nameParam: 'function_module_name',
+    label: 'ABAP function module',
+    available_in: ['onprem', 'cloud', 'legacy'],
+  },
+  {
+    object_type: 'table',
+    display: 'Table',
+    nameParam: 'table_name',
+    label: 'ABAP table',
+    available_in: ['onprem', 'cloud'],
+  },
+  {
+    object_type: 'structure',
+    display: 'Structure',
+    nameParam: 'structure_name',
+    label: 'ABAP structure',
+    available_in: ['onprem', 'cloud'],
+  },
+  {
+    object_type: 'ddl',
+    display: 'Ddl',
+    nameParam: 'ddl_name',
+    label: 'CDS view (DDL source)',
+    available_in: ['onprem', 'cloud', 'legacy'],
+  },
+  {
+    object_type: 'domain',
+    display: 'Domain',
+    nameParam: 'domain_name',
+    label: 'ABAP domain',
+    available_in: ['onprem', 'cloud'],
+  },
+  {
+    object_type: 'data_element',
+    display: 'DataElement',
+    nameParam: 'data_element_name',
+    label: 'ABAP data element',
+    available_in: ['onprem', 'cloud'],
+  },
+  {
+    object_type: 'package',
+    display: 'Package',
+    nameParam: 'package_name',
+    label: 'ABAP package',
+    available_in: ['onprem', 'cloud', 'legacy'],
+  },
+  {
+    object_type: 'behavior_definition',
+    display: 'BehaviorDefinition',
+    nameParam: 'behavior_definition_name',
+    label: 'RAP behavior definition',
+    available_in: ['onprem', 'cloud'],
+  },
+  {
+    object_type: 'metadata_extension',
+    display: 'MetadataExtension',
+    nameParam: 'metadata_extension_name',
+    label: 'CDS metadata extension',
+    available_in: ['onprem', 'cloud'],
+  },
+];
+
+function buildVersionsTool(row: VersionedTypeRow): ObjectVersionToolEntry {
+  const isFm = row.object_type === 'function_module';
+  const properties: Record<string, unknown> = {
+    [row.nameParam]: {
+      type: 'string',
+      description: `${row.label} name.`,
+    },
+  };
+  const required = [row.nameParam];
+  if (isFm) {
+    properties.function_group_name = {
+      type: 'string',
+      description: 'Owning function group name (required).',
+    };
+    required.push('function_group_name');
+  }
+
+  const toolDefinition: ToolDefinition = {
+    name: `Get${row.display}Versions`,
+    ...(row.available_in ? { available_in: row.available_in } : {}),
+    description: `[read-only] List the SAP version history of a ${row.label}. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via Get${row.display}VersionSource.`,
+    inputSchema: {
+      type: 'object',
+      properties,
+      required,
+    },
+  };
+
+  const handler: RawHandler = async (context, args) => {
+    const { connection, logger } = context;
+    try {
+      const name = args?.[row.nameParam];
+      if (!name) {
+        return return_error(new Error(`${row.nameParam} is required`));
+      }
+      const functionGroupName = isFm ? args?.function_group_name : undefined;
+      if (isFm && !functionGroupName) {
+        return return_error(new Error('function_group_name is required'));
+      }
+
+      const client = createAdtClient(connection, logger);
+      let resolved: ReturnType<typeof resolveVersionedObject>;
+      try {
+        resolved = resolveVersionedObject(
+          client,
+          row.object_type,
+          String(name),
+          functionGroupName ? String(functionGroupName) : undefined,
+        );
+      } catch (e: any) {
+        return return_error(e instanceof Error ? e : new Error(String(e)));
+      }
+      if (!resolved) {
+        return return_error(
+          new Error(`Unsupported object_type: ${row.object_type}`),
+        );
+      }
+
+      try {
+        const versions = await resolved.obj.getVersions(resolved.config);
+        return return_response({
+          data: JSON.stringify(
+            {
+              success: true,
+              object_type: row.object_type,
+              object_name: String(name).toUpperCase(),
+              versions,
+            },
+            null,
+            2,
+          ),
+        } as AxiosResponse);
+      } catch (error: any) {
+        if (error?.code === AdtObjectErrorCodes.UNSUPPORTED_OPERATION) {
+          return return_error(
+            new Error(
+              `Version history is not supported for object_type '${row.object_type}' (${String(name).toUpperCase()}).`,
+            ),
+          );
+        }
+        return return_error(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    } catch (error: any) {
+      return return_error(error);
+    }
+  };
+
+  return { toolDefinition, handler };
+}
+
+function buildVersionSourceTool(row: VersionedTypeRow): ObjectVersionToolEntry {
+  const toolDefinition: ToolDefinition = {
+    name: `Get${row.display}VersionSource`,
+    ...(row.available_in ? { available_in: row.available_in } : {}),
+    description: `[read-only] Fetch the source of a specific ${row.label} version by its content_uri (taken from a Get${row.display}Versions entry).`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        content_uri: {
+          type: 'string',
+          description: `Opaque content_uri taken from a Get${row.display}Versions entry.`,
+        },
+      },
+      required: ['content_uri'],
+    },
+  };
+
+  const handler: RawHandler = async (context, args) => {
+    const { connection, logger } = context;
+    try {
+      const content_uri = args?.content_uri;
+      if (!content_uri) {
+        return return_error(new Error('content_uri is required'));
+      }
+
+      const client = createAdtClient(connection, logger);
+      // content_uri carries the full object identity; a placeholder name is only
+      // needed to obtain the right IAdtObject instance.
+      const resolved = resolveVersionedObject(
+        client,
+        row.object_type,
+        'X',
+        'X',
+      );
+      if (!resolved) {
+        return return_error(
+          new Error(`Unsupported object_type: ${row.object_type}`),
+        );
+      }
+
+      try {
+        const source = await resolved.obj.getVersionSource(String(content_uri));
+        return return_response({
+          data: JSON.stringify({ success: true, content_uri, source }, null, 2),
+        } as AxiosResponse);
+      } catch (error: any) {
+        if (error?.code === AdtObjectErrorCodes.UNSUPPORTED_OPERATION) {
+          return return_error(
+            new Error(
+              `Version source is not supported for object_type '${row.object_type}'.`,
+            ),
+          );
+        }
+        return return_error(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    } catch (error: any) {
+      return return_error(error);
+    }
+  };
+
+  return { toolDefinition, handler };
+}
+
+/**
+ * Build all 26 high-level per-object version tools (13 types ×
+ * {Versions, VersionSource}). The handlers take (context, args); the registering
+ * group wraps each with withContext.
+ */
+export function buildObjectVersionTools(): ObjectVersionToolEntry[] {
+  const entries: ObjectVersionToolEntry[] = [];
+  for (const row of VERSIONED_TYPES) {
+    entries.push(buildVersionsTool(row));
+    entries.push(buildVersionSourceTool(row));
+  }
+  return entries;
+}

--- a/src/lib/handlers/groups/HighLevelHandlersGroup.ts
+++ b/src/lib/handlers/groups/HighLevelHandlersGroup.ts
@@ -115,6 +115,7 @@ import {
   TOOL_DEFINITION as ActivateObjects_Tool,
   handleActivateObjects,
 } from '../../../handlers/common/high/handleActivateObjects';
+import { buildObjectVersionTools } from '../../../handlers/common/high/objectVersionTools';
 import {
   TOOL_DEFINITION as CheckDataElement_Tool,
   handleCheckDataElement,
@@ -1063,6 +1064,13 @@ export class HighLevelHandlersGroup extends BaseHandlerGroup {
         toolDefinition: CheckDdl_Tool,
         handler: withContext(handleCheckDdl),
       },
+      // Per-object high-level version-history tools (#30): 13 types ×
+      // {Versions, VersionSource}. HighLevel-only (ReadOnly keeps the generic
+      // GetObjectVersions/GetObjectVersionSource).
+      ...buildObjectVersionTools().map((entry) => ({
+        toolDefinition: entry.toolDefinition,
+        handler: withContext(entry.handler),
+      })),
     ];
   }
 }

--- a/tools/generate-tools-docs.js
+++ b/tools/generate-tools-docs.js
@@ -16,6 +16,13 @@ const COMPACT_MATRIX_PATH = path.join(
   __dirname,
   '../src/handlers/compact/high/compactMatrix.ts',
 );
+// Per-object high-level version tools are built by a DRY factory (#30) rather
+// than one-TOOL_DEFINITION-per-file, so the file walker can't see them. Parse
+// the factory's VERSIONED_TYPES table directly (same pattern as compactMatrix).
+const OBJECT_VERSION_TOOLS_PATH = path.join(
+  __dirname,
+  '../src/handlers/common/high/objectVersionTools.ts',
+);
 const OUTPUT_PATHS = {
   all: path.join(__dirname, '../docs/user-guide/AVAILABLE_TOOLS.md'),
   readonly: path.join(
@@ -442,11 +449,78 @@ function loadCompactMatrix() {
   };
 }
 
+/**
+ * Synthesize doc entries for the per-object high-level version tools (#30),
+ * which are produced by the buildObjectVersionTools() factory and therefore are
+ * not discoverable by the per-file TOOL_DEFINITION walker. Parses the factory's
+ * VERSIONED_TYPES table to stay in sync with the source of truth.
+ */
+function loadObjectVersionTools() {
+  const content = fs.readFileSync(OBJECT_VERSION_TOOLS_PATH, 'utf8');
+  const rowRegex =
+    /object_type:\s*'([^']+)',\s*display:\s*'([^']+)',\s*nameParam:\s*'([^']+)',\s*label:\s*'([^']+)',\s*available_in:\s*\[([^\]]*)\]/g;
+  const tools = [];
+  let m = rowRegex.exec(content);
+  while (m !== null) {
+    const [, objectType, display, nameParam, label, availRaw] = m;
+    const availableIn = availRaw
+      .split(',')
+      .map((s) => s.trim().replace(/['"]/g, ''))
+      .filter(Boolean);
+    const isFm = objectType === 'function_module';
+
+    const versionsProps = {
+      [nameParam]: { type: 'string', description: `${label} name.` },
+    };
+    const versionsRequired = [nameParam];
+    if (isFm) {
+      versionsProps.function_group_name = {
+        type: 'string',
+        description: 'Owning function group name (required).',
+      };
+      versionsRequired.push('function_group_name');
+    }
+
+    tools.push({
+      name: `Get${display}Versions`,
+      description: `[read-only] List the SAP version history of a ${label}. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via Get${display}VersionSource.`,
+      inputSchema: { properties: versionsProps, required: versionsRequired },
+      inputSchemaRef: null,
+      availableIn,
+      objectFolder: 'common',
+      objectTitle: titleCaseFolder('common'),
+      level: 'high',
+      filePath: 'src/handlers/common/high/objectVersionTools.ts',
+    });
+    tools.push({
+      name: `Get${display}VersionSource`,
+      description: `[read-only] Fetch the source of a specific ${label} version by its content_uri (taken from a Get${display}Versions entry).`,
+      inputSchema: {
+        properties: {
+          content_uri: {
+            type: 'string',
+            description: `Opaque content_uri taken from a Get${display}Versions entry.`,
+          },
+        },
+        required: ['content_uri'],
+      },
+      inputSchemaRef: null,
+      availableIn,
+      objectFolder: 'common',
+      objectTitle: titleCaseFolder('common'),
+      level: 'high',
+      filePath: 'src/handlers/common/high/objectVersionTools.ts',
+    });
+    m = rowRegex.exec(content);
+  }
+  return tools;
+}
+
 function loadToolsFromHandlers() {
   const files = [];
   walk(HANDLERS_ROOT, files);
 
-  const tools = [];
+  const tools = [...loadObjectVersionTools()];
 
   for (const filePath of files) {
     const rel = path.relative(HANDLERS_ROOT, filePath).replace(/\\/g, '/');


### PR DESCRIPTION
Follow-up to #130 — extends object history (#30) into the **HighLevel** group.

## Why
ReadOnly is the analytics group, High is full CRUD for development. Because the read tools duplicate across groups (e.g. `ReadProgram` in ReadOnly vs `GetProgram` in High), the server is run with **ReadOnly disabled when High/Low are on**. So the generic `GetObjectVersions`/`GetObjectVersionSource` (ReadOnly, shipped in 8.2.0) are invisible to development clients. This adds per-object version tools to High so development agents get object history too.

## What
- **26 tools** — `Get<Object>Versions` + `Get<Object>VersionSource` for the 13 versioned types (class, program, interface, function_group, function_module, table, structure, ddl, domain, data_element, package, behavior_definition, metadata_extension). E.g. `GetProgramVersions`, `GetProgramVersionSource`, `GetClassVersions`, …
- Built via a DRY factory `src/handlers/common/high/objectVersionTools.ts` reusing `resolveVersionedObject` (no 26 copy-paste files). Registered **HighLevel-only**; the ReadOnly generic tools are untouched.
- `Get<X>Versions` takes the object's natural name param (`program_name`, `class_name`, … ; `function_group_name` for function_module); `Get<X>VersionSource` takes only the opaque `content_uri`.
- Each tool's `available_in` is copied from its `Get<X>` counterpart — e.g. `GetProgramVersions` is `['onprem','legacy']` (no programs on cloud).
- Unsupported object types return a clean `UNSUPPORTED_OPERATION` error, never raw HTTP.
- `AVAILABLE_TOOLS*.md` regenerated (docs generator extended to read the factory table, mirroring the `compactMatrix` precedent).

## Verification
- `npm run build`, `npm run test:check` — green. `objectVersionToolsHigh.test.ts` (7 cases): nameKey dispatch (class), function_module group threading + missing-group error, `content_uri` forwarding, 26-name set, no dups in HighLevel, `available_in` spot-checks incl. program onprem/legacy.
- Reviewer: Spec ✅ / Approved; available_in verified faithful for all 13 types.

## Known minor (non-blocking, from review)
- `GetFunctionModuleVersions` `required` order is `[function_module_name, function_group_name]` (group-second; functionally correct).
- No dedicated test for `GetFunctionModuleVersionSource` (the same factory path is covered by `GetTableVersionSource`).

Minor bump **8.2.0 → 8.3.0** (additive tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)