### PR TITLE
refactor(deps): remove all overrides — audit 0 via in-range resolution + tsx bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Security
-- **Cleared the residual dev-tooling Dependabot alerts.** Upstream patches now exist for the transitive dev dependencies that 8.5.1 had to leave as "accepted", so added `overrides` to pull them: `shell-quote ^1.8.4` (the critical, previously unpatched — via MCP Inspector), `esbuild ^0.28.1` (via `tsx`), `@babel/core ^7.29.6` (via Jest), and a **scoped** `@istanbuljs/load-nyc-config › js-yaml ^3.15.0` (via Jest, leaving the direct `js-yaml@4.3.0` untouched). `npm audit` is now **0** (was 57 before 8.5.1). All four are dev-tooling only — not in the published tarball — and `overrides` are not inherited by consumers, so **no republish is required**; this only cleans the repo's own lockfile so the GitHub alerts close.
+- **Removed all dependency `overrides` — `npm audit` is 0 without any of them.** The overrides added in 8.5.1 turned out to be crutches: a clean lockfile resolution already reaches patched versions within each maintainer's declared semver range, so forcing transitive versions (an untested parent/child combination) was both unnecessary and a maintenance liability. Dropped the entire `overrides` block (11 entries) and let the tree resolve in-range. The single dep that stayed stuck — `esbuild` (low, dev-only, pinned by `tsx@4.21` to `~0.27.0`) — was fixed the right way: by bumping the direct dev dependency we own, `tsx ^4.21.0 → ^4.22.4`, whose maintainer moved the pin to `esbuild ~0.28.0` (includes the patched `0.28.1`). No overrides remain; every fix now comes from a direct-dependency bump or in-range resolution. Verified: `npm audit` 0, `build` + `test:check` + 348 unit tests green. Dev-tooling only, not in the published tarball — no republish required.
 
 ## [8.5.1] - 2026-07-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "pino-pretty": "^13.1.3",
         "serve-handler": "^6.1.7",
         "ts-jest": "^29.2.0",
-        "tsx": "^4.21.0",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.2",
         "yaml": "^2.8.1"
       },
@@ -5659,15 +5659,15 @@
       }
     },
     "node_modules/@modelcontextprotocol/inspector/node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
+        "shell-quote": "1.8.4",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -5775,6 +5775,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/@modelcontextprotocol/inspector/node_modules/concurrently/node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/@modelcontextprotocol/inspector/node_modules/concurrently/node_modules/supports-color": {
       "version": "8.1.1",
@@ -8137,12 +8150,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -30026,13 +30039,12 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -30513,27 +30525,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/tsx/node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/tsx/node_modules/get-tsconfig/node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "pino-pretty": "^13.1.3",
     "serve-handler": "^6.1.7",
     "ts-jest": "^29.2.0",
-    "tsx": "^4.21.0",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.2",
     "yaml": "^2.8.1"
   },
@@ -158,21 +158,6 @@
   },
   "optionalDependencies": {
     "@mcp-abap-adt/sap-rfc-lite": "^0.1.0"
-  },
-  "overrides": {
-    "form-data": "^4.0.6",
-    "hono": "^4.12.27",
-    "@hono/node-server": "^1.19.14",
-    "fast-uri": "^3.1.3",
-    "ws": "^8.21.0",
-    "ip-address": "^10.2.0",
-    "qs": "^6.15.3",
-    "shell-quote": "^1.8.4",
-    "esbuild": "^0.28.1",
-    "@babel/core": "^7.29.6",
-    "@istanbuljs/load-nyc-config": {
-      "js-yaml": "^3.15.0"
-    }
   },
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
## Why
Overrides are a crutch: they pin a transitive dependency to a version its **parent never declared or tested** — an untested combination and a standing maintenance liability. The 11 overrides added across 8.5.1 turned out to be **entirely unnecessary**: a clean lockfile resolution already reaches patched versions within each maintainer's declared semver range.

Empirically confirmed — with **all overrides removed**, `npm audit` reaches **0** through in-range resolution alone.

## What
- **Removed the entire `overrides` block** (11 entries).
- The one dep that stayed stuck in-range — **`esbuild`** (low, dev-only, pinned by `tsx@4.21` to `~0.27.0`) — is fixed the **right way**, not by an override: bump the direct dev dep we own, **`tsx ^4.21.0 → ^4.22.4`**, whose maintainer moved the pin to `esbuild ~0.28.0` (includes patched `0.28.1`).

Principle: every fix now comes from a **direct-dependency bump** (deps we own) or **in-range resolution** (versions the maintainers declared and tested) — never a forced transitive pin. If a component were genuinely stuck on a vulnerable dep because its maintainer won't update, the answer is to replace the component, not to override.

## Verification
- `npm audit` → **0 vulnerabilities**, with **zero overrides**
- `npm run build` ✅ · `npm run test:check` ✅ · 348/348 unit ✅
- Diff: 2 files (`package.json` −overrides / tsx bump, `package-lock.json` in-range)

Dev-tooling only, not in the published tarball; overrides never propagated to consumers anyway — **no republish required**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)