### PR TITLE
feat(history): transport request per version + adt-clients 7.2.0 (8.5.0, #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [8.5.0] - 2026-06-30
+
+### Added
+- **Version history now surfaces the transport request (#30).** `GetObjectVersions` / `Get<Object>Versions` now include `transportRequest` (e.g. `DS4K901917`) and `transportDescription` per version when the SAP version feed carries them — so an agent can map an object's versions to the transports that produced them, which is the "transports of an object" piece of #30. Comes from `@mcp-abap-adt/adt-clients` 7.2.0; no tool/argument change (the new fields are additive on each version entry).
+
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^7.2.0` and `@mcp-abap-adt/interfaces@^9.1.0`** (from `^7.1.0` / `^9.0.0`). 7.2.0 parses the per-version transport-request link into the new optional `IObjectVersion.transportRequest`/`transportDescription` (requires interfaces ^9.1.0). Non-breaking.
+
 ## [8.4.0] - 2026-06-29
 
 ### Added

--- a/docs/user-guide/AVAILABLE_TOOLS.md
+++ b/docs/user-guide/AVAILABLE_TOOLS.md
@@ -513,7 +513,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getobjectversions-read-only-common"></a>
 #### GetObjectVersions (Read-Only / Common)
-**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version source via GetObjectVersionSource.
+**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version source via GetObjectVersionSource.
 
 **Source:** `src/handlers/common/readonly/handleGetObjectVersions.ts`
 
@@ -5628,4 +5628,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-29*
+*Last updated: 2026-06-30*

--- a/docs/user-guide/AVAILABLE_TOOLS.md
+++ b/docs/user-guide/AVAILABLE_TOOLS.md
@@ -1744,7 +1744,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getbehaviordefinitionversions-high-level-common"></a>
 #### GetBehaviorDefinitionVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a RAP behavior definition. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetBehaviorDefinitionVersionSource.
+**Description:** [read-only] List the SAP version history of a RAP behavior definition. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetBehaviorDefinitionVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1778,7 +1778,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getclassversions-high-level-common"></a>
 #### GetClassVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetClassVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetClassVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1812,7 +1812,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getdataelementversions-high-level-common"></a>
 #### GetDataElementVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1846,7 +1846,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getddlversions-high-level-common"></a>
 #### GetDdlVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
+**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1880,7 +1880,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getdomainversions-high-level-common"></a>
 #### GetDomainVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1914,7 +1914,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getfunctiongroupversions-high-level-common"></a>
 #### GetFunctionGroupVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1948,7 +1948,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getfunctionmoduleversions-high-level-common"></a>
 #### GetFunctionModuleVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1983,7 +1983,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getinterfaceversions-high-level-common"></a>
 #### GetInterfaceVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -2017,7 +2017,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getmetadataextensionversions-high-level-common"></a>
 #### GetMetadataExtensionVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a CDS metadata extension. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetMetadataExtensionVersionSource.
+**Description:** [read-only] List the SAP version history of a CDS metadata extension. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetMetadataExtensionVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -2051,7 +2051,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getpackageversions-high-level-common"></a>
 #### GetPackageVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -2085,7 +2085,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getprogramversions-high-level-common"></a>
 #### GetProgramVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -2119,7 +2119,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getstructureversions-high-level-common"></a>
 #### GetStructureVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP structure. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetStructureVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP structure. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetStructureVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -2153,7 +2153,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="gettableversions-high-level-common"></a>
 #### GetTableVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP table. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetTableVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP table. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetTableVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 

--- a/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
@@ -596,4 +596,4 @@ Preferred dedicated compact tools and minimal payloads:
 
 ---
 
-*Last updated: 2026-06-29*
+*Last updated: 2026-06-30*

--- a/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
@@ -593,7 +593,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getbehaviordefinitionversions-high-level-common"></a>
 #### GetBehaviorDefinitionVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a RAP behavior definition. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetBehaviorDefinitionVersionSource.
+**Description:** [read-only] List the SAP version history of a RAP behavior definition. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetBehaviorDefinitionVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -627,7 +627,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getclassversions-high-level-common"></a>
 #### GetClassVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetClassVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetClassVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -661,7 +661,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getdataelementversions-high-level-common"></a>
 #### GetDataElementVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -695,7 +695,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getddlversions-high-level-common"></a>
 #### GetDdlVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
+**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -729,7 +729,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getdomainversions-high-level-common"></a>
 #### GetDomainVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -763,7 +763,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getfunctiongroupversions-high-level-common"></a>
 #### GetFunctionGroupVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -797,7 +797,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getfunctionmoduleversions-high-level-common"></a>
 #### GetFunctionModuleVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -832,7 +832,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getinterfaceversions-high-level-common"></a>
 #### GetInterfaceVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -866,7 +866,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getmetadataextensionversions-high-level-common"></a>
 #### GetMetadataExtensionVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a CDS metadata extension. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetMetadataExtensionVersionSource.
+**Description:** [read-only] List the SAP version history of a CDS metadata extension. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetMetadataExtensionVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -900,7 +900,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getpackageversions-high-level-common"></a>
 #### GetPackageVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -934,7 +934,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getprogramversions-high-level-common"></a>
 #### GetProgramVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -968,7 +968,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getstructureversions-high-level-common"></a>
 #### GetStructureVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP structure. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetStructureVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP structure. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetStructureVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1002,7 +1002,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="gettableversions-high-level-common"></a>
 #### GetTableVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP table. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetTableVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP table. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetTableVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 

--- a/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
@@ -2639,4 +2639,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-29*
+*Last updated: 2026-06-30*

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -807,7 +807,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="getclassversions-high-level-common"></a>
 #### GetClassVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetClassVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP class. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetClassVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -847,7 +847,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="getddlversions-high-level-common"></a>
 #### GetDdlVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
+**Description:** [read-only] List the SAP version history of a CDS view (DDL source). Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDdlVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -887,7 +887,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="getfunctiongroupversions-high-level-common"></a>
 #### GetFunctionGroupVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -927,7 +927,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="getfunctionmoduleversions-high-level-common"></a>
 #### GetFunctionModuleVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP function module. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionModuleVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -968,7 +968,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="getinterfaceversions-high-level-common"></a>
 #### GetInterfaceVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP interface. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetInterfaceVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1008,7 +1008,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="getpackageversions-high-level-common"></a>
 #### GetPackageVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 
@@ -1048,7 +1048,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="getprogramversions-high-level-common"></a>
 #### GetProgramVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
+**Description:** [read-only] List the SAP version history of a ABAP program. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetProgramVersionSource.
 
 **Source:** `src/handlers/common/high/objectVersionTools.ts`
 

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -254,7 +254,7 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 <a id="getobjectversions-read-only-common"></a>
 #### GetObjectVersions (Read-Only / Common)
-**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version source via GetObjectVersionSource.
+**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version source via GetObjectVersionSource.
 
 **Source:** `src/handlers/common/readonly/handleGetObjectVersions.ts`
 
@@ -2922,4 +2922,4 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
-*Last updated: 2026-06-29*
+*Last updated: 2026-06-30*

--- a/docs/user-guide/AVAILABLE_TOOLS_LOW.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LOW.md
@@ -1991,4 +1991,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-29*
+*Last updated: 2026-06-30*

--- a/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
@@ -162,7 +162,7 @@ Generated from code in `src/handlers/**` (not from docs).
 
 <a id="getobjectversions-read-only-common"></a>
 #### GetObjectVersions (Read-Only / Common)
-**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version source via GetObjectVersionSource.
+**Description:** [read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version source via GetObjectVersionSource.
 
 **Source:** `src/handlers/common/readonly/handleGetObjectVersions.ts`
 
@@ -1004,4 +1004,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-29*
+*Last updated: 2026-06-30*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^7.1.0",
+        "@mcp-abap-adt/adt-clients": "^7.2.0",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
         "@mcp-abap-adt/connection": "^1.9.1",
         "@mcp-abap-adt/header-validator": "^0.1.8",
-        "@mcp-abap-adt/interfaces": "^9.0.0",
+        "@mcp-abap-adt/interfaces": "^9.1.0",
         "@mcp-abap-adt/logger": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.14.0",
@@ -227,12 +227,12 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.1.0.tgz",
-      "integrity": "sha512-+Zii+p6FPudDQQD0SWzgKBaS4DDaAAZiOHrP/tHadh1hBtvGQ9gJBkCnVrnEp0DG+boH+r35n7cFOfv4mNHJ/g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.2.0.tgz",
+      "integrity": "sha512-R773O8WhnBRptyugNrsVMU0VCXxbg4eNZRuFjo0dLJj/BCU2YmKo3jOKafXatlpZNWdccUasMTgXJi4wJARjQg==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^9.0.0",
+        "@mcp-abap-adt/interfaces": "^9.1.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.13.6",
         "fast-xml-parser": "^5.4.1"
@@ -920,9 +920,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.0.0.tgz",
-      "integrity": "sha512-jXRdXIMFnXfkK8mTARUEc7HMiQezesnGo9PxKMtF/mc98PdsPCYMxGEJXXrnyRLqErelfElJx3E6b1JhWs7rpA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.1.0.tgz",
+      "integrity": "sha512-AgrSEk7RK38s8R8PSRwOBynGEs7Rg4rYBkZ/F9i5gveWmV2bZ4BAc/+d7mAytyR/hkrngssjsXc1GJslbyN+mA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -138,13 +138,13 @@
     "yaml": "^2.8.1"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^7.1.0",
+    "@mcp-abap-adt/adt-clients": "^7.2.0",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",
     "@mcp-abap-adt/connection": "^1.9.1",
     "@mcp-abap-adt/header-validator": "^0.1.8",
-    "@mcp-abap-adt/interfaces": "^9.0.0",
+    "@mcp-abap-adt/interfaces": "^9.1.0",
     "@mcp-abap-adt/logger": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.14.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.4.0",
+  "version": "8.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/unit/handleObjectVersions.test.ts
+++ b/src/__tests__/unit/handleObjectVersions.test.ts
@@ -77,6 +77,31 @@ describe('GetObjectVersions / GetObjectVersionSource (#30)', () => {
     expect(data.versions).toEqual(versions);
   });
 
+  it('passes through transportRequest/transportDescription per version (adt-clients 7.2.0)', async () => {
+    const versions = [
+      {
+        versionId: '00002',
+        author: 'DEV',
+        updatedAt: '2026-06-30T00:00:00Z',
+        title: 'Version List',
+        transportRequest: 'DS4K901917',
+        transportDescription: 'My change',
+        contentUri: '/sap/bc/adt/...;version=00002',
+      },
+    ];
+    mockClassGetVersions.mockResolvedValue(versions);
+
+    const result = await handleGetObjectVersions(ctx, {
+      object_type: 'class',
+      object_name: 'zcl_my_class',
+    });
+
+    expect(result.isError).toBe(false);
+    const v = payload(result).versions[0];
+    expect(v.transportRequest).toBe('DS4K901917');
+    expect(v.transportDescription).toBe('My change');
+  });
+
   it('dispatches a table to getTable().getVersions with tableName', async () => {
     mockTableGetVersions.mockResolvedValue([]);
 

--- a/src/handlers/common/high/objectVersionTools.ts
+++ b/src/handlers/common/high/objectVersionTools.ts
@@ -169,7 +169,7 @@ function buildVersionsTool(row: VersionedTypeRow): ObjectVersionToolEntry {
   const toolDefinition: ToolDefinition = {
     name: `Get${row.display}Versions`,
     ...(row.available_in ? { available_in: row.available_in } : {}),
-    description: `[read-only] List the SAP version history of a ${row.label}. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via Get${row.display}VersionSource.`,
+    description: `[read-only] List the SAP version history of a ${row.label}. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via Get${row.display}VersionSource.`,
     inputSchema: {
       type: 'object',
       properties,

--- a/src/handlers/common/readonly/handleGetObjectVersions.ts
+++ b/src/handlers/common/readonly/handleGetObjectVersions.ts
@@ -23,7 +23,7 @@ export const TOOL_DEFINITION = {
   name: 'GetObjectVersions',
   available_in: ['onprem', 'cloud', 'legacy'] as const,
   description:
-    '[read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version source via GetObjectVersionSource.',
+    '[read-only] List the version history of an ABAP object. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version source via GetObjectVersionSource.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/tools/generate-tools-docs.js
+++ b/tools/generate-tools-docs.js
@@ -483,7 +483,7 @@ function loadObjectVersionTools() {
 
     tools.push({
       name: `Get${display}Versions`,
-      description: `[read-only] List the SAP version history of a ${label}. Returns each version with its versionId, author, updatedAt, title and an opaque content_uri to fetch that version's source via Get${display}VersionSource.`,
+      description: `[read-only] List the SAP version history of a ${label}. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via Get${display}VersionSource.`,
       inputSchema: { properties: versionsProps, required: versionsRequired },
       inputSchemaRef: null,
       availableIn,


### PR DESCRIPTION
Closes the last open piece of #30 — "the transport requests of an object".

## What
- Migrate `@mcp-abap-adt/adt-clients` `^7.1.0` → **`^7.2.0`** and `@mcp-abap-adt/interfaces` `^9.0.0` → **`^9.1.0`**. 7.2.0 parses each version entry's transport-request `<atom:link>` into the new optional `IObjectVersion.transportRequest` (e.g. `DS4K901917`) + `transportDescription`.
- `GetObjectVersions` and the per-object `Get<Object>Versions` already return the full version objects, so the new fields **surface automatically** — no tool/argument change. Tool descriptions updated to mention `transportRequest`/`transportDescription`.
- An agent can now map an object's versions to the transports that produced them (the "transports of an object" part of #30, alongside version source and diff already shipped).

## Verification
- `npm run build`, `npm run test:check` — green. `handleObjectVersions.test.ts` gains a case asserting `transportRequest`/`transportDescription` pass through per version (5/5). Docs regenerated.
- Migration is non-breaking (mcp-abap-adt is a pure consumer; the new interface fields are optional/additive).

## Known minor
- The generated `AVAILABLE_TOOLS_HIGH.md` synthesizes the factory tools' descriptions, so the per-object version tools' doc text doesn't yet show the new `transportRequest` phrase (the **runtime** TOOL_DEFINITION descriptions and the ReadOnly doc do). Cosmetic; a generator improvement is a separate follow-up.

Minor bump **8.4.0 → 8.5.0** (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)