### PR TITLE
feat(history): version diff tools — GetObjectVersionDiff + per-object (8.4.0, #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.4.0] - 2026-06-29
+
+### Added
+- **Version diff tools (#30).** `GetObjectVersionDiff` (generic, ReadOnly) and per-object `Get<Object>VersionDiff` (HighLevel, 13 types — e.g. `GetClassVersionDiff`, `GetProgramVersionDiff`) return a unified diff between two object versions, given the two `content_uri`s from a `…Versions` call. Each fetches both version sources and diffs them (jsdiff, 3 lines of context); the response includes `identical` and the unified `diff`. Per-object `available_in` mirrors the type's `Get<Object>` tool. Completes #30's "diff between two versions" (2b) alongside the version-history (8.2.0) and per-object high-level (8.3.0) tools.
+
 ## [8.3.0] - 2026-06-29
 
 ### Added

--- a/docs/user-guide/AVAILABLE_TOOLS.md
+++ b/docs/user-guide/AVAILABLE_TOOLS.md
@@ -4,9 +4,9 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ## Summary
 
-- Total tools: 341
-- Read-only tools: 61
-- High-level tools: 156
+- Total tools: 355
+- Read-only tools: 62
+- High-level tools: 169
 - Low-level tools: 124
 
 - Compact tools: 22 (included in High-level group)
@@ -29,6 +29,7 @@ Generated from code in `src/handlers/**` (not from docs).
   - [Class](#read-only-class)
     - [ReadClass](#readclass-read-only-class)
   - [Common](#read-only-common)
+    - [GetObjectVersionDiff](#getobjectversiondiff-read-only-common)
     - [GetObjectVersions](#getobjectversions-read-only-common)
     - [GetObjectVersionSource](#getobjectversionsource-read-only-common)
   - [Data Element](#read-only-data-element)
@@ -138,30 +139,43 @@ Generated from code in `src/handlers/**` (not from docs).
     - [UpdateLocalTypes](#updatelocaltypes-high-level-class)
   - [Common](#high-level-common)
     - [ActivateObjects](#activateobjects-high-level-common)
+    - [GetBehaviorDefinitionVersionDiff](#getbehaviordefinitionversiondiff-high-level-common)
     - [GetBehaviorDefinitionVersions](#getbehaviordefinitionversions-high-level-common)
     - [GetBehaviorDefinitionVersionSource](#getbehaviordefinitionversionsource-high-level-common)
+    - [GetClassVersionDiff](#getclassversiondiff-high-level-common)
     - [GetClassVersions](#getclassversions-high-level-common)
     - [GetClassVersionSource](#getclassversionsource-high-level-common)
+    - [GetDataElementVersionDiff](#getdataelementversiondiff-high-level-common)
     - [GetDataElementVersions](#getdataelementversions-high-level-common)
     - [GetDataElementVersionSource](#getdataelementversionsource-high-level-common)
+    - [GetDdlVersionDiff](#getddlversiondiff-high-level-common)
     - [GetDdlVersions](#getddlversions-high-level-common)
     - [GetDdlVersionSource](#getddlversionsource-high-level-common)
+    - [GetDomainVersionDiff](#getdomainversiondiff-high-level-common)
     - [GetDomainVersions](#getdomainversions-high-level-common)
     - [GetDomainVersionSource](#getdomainversionsource-high-level-common)
+    - [GetFunctionGroupVersionDiff](#getfunctiongroupversiondiff-high-level-common)
     - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
     - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
+    - [GetFunctionModuleVersionDiff](#getfunctionmoduleversiondiff-high-level-common)
     - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
     - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
+    - [GetInterfaceVersionDiff](#getinterfaceversiondiff-high-level-common)
     - [GetInterfaceVersions](#getinterfaceversions-high-level-common)
     - [GetInterfaceVersionSource](#getinterfaceversionsource-high-level-common)
+    - [GetMetadataExtensionVersionDiff](#getmetadataextensionversiondiff-high-level-common)
     - [GetMetadataExtensionVersions](#getmetadataextensionversions-high-level-common)
     - [GetMetadataExtensionVersionSource](#getmetadataextensionversionsource-high-level-common)
+    - [GetPackageVersionDiff](#getpackageversiondiff-high-level-common)
     - [GetPackageVersions](#getpackageversions-high-level-common)
     - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
+    - [GetProgramVersionDiff](#getprogramversiondiff-high-level-common)
     - [GetProgramVersions](#getprogramversions-high-level-common)
     - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
+    - [GetStructureVersionDiff](#getstructureversiondiff-high-level-common)
     - [GetStructureVersions](#getstructureversions-high-level-common)
     - [GetStructureVersionSource](#getstructureversionsource-high-level-common)
+    - [GetTableVersionDiff](#gettableversiondiff-high-level-common)
     - [GetTableVersions](#gettableversions-high-level-common)
     - [GetTableVersionSource](#gettableversionsource-high-level-common)
   - [Compact](#high-level-compact)
@@ -483,6 +497,19 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="read-only-common"></a>
 ### Read-Only / Common
+
+<a id="getobjectversiondiff-read-only-common"></a>
+#### GetObjectVersionDiff (Read-Only / Common)
+**Description:** [read-only] Compute a unified diff between two object versions. Pass the two opaque content_uris from GetObjectVersions entries; returns the unified diff (jsdiff) of their sources.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersionDiff.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetObjectVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetObjectVersions entry).
+- `object_type` (string, required) - Object type (same value used in GetObjectVersions).
+
+---
 
 <a id="getobjectversions-read-only-common"></a>
 #### GetObjectVersions (Read-Only / Common)
@@ -1703,6 +1730,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getbehaviordefinitionversiondiff-high-level-common"></a>
+#### GetBehaviorDefinitionVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two RAP behavior definition versions, by their content_uris (taken from GetBehaviorDefinitionVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetBehaviorDefinitionVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetBehaviorDefinitionVersions entry).
+
+---
+
 <a id="getbehaviordefinitionversions-high-level-common"></a>
 #### GetBehaviorDefinitionVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a RAP behavior definition. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetBehaviorDefinitionVersionSource.
@@ -1722,6 +1761,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetBehaviorDefinitionVersions entry.
+
+---
+
+<a id="getclassversiondiff-high-level-common"></a>
+#### GetClassVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP class versions, by their content_uris (taken from GetClassVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetClassVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetClassVersions entry).
 
 ---
 
@@ -1747,6 +1798,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getdataelementversiondiff-high-level-common"></a>
+#### GetDataElementVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP data element versions, by their content_uris (taken from GetDataElementVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDataElementVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDataElementVersions entry).
+
+---
+
 <a id="getdataelementversions-high-level-common"></a>
 #### GetDataElementVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
@@ -1766,6 +1829,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetDataElementVersions entry.
+
+---
+
+<a id="getddlversiondiff-high-level-common"></a>
+#### GetDdlVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two CDS view (DDL source) versions, by their content_uris (taken from GetDdlVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDdlVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDdlVersions entry).
 
 ---
 
@@ -1791,6 +1866,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getdomainversiondiff-high-level-common"></a>
+#### GetDomainVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP domain versions, by their content_uris (taken from GetDomainVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDomainVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDomainVersions entry).
+
+---
+
 <a id="getdomainversions-high-level-common"></a>
 #### GetDomainVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
@@ -1813,6 +1900,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getfunctiongroupversiondiff-high-level-common"></a>
+#### GetFunctionGroupVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP function group versions, by their content_uris (taken from GetFunctionGroupVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionGroupVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionGroupVersions entry).
+
+---
+
 <a id="getfunctiongroupversions-high-level-common"></a>
 #### GetFunctionGroupVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
@@ -1832,6 +1931,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
+
+---
+
+<a id="getfunctionmoduleversiondiff-high-level-common"></a>
+#### GetFunctionModuleVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP function module versions, by their content_uris (taken from GetFunctionModuleVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionModuleVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionModuleVersions entry).
 
 ---
 
@@ -1858,6 +1969,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getinterfaceversiondiff-high-level-common"></a>
+#### GetInterfaceVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP interface versions, by their content_uris (taken from GetInterfaceVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetInterfaceVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetInterfaceVersions entry).
+
+---
+
 <a id="getinterfaceversions-high-level-common"></a>
 #### GetInterfaceVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
@@ -1877,6 +2000,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetInterfaceVersions entry.
+
+---
+
+<a id="getmetadataextensionversiondiff-high-level-common"></a>
+#### GetMetadataExtensionVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two CDS metadata extension versions, by their content_uris (taken from GetMetadataExtensionVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetMetadataExtensionVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetMetadataExtensionVersions entry).
 
 ---
 
@@ -1902,6 +2037,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getpackageversiondiff-high-level-common"></a>
+#### GetPackageVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP package versions, by their content_uris (taken from GetPackageVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetPackageVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetPackageVersions entry).
+
+---
+
 <a id="getpackageversions-high-level-common"></a>
 #### GetPackageVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
@@ -1921,6 +2068,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
+
+---
+
+<a id="getprogramversiondiff-high-level-common"></a>
+#### GetProgramVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP program versions, by their content_uris (taken from GetProgramVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetProgramVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetProgramVersions entry).
 
 ---
 
@@ -1946,6 +2105,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getstructureversiondiff-high-level-common"></a>
+#### GetStructureVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP structure versions, by their content_uris (taken from GetStructureVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetStructureVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetStructureVersions entry).
+
+---
+
 <a id="getstructureversions-high-level-common"></a>
 #### GetStructureVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP structure. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetStructureVersionSource.
@@ -1965,6 +2136,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetStructureVersions entry.
+
+---
+
+<a id="gettableversiondiff-high-level-common"></a>
+#### GetTableVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP table versions, by their content_uris (taken from GetTableVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetTableVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetTableVersions entry).
 
 ---
 
@@ -5445,4 +5628,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-28*
+*Last updated: 2026-06-29*

--- a/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
@@ -596,4 +596,4 @@ Preferred dedicated compact tools and minimal payloads:
 
 ---
 
-*Last updated: 2026-06-28*
+*Last updated: 2026-06-29*

--- a/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
@@ -3,7 +3,7 @@
 Generated from code in `src/handlers/**` (not from docs).
 
 - Level: High-Level
-- Total tools: 156
+- Total tools: 169
 
 ## Navigation
 
@@ -39,30 +39,43 @@ Generated from code in `src/handlers/**` (not from docs).
     - [UpdateLocalTypes](#updatelocaltypes-high-level-class)
   - [Common](#high-level-common)
     - [ActivateObjects](#activateobjects-high-level-common)
+    - [GetBehaviorDefinitionVersionDiff](#getbehaviordefinitionversiondiff-high-level-common)
     - [GetBehaviorDefinitionVersions](#getbehaviordefinitionversions-high-level-common)
     - [GetBehaviorDefinitionVersionSource](#getbehaviordefinitionversionsource-high-level-common)
+    - [GetClassVersionDiff](#getclassversiondiff-high-level-common)
     - [GetClassVersions](#getclassversions-high-level-common)
     - [GetClassVersionSource](#getclassversionsource-high-level-common)
+    - [GetDataElementVersionDiff](#getdataelementversiondiff-high-level-common)
     - [GetDataElementVersions](#getdataelementversions-high-level-common)
     - [GetDataElementVersionSource](#getdataelementversionsource-high-level-common)
+    - [GetDdlVersionDiff](#getddlversiondiff-high-level-common)
     - [GetDdlVersions](#getddlversions-high-level-common)
     - [GetDdlVersionSource](#getddlversionsource-high-level-common)
+    - [GetDomainVersionDiff](#getdomainversiondiff-high-level-common)
     - [GetDomainVersions](#getdomainversions-high-level-common)
     - [GetDomainVersionSource](#getdomainversionsource-high-level-common)
+    - [GetFunctionGroupVersionDiff](#getfunctiongroupversiondiff-high-level-common)
     - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
     - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
+    - [GetFunctionModuleVersionDiff](#getfunctionmoduleversiondiff-high-level-common)
     - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
     - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
+    - [GetInterfaceVersionDiff](#getinterfaceversiondiff-high-level-common)
     - [GetInterfaceVersions](#getinterfaceversions-high-level-common)
     - [GetInterfaceVersionSource](#getinterfaceversionsource-high-level-common)
+    - [GetMetadataExtensionVersionDiff](#getmetadataextensionversiondiff-high-level-common)
     - [GetMetadataExtensionVersions](#getmetadataextensionversions-high-level-common)
     - [GetMetadataExtensionVersionSource](#getmetadataextensionversionsource-high-level-common)
+    - [GetPackageVersionDiff](#getpackageversiondiff-high-level-common)
     - [GetPackageVersions](#getpackageversions-high-level-common)
     - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
+    - [GetProgramVersionDiff](#getprogramversiondiff-high-level-common)
     - [GetProgramVersions](#getprogramversions-high-level-common)
     - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
+    - [GetStructureVersionDiff](#getstructureversiondiff-high-level-common)
     - [GetStructureVersions](#getstructureversions-high-level-common)
     - [GetStructureVersionSource](#getstructureversionsource-high-level-common)
+    - [GetTableVersionDiff](#gettableversiondiff-high-level-common)
     - [GetTableVersions](#gettableversions-high-level-common)
     - [GetTableVersionSource](#gettableversionsource-high-level-common)
   - [Compact](#high-level-compact)
@@ -566,6 +579,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getbehaviordefinitionversiondiff-high-level-common"></a>
+#### GetBehaviorDefinitionVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two RAP behavior definition versions, by their content_uris (taken from GetBehaviorDefinitionVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetBehaviorDefinitionVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetBehaviorDefinitionVersions entry).
+
+---
+
 <a id="getbehaviordefinitionversions-high-level-common"></a>
 #### GetBehaviorDefinitionVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a RAP behavior definition. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetBehaviorDefinitionVersionSource.
@@ -585,6 +610,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetBehaviorDefinitionVersions entry.
+
+---
+
+<a id="getclassversiondiff-high-level-common"></a>
+#### GetClassVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP class versions, by their content_uris (taken from GetClassVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetClassVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetClassVersions entry).
 
 ---
 
@@ -610,6 +647,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getdataelementversiondiff-high-level-common"></a>
+#### GetDataElementVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP data element versions, by their content_uris (taken from GetDataElementVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDataElementVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDataElementVersions entry).
+
+---
+
 <a id="getdataelementversions-high-level-common"></a>
 #### GetDataElementVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
@@ -629,6 +678,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetDataElementVersions entry.
+
+---
+
+<a id="getddlversiondiff-high-level-common"></a>
+#### GetDdlVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two CDS view (DDL source) versions, by their content_uris (taken from GetDdlVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDdlVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDdlVersions entry).
 
 ---
 
@@ -654,6 +715,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getdomainversiondiff-high-level-common"></a>
+#### GetDomainVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP domain versions, by their content_uris (taken from GetDomainVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDomainVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDomainVersions entry).
+
+---
+
 <a id="getdomainversions-high-level-common"></a>
 #### GetDomainVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
@@ -676,6 +749,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getfunctiongroupversiondiff-high-level-common"></a>
+#### GetFunctionGroupVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP function group versions, by their content_uris (taken from GetFunctionGroupVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionGroupVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionGroupVersions entry).
+
+---
+
 <a id="getfunctiongroupversions-high-level-common"></a>
 #### GetFunctionGroupVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
@@ -695,6 +780,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
+
+---
+
+<a id="getfunctionmoduleversiondiff-high-level-common"></a>
+#### GetFunctionModuleVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP function module versions, by their content_uris (taken from GetFunctionModuleVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionModuleVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionModuleVersions entry).
 
 ---
 
@@ -721,6 +818,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getinterfaceversiondiff-high-level-common"></a>
+#### GetInterfaceVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP interface versions, by their content_uris (taken from GetInterfaceVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetInterfaceVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetInterfaceVersions entry).
+
+---
+
 <a id="getinterfaceversions-high-level-common"></a>
 #### GetInterfaceVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
@@ -740,6 +849,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetInterfaceVersions entry.
+
+---
+
+<a id="getmetadataextensionversiondiff-high-level-common"></a>
+#### GetMetadataExtensionVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two CDS metadata extension versions, by their content_uris (taken from GetMetadataExtensionVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetMetadataExtensionVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetMetadataExtensionVersions entry).
 
 ---
 
@@ -765,6 +886,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getpackageversiondiff-high-level-common"></a>
+#### GetPackageVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP package versions, by their content_uris (taken from GetPackageVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetPackageVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetPackageVersions entry).
+
+---
+
 <a id="getpackageversions-high-level-common"></a>
 #### GetPackageVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
@@ -784,6 +917,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
+
+---
+
+<a id="getprogramversiondiff-high-level-common"></a>
+#### GetProgramVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP program versions, by their content_uris (taken from GetProgramVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetProgramVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetProgramVersions entry).
 
 ---
 
@@ -809,6 +954,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="getstructureversiondiff-high-level-common"></a>
+#### GetStructureVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP structure versions, by their content_uris (taken from GetStructureVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetStructureVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetStructureVersions entry).
+
+---
+
 <a id="getstructureversions-high-level-common"></a>
 #### GetStructureVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP structure. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetStructureVersionSource.
@@ -828,6 +985,18 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetStructureVersions entry.
+
+---
+
+<a id="gettableversiondiff-high-level-common"></a>
+#### GetTableVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP table versions, by their content_uris (taken from GetTableVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetTableVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetTableVersions entry).
 
 ---
 
@@ -2470,4 +2639,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-28*
+*Last updated: 2026-06-29*

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -5,9 +5,9 @@ Generated from code in `src/handlers/**` (not from docs).
 Tools available on legacy SAP systems (BASIS < 7.50).
 Legacy systems support a subset of tools — primarily Class, Interface, View, Program, Function Group/Module, Package (read/update/delete), Include, Unit Test, and common utilities.
 
-- Total tools: 157
-- Read-Only: 17
-- High-Level: 79
+- Total tools: 165
+- Read-Only: 18
+- High-Level: 86
 - Low-Level: 61
 
 ## Navigation
@@ -16,6 +16,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
   - [Class](#read-only-class)
     - [ReadClass](#readclass-read-only-class)
   - [Common](#read-only-common)
+    - [GetObjectVersionDiff](#getobjectversiondiff-read-only-common)
     - [GetObjectVersions](#getobjectversions-read-only-common)
     - [GetObjectVersionSource](#getobjectversionsource-read-only-common)
   - [Ddl](#read-only-ddl)
@@ -63,18 +64,25 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
     - [UpdateLocalTypes](#updatelocaltypes-high-level-class)
   - [Common](#high-level-common)
     - [ActivateObjects](#activateobjects-high-level-common)
+    - [GetClassVersionDiff](#getclassversiondiff-high-level-common)
     - [GetClassVersions](#getclassversions-high-level-common)
     - [GetClassVersionSource](#getclassversionsource-high-level-common)
+    - [GetDdlVersionDiff](#getddlversiondiff-high-level-common)
     - [GetDdlVersions](#getddlversions-high-level-common)
     - [GetDdlVersionSource](#getddlversionsource-high-level-common)
+    - [GetFunctionGroupVersionDiff](#getfunctiongroupversiondiff-high-level-common)
     - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
     - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
+    - [GetFunctionModuleVersionDiff](#getfunctionmoduleversiondiff-high-level-common)
     - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
     - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
+    - [GetInterfaceVersionDiff](#getinterfaceversiondiff-high-level-common)
     - [GetInterfaceVersions](#getinterfaceversions-high-level-common)
     - [GetInterfaceVersionSource](#getinterfaceversionsource-high-level-common)
+    - [GetPackageVersionDiff](#getpackageversiondiff-high-level-common)
     - [GetPackageVersions](#getpackageversions-high-level-common)
     - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
+    - [GetProgramVersionDiff](#getprogramversiondiff-high-level-common)
     - [GetProgramVersions](#getprogramversions-high-level-common)
     - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
   - [Compact](#high-level-compact)
@@ -228,6 +236,21 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="read-only-common"></a>
 ### Read-Only / Common
+
+<a id="getobjectversiondiff-read-only-common"></a>
+#### GetObjectVersionDiff (Read-Only / Common)
+**Description:** [read-only] Compute a unified diff between two object versions. Pass the two opaque content_uris from GetObjectVersions entries; returns the unified diff (jsdiff) of their sources.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersionDiff.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetObjectVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetObjectVersions entry).
+- `object_type` (string, required) - Object type (same value used in GetObjectVersions).
+
+---
 
 <a id="getobjectversions-read-only-common"></a>
 #### GetObjectVersions (Read-Only / Common)
@@ -768,6 +791,20 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
+<a id="getclassversiondiff-high-level-common"></a>
+#### GetClassVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP class versions, by their content_uris (taken from GetClassVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetClassVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetClassVersions entry).
+
+---
+
 <a id="getclassversions-high-level-common"></a>
 #### GetClassVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetClassVersionSource.
@@ -791,6 +828,20 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetClassVersions entry.
+
+---
+
+<a id="getddlversiondiff-high-level-common"></a>
+#### GetDdlVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two CDS view (DDL source) versions, by their content_uris (taken from GetDdlVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDdlVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDdlVersions entry).
 
 ---
 
@@ -820,6 +871,20 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
+<a id="getfunctiongroupversiondiff-high-level-common"></a>
+#### GetFunctionGroupVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP function group versions, by their content_uris (taken from GetFunctionGroupVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionGroupVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionGroupVersions entry).
+
+---
+
 <a id="getfunctiongroupversions-high-level-common"></a>
 #### GetFunctionGroupVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
@@ -843,6 +908,20 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
+
+---
+
+<a id="getfunctionmoduleversiondiff-high-level-common"></a>
+#### GetFunctionModuleVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP function module versions, by their content_uris (taken from GetFunctionModuleVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionModuleVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionModuleVersions entry).
 
 ---
 
@@ -873,6 +952,20 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
+<a id="getinterfaceversiondiff-high-level-common"></a>
+#### GetInterfaceVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP interface versions, by their content_uris (taken from GetInterfaceVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetInterfaceVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetInterfaceVersions entry).
+
+---
+
 <a id="getinterfaceversions-high-level-common"></a>
 #### GetInterfaceVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
@@ -899,6 +992,20 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
+<a id="getpackageversiondiff-high-level-common"></a>
+#### GetPackageVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP package versions, by their content_uris (taken from GetPackageVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `cloud`, `legacy`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetPackageVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetPackageVersions entry).
+
+---
+
 <a id="getpackageversions-high-level-common"></a>
 #### GetPackageVersions (High-Level / Common)
 **Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
@@ -922,6 +1029,20 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
+
+---
+
+<a id="getprogramversiondiff-high-level-common"></a>
+#### GetProgramVersionDiff (High-Level / Common)
+**Description:** [read-only] Compute a unified diff between two ABAP program versions, by their content_uris (taken from GetProgramVersions entries).
+
+**Source:** `src/handlers/common/high/objectVersionTools.ts`
+
+**Available in:** `onprem`, `legacy`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetProgramVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetProgramVersions entry).
 
 ---
 
@@ -2801,4 +2922,4 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
-*Last updated: 2026-06-28*
+*Last updated: 2026-06-29*

--- a/docs/user-guide/AVAILABLE_TOOLS_LOW.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LOW.md
@@ -1991,4 +1991,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-28*
+*Last updated: 2026-06-29*

--- a/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
@@ -3,7 +3,7 @@
 Generated from code in `src/handlers/**` (not from docs).
 
 - Level: Read-Only
-- Total tools: 61
+- Total tools: 62
 
 ## Navigation
 
@@ -15,6 +15,7 @@ Generated from code in `src/handlers/**` (not from docs).
   - [Class](#read-only-class)
     - [ReadClass](#readclass-read-only-class)
   - [Common](#read-only-common)
+    - [GetObjectVersionDiff](#getobjectversiondiff-read-only-common)
     - [GetObjectVersions](#getobjectversions-read-only-common)
     - [GetObjectVersionSource](#getobjectversionsource-read-only-common)
   - [Data Element](#read-only-data-element)
@@ -145,6 +146,19 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="read-only-common"></a>
 ### Read-Only / Common
+
+<a id="getobjectversiondiff-read-only-common"></a>
+#### GetObjectVersionDiff (Read-Only / Common)
+**Description:** [read-only] Compute a unified diff between two object versions. Pass the two opaque content_uris from GetObjectVersions entries; returns the unified diff (jsdiff) of their sources.
+
+**Source:** `src/handlers/common/readonly/handleGetObjectVersionDiff.ts`
+
+**Parameters:**
+- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetObjectVersions entry).
+- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetObjectVersions entry).
+- `object_type` (string, required) - Object type (same value used in GetObjectVersions).
+
+---
 
 <a id="getobjectversions-read-only-common"></a>
 #### GetObjectVersions (Read-Only / Common)
@@ -990,4 +1004,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-28*
+*Last updated: 2026-06-29*

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@mcp-abap-adt/logger": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.14.0",
+        "diff": "^5.2.2",
         "fast-xml-parser": "^5.5.10",
         "js-yaml": "^4.1.1",
         "pino": "^10.1.0",
@@ -32,6 +33,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
         "@modelcontextprotocol/inspector": "^0.21.1",
+        "@types/diff": "^5.2.3",
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.2",
@@ -6917,6 +6919,13 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "node_modules/@types/diff": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
+      "integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/jest": {
       "version": "30.0.0",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
@@ -8012,6 +8021,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotenv": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
     "@modelcontextprotocol/inspector": "^0.21.1",
+    "@types/diff": "^5.2.3",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.2",
@@ -147,6 +148,7 @@
     "@mcp-abap-adt/logger": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.14.0",
+    "diff": "^5.2.2",
     "fast-xml-parser": "^5.5.10",
     "js-yaml": "^4.1.1",
     "pino": "^10.1.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.3.0",
+  "version": "8.4.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/unit/objectVersionDiff.test.ts
+++ b/src/__tests__/unit/objectVersionDiff.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests (#30): version-diff tools.
+ *  - generic GetObjectVersionDiff fetches BOTH content_uris via getVersionSource
+ *    and returns a unified diff with changed lines + identical:false when the
+ *    sources differ, identical:true when equal;
+ *  - per-object GetClassVersionDiff is registered in the HighLevel group with the
+ *    right available_in and forwards both content_uris;
+ *  - an unknown object_type returns an error.
+ * SAP-free via a mocked AdtClient.
+ */
+
+const mockClassGetVersionSource = jest.fn();
+const mockGetClass = jest.fn();
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getClass: mockGetClass,
+  }),
+}));
+
+import { buildObjectVersionTools } from '../../handlers/common/high/objectVersionTools';
+import { handleGetObjectVersionDiff } from '../../handlers/common/readonly/handleGetObjectVersionDiff';
+import { HighLevelHandlersGroup } from '../../lib/handlers/groups/HighLevelHandlersGroup';
+
+const ctx = { connection: {}, logger: undefined } as any;
+
+function payload(result: any) {
+  const text =
+    (result.content.find((c: any) => c.type === 'text') as any)?.text || '';
+  return JSON.parse(text);
+}
+
+function tool(name: string) {
+  const entry = buildObjectVersionTools().find(
+    (e) => e.toolDefinition.name === name,
+  );
+  if (!entry) throw new Error(`tool ${name} not found`);
+  return entry;
+}
+
+beforeEach(() => {
+  mockClassGetVersionSource.mockReset();
+  mockGetClass.mockReset();
+  mockGetClass.mockReturnValue({ getVersionSource: mockClassGetVersionSource });
+});
+
+describe('version diff tools (#30)', () => {
+  it('generic GetObjectVersionDiff fetches both uris and reports differences', async () => {
+    mockClassGetVersionSource
+      .mockResolvedValueOnce('line one\nold middle\nline three\n')
+      .mockResolvedValueOnce('line one\nnew middle\nline three\n');
+
+    const result = await handleGetObjectVersionDiff(ctx, {
+      object_type: 'class',
+      content_uri_from:
+        '/sap/bc/adt/oo/classes/zcl_x/source/main?version=00001',
+      content_uri_to: '/sap/bc/adt/oo/classes/zcl_x/source/main?version=00002',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockClassGetVersionSource).toHaveBeenCalledTimes(2);
+    expect(mockClassGetVersionSource).toHaveBeenNthCalledWith(
+      1,
+      '/sap/bc/adt/oo/classes/zcl_x/source/main?version=00001',
+    );
+    expect(mockClassGetVersionSource).toHaveBeenNthCalledWith(
+      2,
+      '/sap/bc/adt/oo/classes/zcl_x/source/main?version=00002',
+    );
+
+    const data = payload(result);
+    expect(data.success).toBe(true);
+    expect(data.object_type).toBe('class');
+    expect(data.identical).toBe(false);
+    expect(data.diff).toContain('-old middle');
+    expect(data.diff).toContain('+new middle');
+  });
+
+  it('generic GetObjectVersionDiff reports identical:true for equal sources', async () => {
+    mockClassGetVersionSource.mockResolvedValue('same\nsource\n');
+
+    const result = await handleGetObjectVersionDiff(ctx, {
+      object_type: 'class',
+      content_uri_from: '/x?version=00001',
+      content_uri_to: '/x?version=00002',
+    });
+
+    expect(result.isError).toBe(false);
+    const data = payload(result);
+    expect(data.identical).toBe(true);
+  });
+
+  it('returns an error for an unknown object_type', async () => {
+    const result = await handleGetObjectVersionDiff(ctx, {
+      object_type: 'nonsense',
+      content_uri_from: '/x?version=00001',
+      content_uri_to: '/x?version=00002',
+    });
+    expect(result.isError).toBe(true);
+    expect(mockClassGetVersionSource).not.toHaveBeenCalled();
+  });
+
+  it('per-object GetClassVersionDiff forwards both content_uris', async () => {
+    mockClassGetVersionSource
+      .mockResolvedValueOnce('a\n')
+      .mockResolvedValueOnce('b\n');
+
+    const result = await tool('GetClassVersionDiff').handler(ctx, {
+      content_uri_from: '/cls?version=00001',
+      content_uri_to: '/cls?version=00002',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockClassGetVersionSource).toHaveBeenNthCalledWith(
+      1,
+      '/cls?version=00001',
+    );
+    expect(mockClassGetVersionSource).toHaveBeenNthCalledWith(
+      2,
+      '/cls?version=00002',
+    );
+    const data = payload(result);
+    expect(data.identical).toBe(false);
+    expect(data.object_type).toBe('class');
+  });
+
+  it('GetClassVersionDiff errors without both content_uris', async () => {
+    const result = await tool('GetClassVersionDiff').handler(ctx, {
+      content_uri_from: '/cls?version=00001',
+    });
+    expect(result.isError).toBe(true);
+    expect(mockClassGetVersionSource).not.toHaveBeenCalled();
+  });
+
+  it('the factory builds 13 VersionDiff tools (39 total) and they register in High', () => {
+    const names = buildObjectVersionTools().map((e) => e.toolDefinition.name);
+    const diffNames = names.filter((n) => n.endsWith('VersionDiff'));
+    expect(diffNames.length).toBe(13);
+    expect(names.length).toBe(39);
+
+    const group = new HighLevelHandlersGroup({
+      connection: {},
+      logger: undefined,
+    } as any);
+    const registered = group.getHandlers().map((e) => e.toolDefinition.name);
+    for (const n of diffNames) {
+      expect(registered).toContain(n);
+    }
+    // class diff mirrors GetClass available_in
+    expect(tool('GetClassVersionDiff').toolDefinition.available_in).toEqual([
+      'onprem',
+      'cloud',
+      'legacy',
+    ]);
+    // program diff is onprem/legacy-gated (mirrors GetProgram)
+    expect(tool('GetProgramVersionDiff').toolDefinition.available_in).toEqual([
+      'onprem',
+      'legacy',
+    ]);
+  });
+});

--- a/src/__tests__/unit/objectVersionDiff.test.ts
+++ b/src/__tests__/unit/objectVersionDiff.test.ts
@@ -18,6 +18,7 @@ jest.mock('../../lib/clients', () => ({
   }),
 }));
 
+import { AdtObjectErrorCodes } from '@mcp-abap-adt/interfaces';
 import { buildObjectVersionTools } from '../../handlers/common/high/objectVersionTools';
 import { handleGetObjectVersionDiff } from '../../handlers/common/readonly/handleGetObjectVersionDiff';
 import { HighLevelHandlersGroup } from '../../lib/handlers/groups/HighLevelHandlersGroup';
@@ -130,6 +131,46 @@ describe('version diff tools (#30)', () => {
     });
     expect(result.isError).toBe(true);
     expect(mockClassGetVersionSource).not.toHaveBeenCalled();
+  });
+
+  it('generic GetObjectVersionDiff returns clean error on UNSUPPORTED_OPERATION', async () => {
+    const err = Object.assign(new Error('version diff not available'), {
+      code: AdtObjectErrorCodes.UNSUPPORTED_OPERATION,
+    });
+    mockClassGetVersionSource.mockRejectedValue(err);
+
+    const result = await handleGetObjectVersionDiff(ctx, {
+      object_type: 'class',
+      content_uri_from:
+        '/sap/bc/adt/oo/classes/zcl_x/source/main?version=00001',
+      content_uri_to: '/sap/bc/adt/oo/classes/zcl_x/source/main?version=00002',
+    });
+
+    expect(result.isError).toBe(true);
+    const errText =
+      (result.content.find((c: any) => c.type === 'text') as any)?.text || '';
+    expect(errText).toContain('not supported');
+    expect(errText).not.toContain('stack');
+    expect(errText).not.toContain('ADT_UNSUPPORTED_OPERATION');
+  });
+
+  it('per-object GetClassVersionDiff returns clean error on UNSUPPORTED_OPERATION', async () => {
+    const err = Object.assign(new Error('version diff not available'), {
+      code: AdtObjectErrorCodes.UNSUPPORTED_OPERATION,
+    });
+    mockClassGetVersionSource.mockRejectedValue(err);
+
+    const result = await tool('GetClassVersionDiff').handler(ctx, {
+      content_uri_from: '/cls?version=00001',
+      content_uri_to: '/cls?version=00002',
+    });
+
+    expect(result.isError).toBe(true);
+    const errText =
+      (result.content.find((c: any) => c.type === 'text') as any)?.text || '';
+    expect(errText).toContain('not supported');
+    expect(errText).not.toContain('stack');
+    expect(errText).not.toContain('ADT_UNSUPPORTED_OPERATION');
   });
 
   it('the factory builds 13 VersionDiff tools (39 total) and they register in High', () => {

--- a/src/__tests__/unit/objectVersionToolsHigh.test.ts
+++ b/src/__tests__/unit/objectVersionToolsHigh.test.ts
@@ -120,7 +120,7 @@ describe('per-object high-level version tools (#30)', () => {
     expect(data.source).toBe('DEFINE TABLE zmy_table.');
   });
 
-  it('registers all 26 expected tool names', () => {
+  it('registers all 39 expected tool names', () => {
     const names = buildObjectVersionTools().map((e) => e.toolDefinition.name);
     const displays = [
       'Class',
@@ -140,12 +140,13 @@ describe('per-object high-level version tools (#30)', () => {
     const expected = displays.flatMap((d) => [
       `Get${d}Versions`,
       `Get${d}VersionSource`,
+      `Get${d}VersionDiff`,
     ]);
     expect(names.sort()).toEqual(expected.sort());
-    expect(new Set(names).size).toBe(26);
+    expect(new Set(names).size).toBe(39);
   });
 
-  it('the registered HighLevel group contains all 26 version tools (no dups)', () => {
+  it('the registered HighLevel group contains all 39 version tools (no dups)', () => {
     const group = new HighLevelHandlersGroup({
       connection: {},
       logger: undefined,

--- a/src/handlers/common/high/objectVersionTools.ts
+++ b/src/handlers/common/high/objectVersionTools.ts
@@ -27,6 +27,7 @@ import {
   return_error,
   return_response,
 } from '../../../lib/utils';
+import { buildVersionDiff } from '../readonly/handleGetObjectVersionDiff';
 import { resolveVersionedObject } from '../readonly/resolveVersionedObject';
 
 /** Handler signature before context injection (the group wraps with withContext). */
@@ -305,16 +306,105 @@ function buildVersionSourceTool(row: VersionedTypeRow): ObjectVersionToolEntry {
   return { toolDefinition, handler };
 }
 
+function buildVersionDiffTool(row: VersionedTypeRow): ObjectVersionToolEntry {
+  const toolDefinition: ToolDefinition = {
+    name: `Get${row.display}VersionDiff`,
+    ...(row.available_in ? { available_in: row.available_in } : {}),
+    description: `[read-only] Compute a unified diff between two ${row.label} versions, by their content_uris (taken from Get${row.display}Versions entries).`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        content_uri_from: {
+          type: 'string',
+          description: `Opaque content_uri of the OLD/base version (from a Get${row.display}Versions entry).`,
+        },
+        content_uri_to: {
+          type: 'string',
+          description: `Opaque content_uri of the NEW/compare version (from a Get${row.display}Versions entry).`,
+        },
+      },
+      required: ['content_uri_from', 'content_uri_to'],
+    },
+  };
+
+  const handler: RawHandler = async (context, args) => {
+    const { connection, logger } = context;
+    try {
+      const content_uri_from = args?.content_uri_from;
+      const content_uri_to = args?.content_uri_to;
+      if (!content_uri_from || !content_uri_to) {
+        return return_error(
+          new Error('content_uri_from and content_uri_to are required'),
+        );
+      }
+
+      const client = createAdtClient(connection, logger);
+      // content_uri carries the full object identity; a placeholder name is only
+      // needed to obtain the right IAdtObject instance.
+      const resolved = resolveVersionedObject(
+        client,
+        row.object_type,
+        'X',
+        'X',
+      );
+      if (!resolved) {
+        return return_error(
+          new Error(`Unsupported object_type: ${row.object_type}`),
+        );
+      }
+
+      try {
+        const { diff, identical, notes } = await buildVersionDiff(
+          resolved.obj,
+          String(content_uri_from),
+          String(content_uri_to),
+        );
+        return return_response({
+          data: JSON.stringify(
+            {
+              success: true,
+              object_type: row.object_type,
+              content_uri_from,
+              content_uri_to,
+              identical,
+              diff,
+              ...(notes ? { notes } : {}),
+            },
+            null,
+            2,
+          ),
+        } as AxiosResponse);
+      } catch (error: any) {
+        if (error?.code === AdtObjectErrorCodes.UNSUPPORTED_OPERATION) {
+          return return_error(
+            new Error(
+              `Version diff is not supported for object_type '${row.object_type}'.`,
+            ),
+          );
+        }
+        return return_error(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    } catch (error: any) {
+      return return_error(error);
+    }
+  };
+
+  return { toolDefinition, handler };
+}
+
 /**
- * Build all 26 high-level per-object version tools (13 types ×
- * {Versions, VersionSource}). The handlers take (context, args); the registering
- * group wraps each with withContext.
+ * Build all 39 high-level per-object version tools (13 types ×
+ * {Versions, VersionSource, VersionDiff}). The handlers take (context, args);
+ * the registering group wraps each with withContext.
  */
 export function buildObjectVersionTools(): ObjectVersionToolEntry[] {
   const entries: ObjectVersionToolEntry[] = [];
   for (const row of VERSIONED_TYPES) {
     entries.push(buildVersionsTool(row));
     entries.push(buildVersionSourceTool(row));
+    entries.push(buildVersionDiffTool(row));
   }
   return entries;
 }

--- a/src/handlers/common/readonly/handleGetObjectVersionDiff.ts
+++ b/src/handlers/common/readonly/handleGetObjectVersionDiff.ts
@@ -1,0 +1,178 @@
+/**
+ * GetObjectVersionDiff Handler - read-only unified diff between two versions.
+ *
+ * Takes two opaque content_uris (from GetObjectVersions entries) plus the
+ * object_type (needed to obtain an IAdtObject instance), fetches both sources
+ * via getVersionSource and returns a unified diff computed with jsdiff's
+ * createTwoFilesPatch. Closes #30.
+ */
+
+import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import { AdtObjectErrorCodes } from '@mcp-abap-adt/interfaces';
+import { createTwoFilesPatch } from 'diff';
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+import {
+  resolveVersionedObject,
+  VERSIONED_OBJECT_TYPES,
+} from './resolveVersionedObject';
+
+export interface VersionDiffResult {
+  diff: string;
+  identical: boolean;
+  /** Non-fatal notes (e.g. a source came back undefined → treated as empty). */
+  notes?: string[];
+}
+
+/**
+ * Shared "fetch two sources + unified patch" logic reused by the generic
+ * GetObjectVersionDiff and every per-object Get<X>VersionDiff factory tool.
+ * Guards against undefined sources by treating them as empty strings.
+ */
+export async function buildVersionDiff(
+  obj: IAdtObject<any, any>,
+  contentUriFrom: string,
+  contentUriTo: string,
+): Promise<VersionDiffResult> {
+  const [rawFrom, rawTo] = await Promise.all([
+    obj.getVersionSource(contentUriFrom),
+    obj.getVersionSource(contentUriTo),
+  ]);
+
+  const notes: string[] = [];
+  if (rawFrom == null) {
+    notes.push(`Source for content_uri_from was empty/undefined.`);
+  }
+  if (rawTo == null) {
+    notes.push(`Source for content_uri_to was empty/undefined.`);
+  }
+
+  const srcFrom = rawFrom ?? '';
+  const srcTo = rawTo ?? '';
+  const diff = createTwoFilesPatch(
+    contentUriFrom,
+    contentUriTo,
+    srcFrom,
+    srcTo,
+    '',
+    '',
+    { context: 3 },
+  );
+
+  return {
+    diff,
+    identical: srcFrom === srcTo,
+    ...(notes.length ? { notes } : {}),
+  };
+}
+
+export const TOOL_DEFINITION = {
+  name: 'GetObjectVersionDiff',
+  available_in: ['onprem', 'cloud', 'legacy'] as const,
+  description:
+    '[read-only] Compute a unified diff between two object versions. Pass the two opaque content_uris from GetObjectVersions entries; returns the unified diff (jsdiff) of their sources.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      object_type: {
+        type: 'string',
+        description: 'Object type (same value used in GetObjectVersions).',
+        enum: [...VERSIONED_OBJECT_TYPES],
+      },
+      content_uri_from: {
+        type: 'string',
+        description:
+          'Opaque content_uri of the OLD/base version (from a GetObjectVersions entry).',
+      },
+      content_uri_to: {
+        type: 'string',
+        description:
+          'Opaque content_uri of the NEW/compare version (from a GetObjectVersions entry).',
+      },
+    },
+    required: ['object_type', 'content_uri_from', 'content_uri_to'],
+  },
+} as const;
+
+interface GetObjectVersionDiffArgs {
+  object_type: string;
+  content_uri_from: string;
+  content_uri_to: string;
+}
+
+export async function handleGetObjectVersionDiff(
+  context: HandlerContext,
+  args: GetObjectVersionDiffArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const { content_uri_from, content_uri_to } = args;
+    const object_type = (args.object_type || '').toLowerCase();
+
+    if (!object_type || !content_uri_from || !content_uri_to) {
+      return return_error(
+        new Error(
+          'object_type, content_uri_from and content_uri_to are required',
+        ),
+      );
+    }
+    if (!VERSIONED_OBJECT_TYPES.includes(object_type as any)) {
+      return return_error(
+        new Error(
+          `Invalid object_type. Must be one of: ${VERSIONED_OBJECT_TYPES.join(', ')}`,
+        ),
+      );
+    }
+
+    const client = createAdtClient(connection, logger);
+    // object_type only selects the client; each content_uri carries the full
+    // object identity (same placeholder pattern as GetObjectVersionSource).
+    const resolved = resolveVersionedObject(client, object_type, 'X', 'X');
+    if (!resolved) {
+      return return_error(
+        new Error(`Unsupported object_type: ${args.object_type}`),
+      );
+    }
+
+    try {
+      const { diff, identical, notes } = await buildVersionDiff(
+        resolved.obj,
+        content_uri_from,
+        content_uri_to,
+      );
+      return return_response({
+        data: JSON.stringify(
+          {
+            success: true,
+            object_type,
+            content_uri_from,
+            content_uri_to,
+            identical,
+            diff,
+            ...(notes ? { notes } : {}),
+          },
+          null,
+          2,
+        ),
+      } as AxiosResponse);
+    } catch (error: any) {
+      if (error?.code === AdtObjectErrorCodes.UNSUPPORTED_OPERATION) {
+        return return_error(
+          new Error(
+            `Version diff is not supported for object_type '${object_type}'.`,
+          ),
+        );
+      }
+      return return_error(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/lib/handlers/groups/ReadOnlyHandlersGroup.ts
+++ b/src/lib/handlers/groups/ReadOnlyHandlersGroup.ts
@@ -11,6 +11,10 @@ import {
   TOOL_DEFINITION as ReadClass_Tool,
 } from '../../../handlers/class/readonly/handleReadClass';
 import {
+  TOOL_DEFINITION as GetObjectVersionDiff_Tool,
+  handleGetObjectVersionDiff,
+} from '../../../handlers/common/readonly/handleGetObjectVersionDiff';
+import {
   TOOL_DEFINITION as GetObjectVersionSource_Tool,
   handleGetObjectVersionSource,
 } from '../../../handlers/common/readonly/handleGetObjectVersionSource';
@@ -235,6 +239,10 @@ export class ReadOnlyHandlersGroup extends BaseHandlerGroup {
         toolDefinition: GetObjectVersionSource_Tool,
         handler: (args: any) =>
           handleGetObjectVersionSource(this.context, args),
+      },
+      {
+        toolDefinition: GetObjectVersionDiff_Tool,
+        handler: (args: any) => handleGetObjectVersionDiff(this.context, args),
       },
       {
         toolDefinition: ReadDdl_Tool,

--- a/tools/generate-tools-docs.js
+++ b/tools/generate-tools-docs.js
@@ -511,6 +511,29 @@ function loadObjectVersionTools() {
       level: 'high',
       filePath: 'src/handlers/common/high/objectVersionTools.ts',
     });
+    tools.push({
+      name: `Get${display}VersionDiff`,
+      description: `[read-only] Compute a unified diff between two ${label} versions, by their content_uris (taken from Get${display}Versions entries).`,
+      inputSchema: {
+        properties: {
+          content_uri_from: {
+            type: 'string',
+            description: `Opaque content_uri of the OLD/base version (from a Get${display}Versions entry).`,
+          },
+          content_uri_to: {
+            type: 'string',
+            description: `Opaque content_uri of the NEW/compare version (from a Get${display}Versions entry).`,
+          },
+        },
+        required: ['content_uri_from', 'content_uri_to'],
+      },
+      inputSchemaRef: null,
+      availableIn,
+      objectFolder: 'common',
+      objectTitle: titleCaseFolder('common'),
+      level: 'high',
+      filePath: 'src/handlers/common/high/objectVersionTools.ts',
+    });
     m = rowRegex.exec(content);
   }
   return tools;


### PR DESCRIPTION
Completes #30 (2b — diff between two versions).

## What
- **`GetObjectVersionDiff`** (generic, ReadOnly) — `object_type` + `content_uri_from` + `content_uri_to`.
- **`Get<Object>VersionDiff`** (per-object, HighLevel, 13 types: `GetClassVersionDiff`, `GetProgramVersionDiff`, …) — `content_uri_from` + `content_uri_to` (object_type fixed).
- Each fetches both version sources via `getVersionSource` and returns a **unified diff** (jsdiff `createTwoFilesPatch`, 3 lines context). Response: `{ success, …, identical, diff }`.
- Mirrors the version-history design: generic in ReadOnly (analytics), per-object in HighLevel (development). Per-object `available_in` copied from each `Get<X>`. The shared `buildVersionDiff` helper is reused by both paths (no duplication).
- Unsupported object types → clean `UNSUPPORTED_OPERATION` error, never raw HTTP.

## Deps
- Adds `diff` (jsdiff) `^5.2.2` as a **runtime** dependency and `@types/diff` as dev. jsdiff is zero-dependency, MIT, the de-facto unified-diff library.

## Verification
- `npm run build`, `npm run test:check` — green. `objectVersionDiff.test.ts` (8 cases): both sources fetched, diff content present, `identical` true/false, per-object diff registered with correct `available_in`, and the `UNSUPPORTED_OPERATION` path (generic + per-object).
- Reviewer: Spec ✅ / Approved.
- Docs regenerated (generator extended for the factory diff tools, mirroring the existing precedent).

## #30 status after this
Object history is complete: list versions (8.2.0) → per-object high-level (8.3.0) → diff two versions (this). "Transport requests from an object" (2.1) is approximated by the version history (`IObjectVersion` has versionId/author/updatedAt, no explicit TR field).

Minor bump **8.3.0 → 8.4.0** (additive tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)