### PR TITLE
fix(config): resolve YAML runtime dep — npx install crash (#143) — 8.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.5.2] - 2026-07-05
+
+### Fixed
+- **`npx -y @mcp-abap-adt/core` (and any fresh install) crashed with `Cannot find module 'yaml'` (#143).** The runtime config loader (`src/lib/config/yamlConfig.ts`) imported the `yaml` package, but `yaml` was declared only in `devDependencies` — so it was absent from the published tarball and every consumer install failed at startup. Consolidated all runtime YAML parsing onto `js-yaml` (already a runtime `dependency`, via `load()`), migrated the two integration-test helpers off `yaml` as well, and **removed the `yaml` package entirely** — one YAML library instead of two, and the runtime import now resolves from a declared dependency. Added `yamlConfig` unit tests to guard it.
+
 ### Security
 - **Removed all dependency `overrides` — `npm audit` is 0 without any of them.** The overrides added in 8.5.1 turned out to be crutches: a clean lockfile resolution already reaches patched versions within each maintainer's declared semver range, so forcing transitive versions (an untested parent/child combination) was both unnecessary and a maintenance liability. Dropped the entire `overrides` block (11 entries) and let the tree resolve in-range. The single dep that stayed stuck — `esbuild` (low, dev-only, pinned by `tsx@4.21` to `~0.27.0`) — was fixed the right way: by bumping the direct dev dependency we own, `tsx ^4.21.0 → ^4.22.4`, whose maintainer moved the pin to `esbuild ~0.28.0` (includes the patched `0.28.1`). No overrides remain; every fix now comes from a direct-dependency bump or in-range resolution. Verified: `npm audit` 0, `build` + `test:check` + 348 unit tests green. Dev-tooling only, not in the published tarball — no republish required.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.5.1",
+  "version": "8.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.5.1",
+      "version": "8.5.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^7.2.1",
@@ -52,8 +52,7 @@
         "serve-handler": "^6.1.7",
         "ts-jest": "^29.2.0",
         "tsx": "^4.22.4",
-        "typescript": "^6.0.2",
-        "yaml": "^2.8.1"
+        "typescript": "^6.0.2"
       },
       "engines": {
         "node": ">=22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.5.1",
+  "version": "8.5.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -134,8 +134,7 @@
     "serve-handler": "^6.1.7",
     "ts-jest": "^29.2.0",
     "tsx": "^4.22.4",
-    "typescript": "^6.0.2",
-    "yaml": "^2.8.1"
+    "typescript": "^6.0.2"
   },
   "dependencies": {
     "@mcp-abap-adt/adt-clients": "^7.2.1",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.5.1",
+  "version": "8.5.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.5.1",
+      "version": "8.5.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/integration/globalSetup.ts
+++ b/src/__tests__/integration/globalSetup.ts
@@ -19,9 +19,9 @@ function loadTestConfig(): any {
   for (const configPath of configPaths) {
     try {
       const fs = require('node:fs');
-      const yaml = require('yaml');
+      const yaml = require('js-yaml');
       const content = fs.readFileSync(configPath, 'utf8');
-      return yaml.parse(content);
+      return yaml.load(content);
     } catch {
       // try next
     }

--- a/src/__tests__/integration/helpers/configHelpers.ts
+++ b/src/__tests__/integration/helpers/configHelpers.ts
@@ -7,7 +7,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { SapConfig } from '@mcp-abap-adt/connection';
 import * as dotenv from 'dotenv';
-import * as yaml from 'yaml';
+import * as yaml from 'js-yaml';
 import { applyCertKerberosFields } from '../../../lib/config/applyAuthFields';
 import { parseAuthType } from '../../../lib/config/parseAuthType';
 import { invalidateConnectionCache } from '../../../lib/utils';
@@ -252,7 +252,7 @@ export function loadTestConfig(): any {
 
   if (fs.existsSync(configPath)) {
     const configContent = fs.readFileSync(configPath, 'utf8');
-    cachedConfig = yaml.parse(configContent) || {};
+    cachedConfig = (yaml.load(configContent) as Record<string, unknown>) || {};
     return cachedConfig;
   }
 
@@ -261,7 +261,8 @@ export function loadTestConfig(): any {
       '⚠️ tests/test-config.yaml not found. Using template (all integration tests will be disabled).',
     );
     const templateContent = fs.readFileSync(templatePath, 'utf8');
-    cachedConfig = yaml.parse(templateContent) || {};
+    cachedConfig =
+      (yaml.load(templateContent) as Record<string, unknown>) || {};
     return cachedConfig;
   }
 

--- a/src/__tests__/unit/yamlConfig.test.ts
+++ b/src/__tests__/unit/yamlConfig.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests (#143): YAML startup-config loading.
+ * Guards the fix that consolidated runtime YAML parsing onto `js-yaml`
+ * (a real runtime dependency) after `yaml` was dropped — the `yaml`
+ * package used to be a devDependency, so `npx` installs crashed with
+ * "Cannot find module 'yaml'". These tests prove the config loads and
+ * validates without the `yaml` package present.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  loadYamlConfig,
+  validateYamlConfig,
+} from '../../lib/config/yamlConfig';
+
+function writeTempYaml(name: string, content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-yaml-'));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content, 'utf-8');
+  return file;
+}
+
+describe('yamlConfig (js-yaml runtime parsing, #143)', () => {
+  it('parses a YAML config file into typed values', () => {
+    const file = writeTempYaml(
+      'config.yaml',
+      ['transport: http', 'http:', '  port: 8080', '  host: 127.0.0.1'].join(
+        '\n',
+      ),
+    );
+
+    const config = loadYamlConfig(file);
+
+    expect(config).not.toBeNull();
+    expect(config?.transport).toBe('http');
+    expect(config?.http?.port).toBe(8080);
+    expect(config?.http?.host).toBe('127.0.0.1');
+  });
+
+  it('parses a YAML array (exposition) into a string[]', () => {
+    const file = writeTempYaml(
+      'array.yaml',
+      ['exposition:', '  - readonly', '  - high', '  - low'].join('\n'),
+    );
+
+    const config = loadYamlConfig(file);
+
+    expect(config?.exposition).toEqual(['readonly', 'high', 'low']);
+  });
+
+  it('returns null when the config file does not exist', () => {
+    const missing = path.join(os.tmpdir(), 'definitely-not-here-143.yaml');
+    expect(loadYamlConfig(missing)).toBeNull();
+  });
+
+  it('throws when the parsed config fails validation', () => {
+    const file = writeTempYaml('bad.yaml', 'transport: telepathy\n');
+    expect(() => loadYamlConfig(file)).toThrow(/Invalid transport/);
+  });
+
+  it('validateYamlConfig rejects an out-of-range HTTP port', () => {
+    const result = validateYamlConfig({ http: { port: 70000 } });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/Invalid HTTP port/);
+  });
+});

--- a/src/lib/config/yamlConfig.ts
+++ b/src/lib/config/yamlConfig.ts
@@ -5,7 +5,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { parse as parseYaml } from 'yaml';
+import { load as parseYaml } from 'js-yaml';
 
 export interface YamlConfig {
   transport?: string;


### PR DESCRIPTION
## Fixes #143

`npx -y @mcp-abap-adt/core` (and every fresh consumer install) crashed at startup with:
```
Error: Cannot find module 'yaml'
  ... dist/lib/config/yamlConfig.js
```

### Root cause
`src/lib/config/yamlConfig.ts` imported the **`yaml`** package at runtime, but `yaml` was declared only in **`devDependencies`** — so it was not in the published tarball, and consumers (who install only `dependencies`) never got it.

### Fix (option B — consolidate, not just move)
The repo already ships **`js-yaml`** as a runtime `dependency`. Rather than adding `yaml` to `dependencies` (two YAML libs), consolidate onto one:
- `yamlConfig.ts`: `import { load as parseYaml } from 'js-yaml'` (`load` ≡ `yaml.parse`)
- Migrated the two integration-test helpers (`configHelpers.ts`, `globalSetup.ts`) off `yaml` as well
- **Removed the `yaml` package entirely** from `package.json`
- Added `yamlConfig` unit tests (parse, YAML array, missing file, validation error)

### Verification
- `dist/lib/config/yamlConfig.js` now `require("js-yaml")` (a declared runtime dep) — no bare `yaml` require anywhere in `dist/`
- `npm run build` ✅ · `test:check` ✅ · **353 unit tests** (17 suites, +5 new) ✅
- `npm audit` **0**; versions **8.5.2** consistent across `package.json` / `package-lock.json` / `server.json`
- Remaining `yaml@2.8.3` in the tree is transitive via `lint-staged` (dev) — not ours, not shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)