### PR TITLE
chore(deps): migrate to adt-clients 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Added
 - **Per-object high-level version tools (#30).** Added `Get<Object>Versions` and `Get<Object>VersionSource` for the 13 versioned object types (class, program, interface, function_group, function_module, table, structure, ddl, domain, data_element, package, behavior_definition, metadata_extension) to the **HighLevel** group — e.g. `GetProgramVersions`/`GetProgramVersionSource`, `GetClassVersions`/`GetClassVersionSource`. These mirror the per-object `Get<Object>` read tools (the way `GetProgram` coexists with the read-only `ReadProgram`), so development clients that run with the ReadOnly analytics group disabled still get object version history. Each tool's `available_in` matches its `Get<Object>` counterpart (e.g. `GetProgramVersions` is onprem/legacy only). The generic `GetObjectVersions`/`GetObjectVersionSource` in the ReadOnly group are unchanged.
 
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^7.1.0`** (from `^7.0.1`). 7.1.0 makes where-used result parsing namespace-prefix agnostic (`usagereferences:` vs `usageReferences:`), further hardening append detection in `GetStructuresList` (#128) on systems that emit the other prefix; it also adds per-group subpath exports (`/core`, `/runtime`, …) — not yet adopted here. Non-breaking; no tool contract changed.
+
 ## [8.2.0] - 2026-06-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^7.0.1",
+        "@mcp-abap-adt/adt-clients": "^7.1.0",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
@@ -225,16 +225,15 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.0.1.tgz",
-      "integrity": "sha512-Or3HSbeGVT/kYaOWKnJioh0XdZ9KYAQAOM+Ui5H/INqsIjtiKUpfhiEpKqNxLVPWNXNRiLdLLs+yEx1jDlu54A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.1.0.tgz",
+      "integrity": "sha512-+Zii+p6FPudDQQD0SWzgKBaS4DDaAAZiOHrP/tHadh1hBtvGQ9gJBkCnVrnEp0DG+boH+r35n7cFOfv4mNHJ/g==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^9.0.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.13.6",
-        "fast-xml-parser": "^5.4.1",
-        "yaml": "^2.3.4"
+        "fast-xml-parser": "^5.4.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -30308,6 +30307,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "yaml": "^2.8.1"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^7.0.1",
+    "@mcp-abap-adt/adt-clients": "^7.1.0",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",


### PR DESCRIPTION
Bumps `@mcp-abap-adt/adt-clients` `^7.0.1` → **`^7.1.0`** (interfaces stays `^9.0.0`). Non-breaking — mcp-abap-adt is a pure consumer; build + test:check green, no tool contract changed.

7.1.0 brings:
- **Where-used parsing is namespace-prefix agnostic** (`usagereferences:` vs `usageReferences:`) — further hardens `GetStructuresList` append detection (#128) on systems that emit the other prefix.
- Per-group subpath exports (`/core`, `/runtime`, …) — available, not yet adopted (possible startup-graph optimization for a follow-up).
- `yaml` moved to devDependencies (internal).

Folds into the unreleased **8.3.0** (merged #131 object-version tools); released together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)