### PR TITLE
feat(message-class): MSAG CRUD MCP tools + adt-clients 7.3.1 — 8.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [8.6.0] - 2026-07-05
+
+### Added
+- **Message Class (MSAG / T100) CRUD tools.** Exposes the new message-class client from `@mcp-abap-adt/adt-clients` 7.3.x as MCP tools:
+  - **ReadOnly group:** `ReadMessageClass` (class header + all messages), `ReadMessageClassMessage` (one message by number).
+  - **HighLevel group:** `GetMessageClass`, `CreateMessageClass`, `UpdateMessageClass`, `DeleteMessageClass`, and per-message `GetMessageClassMessage`, `CreateMessageClassMessage`, `UpdateMessageClassMessage`, `DeleteMessageClassMessage`.
+  - Message classes are not activatable/versioned, so there are no Check/Activate/Versions tools for them. Transport handling matches the other CRUD objects (`transport_request` sent as `corrNr`; required for transportable packages). `available_in: ['onprem', 'cloud']`.
+
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^7.3.1` and `@mcp-abap-adt/interfaces@^9.2.0`** (from `^7.2.1` / `^9.1.0`). 7.3.0 adds the Message Class client (`getMessageClass()` / `getMessageClassMessage()`); 7.3.1 wires `transport_request` (`corrNr`) from config. Non-breaking for existing tools.
+
 ## [8.5.2] - 2026-07-05
 
 ### Fixed

--- a/docs/user-guide/AVAILABLE_TOOLS.md
+++ b/docs/user-guide/AVAILABLE_TOOLS.md
@@ -4,9 +4,9 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ## Summary
 
-- Total tools: 355
-- Read-only tools: 62
-- High-level tools: 169
+- Total tools: 365
+- Read-only tools: 64
+- High-level tools: 177
 - Low-level tools: 124
 
 - Compact tools: 22 (included in High-level group)
@@ -55,6 +55,9 @@ Generated from code in `src/handlers/**` (not from docs).
     - [GetIncludesList](#getincludeslist-read-only-include)
   - [Interface](#read-only-interface)
     - [ReadInterface](#readinterface-read-only-interface)
+  - [Message Class](#read-only-message-class)
+    - [ReadMessageClass](#readmessageclass-read-only-message-class)
+    - [ReadMessageClassMessage](#readmessageclassmessage-read-only-message-class)
   - [Metadata Extension](#read-only-metadata-extension)
     - [ReadMetadataExtension](#readmetadataextension-read-only-metadata-extension)
   - [Package](#read-only-package)
@@ -246,6 +249,15 @@ Generated from code in `src/handlers/**` (not from docs).
     - [DeleteInterface](#deleteinterface-high-level-interface)
     - [GetInterface](#getinterface-high-level-interface)
     - [UpdateInterface](#updateinterface-high-level-interface)
+  - [Message Class](#high-level-message-class)
+    - [CreateMessageClass](#createmessageclass-high-level-message-class)
+    - [CreateMessageClassMessage](#createmessageclassmessage-high-level-message-class)
+    - [DeleteMessageClass](#deletemessageclass-high-level-message-class)
+    - [DeleteMessageClassMessage](#deletemessageclassmessage-high-level-message-class)
+    - [GetMessageClass](#getmessageclass-high-level-message-class)
+    - [GetMessageClassMessage](#getmessageclassmessage-high-level-message-class)
+    - [UpdateMessageClass](#updatemessageclass-high-level-message-class)
+    - [UpdateMessageClassMessage](#updatemessageclassmessage-high-level-message-class)
   - [Metadata Extension](#high-level-metadata-extension)
     - [DeleteMetadataExtension](#deletemetadataextension-high-level-metadata-extension)
     - [GetMetadataExtension](#getmetadataextension-high-level-metadata-extension)
@@ -728,6 +740,32 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `interface_name` (string, required) - Interface name (e.g., ZIF_MY_INTERFACE).
 - `version` (string, optional (default: active)) - Version to read: "active" (default) or "inactive".
+
+---
+
+<a id="read-only-message-class"></a>
+### Read-Only / Message Class
+
+<a id="readmessageclass-read-only-message-class"></a>
+#### ReadMessageClass (Read-Only / Message Class)
+**Description:** Operation: Read. Subject: Message Class (MSAG). Will be useful for reading a message class and its messages. [read-only] Read an ABAP message class (T100) with all of its messages. Answers: "show message class X", "list messages of message class", "display message text 001 of class". Returns name, description, package, master language and the array of messages (msgno, msgtext, self-explanatory, description).
+
+**Source:** `src/handlers/message_class/readonly/handleReadMessageClass.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS).
+
+---
+
+<a id="readmessageclassmessage-read-only-message-class"></a>
+#### ReadMessageClassMessage (Read-Only / Message Class)
+**Description:** Operation: Read. Subject: a single message inside a Message Class (MSAG). [read-only] Read one message (by number) from an ABAP message class. Answers: "show message 001 of class ZMY_MSGS", "get text of message". Returns msgno, msgtext, self-explanatory flag and description.
+
+**Source:** `src/handlers/message_class/readonly/handleReadMessageClassMessage.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number (e.g., "001").
 
 ---
 
@@ -3159,6 +3197,117 @@ Generated from code in `src/handlers/**` (not from docs).
 - `interface_name` (string, required) - Interface name (e.g., ZIF_MY_INTERFACE). Must exist in the system.
 - `source_code` (string, required) - Complete ABAP interface source code with INTERFACE...ENDINTERFACE section.
 - `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Optional if object is local or already in transport.
+
+---
+
+<a id="high-level-message-class"></a>
+### High-Level / Message Class
+
+<a id="createmessageclass-high-level-message-class"></a>
+#### CreateMessageClass (High-Level / Message Class)
+**Description:** Operation: Create. Subject: Message Class (MSAG). Create a new ABAP message class (T100) shell. Individual messages are added afterwards with CreateMessageClassMessage. Message classes are not activated.
+
+**Source:** `src/handlers/message_class/high/handleCreateMessageClass.ts`
+
+**Parameters:**
+- `description` (string, optional) - (optional) Short description. If not provided, message_class_name is used.
+- `master_language` (string, optional) - (optional) Master/original language (e.g. "EN", "DE"). Defaults to the session language (SAP_LANGUAGE) or EN.
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS). Must follow SAP naming conventions.
+- `package_name` (string, required) - Package name (e.g., ZMY_PKG, $TMP for local objects).
+- `transport_request` (string, optional) - (optional) Transport request number (e.g., E19K905635). Required for transportable packages.
+
+---
+
+<a id="createmessageclassmessage-high-level-message-class"></a>
+#### CreateMessageClassMessage (High-Level / Message Class)
+**Description:** Operation: Create. Subject: a single message inside a Message Class (MSAG). Add a message (number + text) to an existing ABAP message class (T100). The parent class must exist first (CreateMessageClass).
+
+**Source:** `src/handlers/message_class/high/handleCreateMessageClassMessage.ts`
+
+**Parameters:**
+- `description` (string, optional) - (optional) Long description for the message.
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number (e.g., "001").
+- `msgtext` (string, required) - Message text. May contain placeholders &1 &2 &3 &4 (or &).
+- `self_explanatory` (boolean, optional (default: false)) - (optional) Mark the message as self-explanatory (no long text needed). Default: false.
+- `transport_request` (string, optional) - (optional) Transport request number. Required for transportable objects.
+
+---
+
+<a id="deletemessageclass-high-level-message-class"></a>
+#### DeleteMessageClass (High-Level / Message Class)
+**Description:** Delete an ABAP message class (MSAG) and all of its messages from the SAP system. Includes a deletion check before the actual deletion. Transport request required for transportable objects, optional for local ($TMP).
+
+**Source:** `src/handlers/message_class/high/handleDeleteMessageClass.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS).
+- `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable objects, optional for local ($TMP).
+
+---
+
+<a id="deletemessageclassmessage-high-level-message-class"></a>
+#### DeleteMessageClassMessage (High-Level / Message Class)
+**Description:** Operation: Delete. Subject: a single message inside a Message Class (MSAG). Remove one message (by number) from an ABAP message class (T100), keeping the class and its other messages. Transport request required for transportable objects.
+
+**Source:** `src/handlers/message_class/high/handleDeleteMessageClassMessage.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number to delete (e.g., "001").
+- `transport_request` (string, optional) - Transport request number. Required for transportable objects, optional for local ($TMP).
+
+---
+
+<a id="getmessageclass-high-level-message-class"></a>
+#### GetMessageClass (High-Level / Message Class)
+**Description:** Retrieve an ABAP message class (MSAG/T100) with its messages: name, description, package, master language and the message list (msgno, msgtext, self-explanatory).
+
+**Source:** `src/handlers/message_class/high/handleGetMessageClass.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS).
+
+---
+
+<a id="getmessageclassmessage-high-level-message-class"></a>
+#### GetMessageClassMessage (High-Level / Message Class)
+**Description:** Retrieve a single message (by number) from an ABAP message class (MSAG/T100). Returns msgno, msgtext, self-explanatory flag and description.
+
+**Source:** `src/handlers/message_class/high/handleGetMessageClassMessage.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number (e.g., "001").
+
+---
+
+<a id="updatemessageclass-high-level-message-class"></a>
+#### UpdateMessageClass (High-Level / Message Class)
+**Description:** Operation: Update. Subject: Message Class (MSAG). Update a message class header (e.g. its description). To add or change individual messages use CreateMessageClassMessage / UpdateMessageClassMessage.
+
+**Source:** `src/handlers/message_class/high/handleUpdateMessageClass.ts`
+
+**Parameters:**
+- `description` (string, required) - New short description for the message class.
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS).
+- `transport_request` (string, optional) - (optional) Transport request number. Required for transportable objects.
+
+---
+
+<a id="updatemessageclassmessage-high-level-message-class"></a>
+#### UpdateMessageClassMessage (High-Level / Message Class)
+**Description:** Operation: Update. Subject: a single message inside a Message Class (MSAG). Change the text / flags of an existing message in an ABAP message class (T100). Upserts the message if it does not exist yet.
+
+**Source:** `src/handlers/message_class/high/handleUpdateMessageClassMessage.ts`
+
+**Parameters:**
+- `description` (string, optional) - (optional) Long description for the message.
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number (e.g., "001").
+- `msgtext` (string, required) - New message text. May contain placeholders &1 &2 &3 &4 (or &).
+- `self_explanatory` (boolean, optional) - (optional) Mark the message as self-explanatory.
+- `transport_request` (string, optional) - (optional) Transport request number. Required for transportable objects.
 
 ---
 
@@ -5628,4 +5777,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-30*
+*Last updated: 2026-07-05*

--- a/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
@@ -596,4 +596,4 @@ Preferred dedicated compact tools and minimal payloads:
 
 ---
 
-*Last updated: 2026-06-30*
+*Last updated: 2026-07-05*

--- a/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
@@ -3,7 +3,7 @@
 Generated from code in `src/handlers/**` (not from docs).
 
 - Level: High-Level
-- Total tools: 169
+- Total tools: 177
 
 ## Navigation
 
@@ -146,6 +146,15 @@ Generated from code in `src/handlers/**` (not from docs).
     - [DeleteInterface](#deleteinterface-high-level-interface)
     - [GetInterface](#getinterface-high-level-interface)
     - [UpdateInterface](#updateinterface-high-level-interface)
+  - [Message Class](#high-level-message-class)
+    - [CreateMessageClass](#createmessageclass-high-level-message-class)
+    - [CreateMessageClassMessage](#createmessageclassmessage-high-level-message-class)
+    - [DeleteMessageClass](#deletemessageclass-high-level-message-class)
+    - [DeleteMessageClassMessage](#deletemessageclassmessage-high-level-message-class)
+    - [GetMessageClass](#getmessageclass-high-level-message-class)
+    - [GetMessageClassMessage](#getmessageclassmessage-high-level-message-class)
+    - [UpdateMessageClass](#updatemessageclass-high-level-message-class)
+    - [UpdateMessageClassMessage](#updatemessageclassmessage-high-level-message-class)
   - [Metadata Extension](#high-level-metadata-extension)
     - [DeleteMetadataExtension](#deletemetadataextension-high-level-metadata-extension)
     - [GetMetadataExtension](#getmetadataextension-high-level-metadata-extension)
@@ -2011,6 +2020,117 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
+<a id="high-level-message-class"></a>
+### High-Level / Message Class
+
+<a id="createmessageclass-high-level-message-class"></a>
+#### CreateMessageClass (High-Level / Message Class)
+**Description:** Operation: Create. Subject: Message Class (MSAG). Create a new ABAP message class (T100) shell. Individual messages are added afterwards with CreateMessageClassMessage. Message classes are not activated.
+
+**Source:** `src/handlers/message_class/high/handleCreateMessageClass.ts`
+
+**Parameters:**
+- `description` (string, optional) - (optional) Short description. If not provided, message_class_name is used.
+- `master_language` (string, optional) - (optional) Master/original language (e.g. "EN", "DE"). Defaults to the session language (SAP_LANGUAGE) or EN.
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS). Must follow SAP naming conventions.
+- `package_name` (string, required) - Package name (e.g., ZMY_PKG, $TMP for local objects).
+- `transport_request` (string, optional) - (optional) Transport request number (e.g., E19K905635). Required for transportable packages.
+
+---
+
+<a id="createmessageclassmessage-high-level-message-class"></a>
+#### CreateMessageClassMessage (High-Level / Message Class)
+**Description:** Operation: Create. Subject: a single message inside a Message Class (MSAG). Add a message (number + text) to an existing ABAP message class (T100). The parent class must exist first (CreateMessageClass).
+
+**Source:** `src/handlers/message_class/high/handleCreateMessageClassMessage.ts`
+
+**Parameters:**
+- `description` (string, optional) - (optional) Long description for the message.
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number (e.g., "001").
+- `msgtext` (string, required) - Message text. May contain placeholders &1 &2 &3 &4 (or &).
+- `self_explanatory` (boolean, optional (default: false)) - (optional) Mark the message as self-explanatory (no long text needed). Default: false.
+- `transport_request` (string, optional) - (optional) Transport request number. Required for transportable objects.
+
+---
+
+<a id="deletemessageclass-high-level-message-class"></a>
+#### DeleteMessageClass (High-Level / Message Class)
+**Description:** Delete an ABAP message class (MSAG) and all of its messages from the SAP system. Includes a deletion check before the actual deletion. Transport request required for transportable objects, optional for local ($TMP).
+
+**Source:** `src/handlers/message_class/high/handleDeleteMessageClass.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS).
+- `transport_request` (string, optional) - Transport request number (e.g., E19K905635). Required for transportable objects, optional for local ($TMP).
+
+---
+
+<a id="deletemessageclassmessage-high-level-message-class"></a>
+#### DeleteMessageClassMessage (High-Level / Message Class)
+**Description:** Operation: Delete. Subject: a single message inside a Message Class (MSAG). Remove one message (by number) from an ABAP message class (T100), keeping the class and its other messages. Transport request required for transportable objects.
+
+**Source:** `src/handlers/message_class/high/handleDeleteMessageClassMessage.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number to delete (e.g., "001").
+- `transport_request` (string, optional) - Transport request number. Required for transportable objects, optional for local ($TMP).
+
+---
+
+<a id="getmessageclass-high-level-message-class"></a>
+#### GetMessageClass (High-Level / Message Class)
+**Description:** Retrieve an ABAP message class (MSAG/T100) with its messages: name, description, package, master language and the message list (msgno, msgtext, self-explanatory).
+
+**Source:** `src/handlers/message_class/high/handleGetMessageClass.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS).
+
+---
+
+<a id="getmessageclassmessage-high-level-message-class"></a>
+#### GetMessageClassMessage (High-Level / Message Class)
+**Description:** Retrieve a single message (by number) from an ABAP message class (MSAG/T100). Returns msgno, msgtext, self-explanatory flag and description.
+
+**Source:** `src/handlers/message_class/high/handleGetMessageClassMessage.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number (e.g., "001").
+
+---
+
+<a id="updatemessageclass-high-level-message-class"></a>
+#### UpdateMessageClass (High-Level / Message Class)
+**Description:** Operation: Update. Subject: Message Class (MSAG). Update a message class header (e.g. its description). To add or change individual messages use CreateMessageClassMessage / UpdateMessageClassMessage.
+
+**Source:** `src/handlers/message_class/high/handleUpdateMessageClass.ts`
+
+**Parameters:**
+- `description` (string, required) - New short description for the message class.
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS).
+- `transport_request` (string, optional) - (optional) Transport request number. Required for transportable objects.
+
+---
+
+<a id="updatemessageclassmessage-high-level-message-class"></a>
+#### UpdateMessageClassMessage (High-Level / Message Class)
+**Description:** Operation: Update. Subject: a single message inside a Message Class (MSAG). Change the text / flags of an existing message in an ABAP message class (T100). Upserts the message if it does not exist yet.
+
+**Source:** `src/handlers/message_class/high/handleUpdateMessageClassMessage.ts`
+
+**Parameters:**
+- `description` (string, optional) - (optional) Long description for the message.
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number (e.g., "001").
+- `msgtext` (string, required) - New message text. May contain placeholders &1 &2 &3 &4 (or &).
+- `self_explanatory` (boolean, optional) - (optional) Mark the message as self-explanatory.
+- `transport_request` (string, optional) - (optional) Transport request number. Required for transportable objects.
+
+---
+
 <a id="high-level-metadata-extension"></a>
 ### High-Level / Metadata Extension
 
@@ -2639,4 +2759,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-30*
+*Last updated: 2026-07-05*

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -2922,4 +2922,4 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
-*Last updated: 2026-06-30*
+*Last updated: 2026-07-05*

--- a/docs/user-guide/AVAILABLE_TOOLS_LOW.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LOW.md
@@ -1991,4 +1991,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-30*
+*Last updated: 2026-07-05*

--- a/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
@@ -3,7 +3,7 @@
 Generated from code in `src/handlers/**` (not from docs).
 
 - Level: Read-Only
-- Total tools: 62
+- Total tools: 64
 
 ## Navigation
 
@@ -41,6 +41,9 @@ Generated from code in `src/handlers/**` (not from docs).
     - [GetIncludesList](#getincludeslist-read-only-include)
   - [Interface](#read-only-interface)
     - [ReadInterface](#readinterface-read-only-interface)
+  - [Message Class](#read-only-message-class)
+    - [ReadMessageClass](#readmessageclass-read-only-message-class)
+    - [ReadMessageClassMessage](#readmessageclassmessage-read-only-message-class)
   - [Metadata Extension](#read-only-metadata-extension)
     - [ReadMetadataExtension](#readmetadataextension-read-only-metadata-extension)
   - [Package](#read-only-package)
@@ -377,6 +380,32 @@ Generated from code in `src/handlers/**` (not from docs).
 **Parameters:**
 - `interface_name` (string, required) - Interface name (e.g., ZIF_MY_INTERFACE).
 - `version` (string, optional (default: active)) - Version to read: "active" (default) or "inactive".
+
+---
+
+<a id="read-only-message-class"></a>
+### Read-Only / Message Class
+
+<a id="readmessageclass-read-only-message-class"></a>
+#### ReadMessageClass (Read-Only / Message Class)
+**Description:** Operation: Read. Subject: Message Class (MSAG). Will be useful for reading a message class and its messages. [read-only] Read an ABAP message class (T100) with all of its messages. Answers: "show message class X", "list messages of message class", "display message text 001 of class". Returns name, description, package, master language and the array of messages (msgno, msgtext, self-explanatory, description).
+
+**Source:** `src/handlers/message_class/readonly/handleReadMessageClass.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Message class name (e.g., ZMY_MSGS).
+
+---
+
+<a id="readmessageclassmessage-read-only-message-class"></a>
+#### ReadMessageClassMessage (Read-Only / Message Class)
+**Description:** Operation: Read. Subject: a single message inside a Message Class (MSAG). [read-only] Read one message (by number) from an ABAP message class. Answers: "show message 001 of class ZMY_MSGS", "get text of message". Returns msgno, msgtext, self-explanatory flag and description.
+
+**Source:** `src/handlers/message_class/readonly/handleReadMessageClassMessage.ts`
+
+**Parameters:**
+- `message_class_name` (string, required) - Parent message class name (e.g., ZMY_MSGS).
+- `msgno` (string, required) - Message number (e.g., "001").
 
 ---
 
@@ -1004,4 +1033,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-06-30*
+*Last updated: 2026-07-05*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.5.2",
+  "version": "8.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.5.2",
+      "version": "8.6.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^7.2.1",
+        "@mcp-abap-adt/adt-clients": "^7.3.1",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
         "@mcp-abap-adt/connection": "^1.9.1",
         "@mcp-abap-adt/header-validator": "^0.1.8",
-        "@mcp-abap-adt/interfaces": "^9.1.0",
+        "@mcp-abap-adt/interfaces": "^9.2.0",
         "@mcp-abap-adt/logger": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.18.1",
@@ -226,12 +226,12 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.2.1.tgz",
-      "integrity": "sha512-PaAjY3vd1dGrUsd9Pu1fu6Lcq1zLQwx3iqeEBAB+YFpda4X0OP59sYAPAtmYG8/t637Euj+huOaQ0QFq0a/oWA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.3.1.tgz",
+      "integrity": "sha512-sq9sj68fUhZgF9082vUpS8lb6a42RQEnhcKYQFB3lAcCeOkfvVdHmZgdK1oeiysphSMhGUIT3u17oNnyaumBng==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^9.1.0",
+        "@mcp-abap-adt/interfaces": "^9.2.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.1.0.tgz",
-      "integrity": "sha512-AgrSEk7RK38s8R8PSRwOBynGEs7Rg4rYBkZ/F9i5gveWmV2bZ4BAc/+d7mAytyR/hkrngssjsXc1GJslbyN+mA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.2.0.tgz",
+      "integrity": "sha512-iMb3OOjMsMxAf8dSXz763uq+Q4CV32fuSjc6GSL4Uu8cCxjJs3AWjNgbQFyhmzIhw0LlSlYWChCkrZBOUJI7GA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.5.2",
+  "version": "8.6.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -137,13 +137,13 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^7.2.1",
+    "@mcp-abap-adt/adt-clients": "^7.3.1",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",
     "@mcp-abap-adt/connection": "^1.9.1",
     "@mcp-abap-adt/header-validator": "^0.1.8",
-    "@mcp-abap-adt/interfaces": "^9.1.0",
+    "@mcp-abap-adt/interfaces": "^9.2.0",
     "@mcp-abap-adt/logger": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.18.1",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.5.2",
+  "version": "8.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.5.2",
+      "version": "8.6.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/unit/handleMessageClass.test.ts
+++ b/src/__tests__/unit/handleMessageClass.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests: Message Class (MSAG) CRUD tools.
+ *  - the message-class handlers dispatch to client.getMessageClass()
+ *    with the right config (name uppercased, package, transport, master lang);
+ *  - the message handlers dispatch to client.getMessageClassMessage()
+ *    with { className, msgno, msgtext, ... };
+ *  - read handlers surface the parsed messageClass / message.
+ * SAP-free via a mocked AdtClient.
+ */
+
+const mockMc = {
+  create: jest.fn(),
+  read: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+const mockMsg = {
+  create: jest.fn(),
+  read: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getMessageClass: () => mockMc,
+    getMessageClassMessage: () => mockMsg,
+  }),
+}));
+
+import { handleCreateMessageClass } from '../../handlers/message_class/high/handleCreateMessageClass';
+import { handleCreateMessageClassMessage } from '../../handlers/message_class/high/handleCreateMessageClassMessage';
+import { handleDeleteMessageClass } from '../../handlers/message_class/high/handleDeleteMessageClass';
+import { handleGetMessageClass } from '../../handlers/message_class/high/handleGetMessageClass';
+import { handleUpdateMessageClassMessage } from '../../handlers/message_class/high/handleUpdateMessageClassMessage';
+import { handleReadMessageClass } from '../../handlers/message_class/readonly/handleReadMessageClass';
+import { handleReadMessageClassMessage } from '../../handlers/message_class/readonly/handleReadMessageClassMessage';
+
+const ctx = { connection: {}, logger: undefined } as any;
+
+function payload(result: any) {
+  const text =
+    (result.content.find((c: any) => c.type === 'text') as any)?.text || '';
+  return JSON.parse(text);
+}
+
+describe('Message Class (MSAG) CRUD tools', () => {
+  beforeEach(() => {
+    for (const m of [mockMc, mockMsg]) {
+      for (const fn of Object.values(m)) (fn as jest.Mock).mockReset();
+    }
+  });
+
+  it('ReadMessageClass returns the parsed message class', async () => {
+    mockMc.read.mockResolvedValue({
+      messageClass: {
+        name: 'ZMY_MSGS',
+        description: 'My messages',
+        packageName: 'ZPKG',
+        messages: [{ msgno: '001', msgtext: 'Hello &1' }],
+      },
+    });
+
+    const result = await handleReadMessageClass(ctx, {
+      message_class_name: 'zmy_msgs',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockMc.read).toHaveBeenCalledWith({ name: 'ZMY_MSGS' });
+    expect(payload(result).message_class.messages[0].msgno).toBe('001');
+  });
+
+  it('GetMessageClass surfaces "not found" when read returns undefined', async () => {
+    mockMc.read.mockResolvedValue(undefined);
+    const result = await handleGetMessageClass(ctx, {
+      message_class_name: 'ZNOPE',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('CreateMessageClass dispatches create() with camelCase config', async () => {
+    mockMc.create.mockResolvedValue({ createResult: { status: 201 } });
+
+    const result = await handleCreateMessageClass(ctx, {
+      message_class_name: 'zmy_msgs',
+      description: 'My messages',
+      package_name: '$TMP',
+      master_language: 'EN',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockMc.create).toHaveBeenCalledWith({
+      name: 'ZMY_MSGS',
+      description: 'My messages',
+      packageName: '$TMP',
+      transportRequest: undefined,
+      masterLanguage: 'EN',
+    });
+  });
+
+  it('DeleteMessageClass dispatches delete() with name + transport', async () => {
+    mockMc.delete.mockResolvedValue({ deleteResult: { status: 200 } });
+
+    const result = await handleDeleteMessageClass(ctx, {
+      message_class_name: 'ZMY_MSGS',
+      transport_request: 'E19K900001',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockMc.delete).toHaveBeenCalledWith({
+      name: 'ZMY_MSGS',
+      transportRequest: 'E19K900001',
+    });
+  });
+
+  it('CreateMessageClassMessage dispatches to getMessageClassMessage().create', async () => {
+    mockMsg.create.mockResolvedValue({ createResult: { status: 200 } });
+
+    const result = await handleCreateMessageClassMessage(ctx, {
+      message_class_name: 'zmy_msgs',
+      msgno: '001',
+      msgtext: 'Hello &1',
+      self_explanatory: true,
+      transport_request: 'E19K900001',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockMsg.create).toHaveBeenCalledWith({
+      className: 'ZMY_MSGS',
+      msgno: '001',
+      msgtext: 'Hello &1',
+      selfExplanatory: true,
+      description: undefined,
+      transportRequest: 'E19K900001',
+    });
+  });
+
+  it('UpdateMessageClassMessage dispatches update() with the new text', async () => {
+    mockMsg.update.mockResolvedValue({ updateResult: { status: 200 } });
+
+    const result = await handleUpdateMessageClassMessage(ctx, {
+      message_class_name: 'ZMY_MSGS',
+      msgno: '001',
+      msgtext: 'Updated &1',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockMsg.update).toHaveBeenCalledWith({
+      className: 'ZMY_MSGS',
+      msgno: '001',
+      msgtext: 'Updated &1',
+      selfExplanatory: undefined,
+      description: undefined,
+      transportRequest: undefined,
+    });
+  });
+
+  it('ReadMessageClassMessage returns the single parsed message', async () => {
+    mockMsg.read.mockResolvedValue({
+      message: { msgno: '001', msgtext: 'Hello &1', selfExplanatory: false },
+    });
+
+    const result = await handleReadMessageClassMessage(ctx, {
+      message_class_name: 'ZMY_MSGS',
+      msgno: '001',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(mockMsg.read).toHaveBeenCalledWith({
+      className: 'ZMY_MSGS',
+      msgno: '001',
+    });
+    expect(payload(result).message.msgtext).toBe('Hello &1');
+  });
+});

--- a/src/handlers/message_class/high/handleCreateMessageClass.ts
+++ b/src/handlers/message_class/high/handleCreateMessageClass.ts
@@ -1,0 +1,142 @@
+/**
+ * CreateMessageClass Handler - Create an ABAP Message Class (MSAG) via AdtClient.
+ *
+ * Uses AdtClient.getMessageClass().create(). Message classes are not activated —
+ * create() registers the object in its final (usable) state.
+ */
+
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  ErrorCode,
+  McpError,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+import { validateTransportRequest } from '../../../utils/transportValidation';
+
+export const TOOL_DEFINITION = {
+  name: 'CreateMessageClass',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Operation: Create. Subject: Message Class (MSAG). Create a new ABAP message class (T100) shell. Individual messages are added afterwards with CreateMessageClassMessage. Message classes are not activated.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description:
+          'Message class name (e.g., ZMY_MSGS). Must follow SAP naming conventions.',
+      },
+      description: {
+        type: 'string',
+        description:
+          '(optional) Short description. If not provided, message_class_name is used.',
+      },
+      package_name: {
+        type: 'string',
+        description: 'Package name (e.g., ZMY_PKG, $TMP for local objects).',
+      },
+      transport_request: {
+        type: 'string',
+        description:
+          '(optional) Transport request number (e.g., E19K905635). Required for transportable packages.',
+      },
+      master_language: {
+        type: 'string',
+        description:
+          '(optional) Master/original language (e.g. "EN", "DE"). Defaults to the session language (SAP_LANGUAGE) or EN.',
+      },
+    },
+    required: ['message_class_name', 'package_name'],
+  },
+} as const;
+
+interface CreateMessageClassArgs {
+  message_class_name: string;
+  description?: string;
+  package_name: string;
+  transport_request?: string;
+  master_language?: string;
+}
+
+export async function handleCreateMessageClass(
+  context: HandlerContext,
+  args: CreateMessageClassArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    if (!args?.message_class_name) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'message_class_name is required',
+      );
+    }
+    if (!args?.package_name) {
+      throw new McpError(ErrorCode.InvalidParams, 'package_name is required');
+    }
+
+    // Transport required for transportable (non-$TMP/non-local) packages
+    validateTransportRequest(args.package_name, args.transport_request);
+
+    const name = args.message_class_name.toUpperCase();
+    const description = args.description || name;
+
+    logger?.info(`Starting message class creation: ${name}`);
+
+    const client = createAdtClient(connection, logger);
+
+    try {
+      await client.getMessageClass().create({
+        name,
+        description,
+        packageName: args.package_name,
+        transportRequest: args.transport_request,
+        masterLanguage: args.master_language,
+      });
+
+      logger?.info(`✅ CreateMessageClass completed: ${name}`);
+
+      return return_response({
+        data: JSON.stringify({
+          success: true,
+          message_class_name: name,
+          package: args.package_name,
+          transport_request: args.transport_request,
+          message: `Message class ${name} created successfully`,
+        }),
+      } as AxiosResponse);
+    } catch (error: any) {
+      logger?.error(
+        `Error creating message class ${name}: ${error?.message || error}`,
+      );
+
+      if (
+        error.message?.includes('already exists') ||
+        error.response?.data?.includes?.('ExceptionResourceAlreadyExists')
+      ) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Message class ${name} already exists. Delete it first or use a different name.`,
+        );
+      }
+
+      const errorMessage = error.response?.data
+        ? typeof error.response.data === 'string'
+          ? error.response.data
+          : String(error.response.data).substring(0, 500)
+        : error.message || String(error);
+
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create message class ${name}: ${errorMessage}`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/high/handleCreateMessageClassMessage.ts
+++ b/src/handlers/message_class/high/handleCreateMessageClassMessage.ts
@@ -1,0 +1,123 @@
+/**
+ * CreateMessageClassMessage Handler - Add (upsert) a single message to a
+ * Message Class (MSAG) via AdtClient.
+ *
+ * Uses AdtClient.getMessageClassMessage().create(). The parent message class
+ * must already exist (create it with CreateMessageClass). Lock/unlock of the
+ * class and the message is handled internally by the client.
+ */
+
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  ErrorCode,
+  McpError,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'CreateMessageClassMessage',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Operation: Create. Subject: a single message inside a Message Class (MSAG). Add a message (number + text) to an existing ABAP message class (T100). The parent class must exist first (CreateMessageClass).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Parent message class name (e.g., ZMY_MSGS).',
+      },
+      msgno: {
+        type: 'string',
+        description: 'Message number (e.g., "001").',
+      },
+      msgtext: {
+        type: 'string',
+        description:
+          'Message text. May contain placeholders &1 &2 &3 &4 (or &).',
+      },
+      self_explanatory: {
+        type: 'boolean',
+        description:
+          '(optional) Mark the message as self-explanatory (no long text needed). Default: false.',
+        default: false,
+      },
+      description: {
+        type: 'string',
+        description: '(optional) Long description for the message.',
+      },
+      transport_request: {
+        type: 'string',
+        description:
+          '(optional) Transport request number. Required for transportable objects.',
+      },
+    },
+    required: ['message_class_name', 'msgno', 'msgtext'],
+  },
+} as const;
+
+interface CreateMessageClassMessageArgs {
+  message_class_name: string;
+  msgno: string;
+  msgtext: string;
+  self_explanatory?: boolean;
+  description?: string;
+  transport_request?: string;
+}
+
+export async function handleCreateMessageClassMessage(
+  context: HandlerContext,
+  args: CreateMessageClassMessageArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    if (!args?.message_class_name) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'message_class_name is required',
+      );
+    }
+    if (!args?.msgno) {
+      throw new McpError(ErrorCode.InvalidParams, 'msgno is required');
+    }
+    if (args?.msgtext === undefined || args?.msgtext === null) {
+      throw new McpError(ErrorCode.InvalidParams, 'msgtext is required');
+    }
+
+    const client = createAdtClient(connection, logger);
+    const className = args.message_class_name.toUpperCase();
+
+    logger?.info(`Creating message ${args.msgno} in class ${className}`);
+
+    const state = await client.getMessageClassMessage().create({
+      className,
+      msgno: args.msgno,
+      msgtext: args.msgtext,
+      selfExplanatory: args.self_explanatory ?? false,
+      description: args.description,
+      transportRequest: args.transport_request,
+    });
+
+    logger?.info(
+      `✅ CreateMessageClassMessage completed: ${className}/${args.msgno}`,
+    );
+
+    return return_response({
+      data: JSON.stringify({
+        success: true,
+        message_class_name: className,
+        msgno: args.msgno,
+        transport_request: args.transport_request,
+        status: state.createResult?.status ?? state.updateResult?.status,
+        message: `Message ${args.msgno} created in message class ${className}`,
+      }),
+    } as AxiosResponse);
+  } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/high/handleDeleteMessageClass.ts
+++ b/src/handlers/message_class/high/handleDeleteMessageClass.ts
@@ -1,0 +1,78 @@
+/**
+ * DeleteMessageClass Handler - Delete an ABAP Message Class (MSAG) via AdtClient.
+ *
+ * Uses AdtClient.getMessageClass().delete(), which runs the ADT deletion
+ * check + delete service. Deletes the class and all of its messages.
+ */
+
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'DeleteMessageClass',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Delete an ABAP message class (MSAG) and all of its messages from the SAP system. Includes a deletion check before the actual deletion. Transport request required for transportable objects, optional for local ($TMP).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Message class name (e.g., ZMY_MSGS).',
+      },
+      transport_request: {
+        type: 'string',
+        description:
+          'Transport request number (e.g., E19K905635). Required for transportable objects, optional for local ($TMP).',
+      },
+    },
+    required: ['message_class_name'],
+  },
+} as const;
+
+interface DeleteMessageClassArgs {
+  message_class_name: string;
+  transport_request?: string;
+}
+
+export async function handleDeleteMessageClass(
+  context: HandlerContext,
+  args: DeleteMessageClassArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const { message_class_name, transport_request } = args;
+    if (!message_class_name) {
+      return return_error(new Error('message_class_name is required'));
+    }
+
+    const client = createAdtClient(connection, logger);
+    const name = message_class_name.toUpperCase();
+
+    logger?.info(`Starting message class deletion: ${name}`);
+
+    const state = await client.getMessageClass().delete({
+      name,
+      transportRequest: transport_request,
+    });
+
+    logger?.info(`✅ DeleteMessageClass completed: ${name}`);
+
+    return return_response({
+      data: JSON.stringify({
+        success: true,
+        message_class_name: name,
+        transport_request,
+        status: state.deleteResult?.status,
+        message: `Message class ${name} deleted successfully`,
+      }),
+    } as AxiosResponse);
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/high/handleDeleteMessageClassMessage.ts
+++ b/src/handlers/message_class/high/handleDeleteMessageClassMessage.ts
@@ -1,0 +1,92 @@
+/**
+ * DeleteMessageClassMessage Handler - Delete a single message from a Message
+ * Class (MSAG) via AdtClient.
+ *
+ * Uses AdtClient.getMessageClassMessage().delete(). The parent class is kept;
+ * only the one message (by number) is removed. Lock/unlock is handled
+ * internally by the client.
+ */
+
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'DeleteMessageClassMessage',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Operation: Delete. Subject: a single message inside a Message Class (MSAG). Remove one message (by number) from an ABAP message class (T100), keeping the class and its other messages. Transport request required for transportable objects.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Parent message class name (e.g., ZMY_MSGS).',
+      },
+      msgno: {
+        type: 'string',
+        description: 'Message number to delete (e.g., "001").',
+      },
+      transport_request: {
+        type: 'string',
+        description:
+          'Transport request number. Required for transportable objects, optional for local ($TMP).',
+      },
+    },
+    required: ['message_class_name', 'msgno'],
+  },
+} as const;
+
+interface DeleteMessageClassMessageArgs {
+  message_class_name: string;
+  msgno: string;
+  transport_request?: string;
+}
+
+export async function handleDeleteMessageClassMessage(
+  context: HandlerContext,
+  args: DeleteMessageClassMessageArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const { message_class_name, msgno, transport_request } = args;
+    if (!message_class_name) {
+      return return_error(new Error('message_class_name is required'));
+    }
+    if (!msgno) {
+      return return_error(new Error('msgno is required'));
+    }
+
+    const client = createAdtClient(connection, logger);
+    const className = message_class_name.toUpperCase();
+
+    logger?.info(`Deleting message ${msgno} from class ${className}`);
+
+    const state = await client.getMessageClassMessage().delete({
+      className,
+      msgno,
+      transportRequest: transport_request,
+    });
+
+    logger?.info(
+      `✅ DeleteMessageClassMessage completed: ${className}/${msgno}`,
+    );
+
+    return return_response({
+      data: JSON.stringify({
+        success: true,
+        message_class_name: className,
+        msgno,
+        transport_request,
+        status: state.deleteResult?.status,
+        message: `Message ${msgno} deleted from message class ${className}`,
+      }),
+    } as AxiosResponse);
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/high/handleGetMessageClass.ts
+++ b/src/handlers/message_class/high/handleGetMessageClass.ts
@@ -1,0 +1,75 @@
+/**
+ * GetMessageClass Handler - Read an ABAP Message Class (MSAG) via AdtClient.
+ *
+ * Uses AdtClient.getMessageClass().read(). Message classes are not versioned
+ * or activatable, so there is no version parameter.
+ */
+
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'GetMessageClass',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Retrieve an ABAP message class (MSAG/T100) with its messages: name, description, package, master language and the message list (msgno, msgtext, self-explanatory).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Message class name (e.g., ZMY_MSGS).',
+      },
+    },
+    required: ['message_class_name'],
+  },
+} as const;
+
+interface GetMessageClassArgs {
+  message_class_name: string;
+}
+
+export async function handleGetMessageClass(
+  context: HandlerContext,
+  args: GetMessageClassArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const { message_class_name } = args;
+    if (!message_class_name) {
+      return return_error(new Error('message_class_name is required'));
+    }
+
+    const client = createAdtClient(connection, logger);
+    const name = message_class_name.toUpperCase();
+
+    logger?.info(`Reading message class ${name}`);
+
+    const state = await client.getMessageClass().read({ name });
+    if (!state) {
+      return return_error(new Error(`Message class ${name} not found.`));
+    }
+
+    logger?.info(`✅ GetMessageClass completed: ${name}`);
+
+    return return_response({
+      data: JSON.stringify(
+        {
+          success: true,
+          message_class_name: name,
+          message_class: state.messageClass ?? null,
+          status: state.readResult?.status,
+        },
+        null,
+        2,
+      ),
+    } as AxiosResponse);
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/high/handleGetMessageClassMessage.ts
+++ b/src/handlers/message_class/high/handleGetMessageClassMessage.ts
@@ -1,0 +1,84 @@
+/**
+ * GetMessageClassMessage Handler - Read a single message from a Message Class (MSAG).
+ *
+ * Uses AdtClient.getMessageClassMessage().read().
+ */
+
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'GetMessageClassMessage',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Retrieve a single message (by number) from an ABAP message class (MSAG/T100). Returns msgno, msgtext, self-explanatory flag and description.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Parent message class name (e.g., ZMY_MSGS).',
+      },
+      msgno: {
+        type: 'string',
+        description: 'Message number (e.g., "001").',
+      },
+    },
+    required: ['message_class_name', 'msgno'],
+  },
+} as const;
+
+interface GetMessageClassMessageArgs {
+  message_class_name: string;
+  msgno: string;
+}
+
+export async function handleGetMessageClassMessage(
+  context: HandlerContext,
+  args: GetMessageClassMessageArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const { message_class_name, msgno } = args;
+    if (!message_class_name) {
+      return return_error(new Error('message_class_name is required'));
+    }
+    if (!msgno) {
+      return return_error(new Error('msgno is required'));
+    }
+
+    const client = createAdtClient(connection, logger);
+    const className = message_class_name.toUpperCase();
+
+    logger?.info(`Reading message ${msgno} of message class ${className}`);
+
+    const state = await client
+      .getMessageClassMessage()
+      .read({ className, msgno });
+    if (!state) {
+      return return_error(new Error(`Message class ${className} not found.`));
+    }
+
+    logger?.info(`✅ GetMessageClassMessage completed: ${className}/${msgno}`);
+
+    return return_response({
+      data: JSON.stringify(
+        {
+          success: true,
+          message_class_name: className,
+          msgno,
+          message: state.message ?? null,
+        },
+        null,
+        2,
+      ),
+    } as AxiosResponse);
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/high/handleUpdateMessageClass.ts
+++ b/src/handlers/message_class/high/handleUpdateMessageClass.ts
@@ -1,0 +1,89 @@
+/**
+ * UpdateMessageClass Handler - Update an ABAP Message Class (MSAG) via AdtClient.
+ *
+ * Uses AdtClient.getMessageClass().update() — currently updates the class
+ * description. Individual messages are managed with the *MessageClassMessage tools.
+ * Lock/unlock is handled internally by the client.
+ */
+
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'UpdateMessageClass',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Operation: Update. Subject: Message Class (MSAG). Update a message class header (e.g. its description). To add or change individual messages use CreateMessageClassMessage / UpdateMessageClassMessage.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Message class name (e.g., ZMY_MSGS).',
+      },
+      description: {
+        type: 'string',
+        description: 'New short description for the message class.',
+      },
+      transport_request: {
+        type: 'string',
+        description:
+          '(optional) Transport request number. Required for transportable objects.',
+      },
+    },
+    required: ['message_class_name', 'description'],
+  },
+} as const;
+
+interface UpdateMessageClassArgs {
+  message_class_name: string;
+  description: string;
+  transport_request?: string;
+}
+
+export async function handleUpdateMessageClass(
+  context: HandlerContext,
+  args: UpdateMessageClassArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const { message_class_name, description, transport_request } = args;
+    if (!message_class_name) {
+      return return_error(new Error('message_class_name is required'));
+    }
+    if (!description) {
+      return return_error(new Error('description is required'));
+    }
+
+    const client = createAdtClient(connection, logger);
+    const name = message_class_name.toUpperCase();
+
+    logger?.info(`Updating message class ${name}`);
+
+    const state = await client.getMessageClass().update({
+      name,
+      description,
+      transportRequest: transport_request,
+    });
+
+    logger?.info(`✅ UpdateMessageClass completed: ${name}`);
+
+    return return_response({
+      data: JSON.stringify({
+        success: true,
+        message_class_name: name,
+        description,
+        transport_request,
+        status: state.updateResult?.status,
+        message: `Message class ${name} updated successfully`,
+      }),
+    } as AxiosResponse);
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/high/handleUpdateMessageClassMessage.ts
+++ b/src/handlers/message_class/high/handleUpdateMessageClassMessage.ts
@@ -1,0 +1,120 @@
+/**
+ * UpdateMessageClassMessage Handler - Update (upsert) a single message in a
+ * Message Class (MSAG) via AdtClient.
+ *
+ * Uses AdtClient.getMessageClassMessage().update(). Lock/unlock is handled
+ * internally by the client.
+ */
+
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'UpdateMessageClassMessage',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Operation: Update. Subject: a single message inside a Message Class (MSAG). Change the text / flags of an existing message in an ABAP message class (T100). Upserts the message if it does not exist yet.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Parent message class name (e.g., ZMY_MSGS).',
+      },
+      msgno: {
+        type: 'string',
+        description: 'Message number (e.g., "001").',
+      },
+      msgtext: {
+        type: 'string',
+        description:
+          'New message text. May contain placeholders &1 &2 &3 &4 (or &).',
+      },
+      self_explanatory: {
+        type: 'boolean',
+        description: '(optional) Mark the message as self-explanatory.',
+      },
+      description: {
+        type: 'string',
+        description: '(optional) Long description for the message.',
+      },
+      transport_request: {
+        type: 'string',
+        description:
+          '(optional) Transport request number. Required for transportable objects.',
+      },
+    },
+    required: ['message_class_name', 'msgno', 'msgtext'],
+  },
+} as const;
+
+interface UpdateMessageClassMessageArgs {
+  message_class_name: string;
+  msgno: string;
+  msgtext: string;
+  self_explanatory?: boolean;
+  description?: string;
+  transport_request?: string;
+}
+
+export async function handleUpdateMessageClassMessage(
+  context: HandlerContext,
+  args: UpdateMessageClassMessageArgs,
+) {
+  const { connection, logger } = context;
+  try {
+    const {
+      message_class_name,
+      msgno,
+      msgtext,
+      self_explanatory,
+      description,
+      transport_request,
+    } = args;
+    if (!message_class_name) {
+      return return_error(new Error('message_class_name is required'));
+    }
+    if (!msgno) {
+      return return_error(new Error('msgno is required'));
+    }
+    if (msgtext === undefined || msgtext === null) {
+      return return_error(new Error('msgtext is required'));
+    }
+
+    const client = createAdtClient(connection, logger);
+    const className = message_class_name.toUpperCase();
+
+    logger?.info(`Updating message ${msgno} in class ${className}`);
+
+    const state = await client.getMessageClassMessage().update({
+      className,
+      msgno,
+      msgtext,
+      selfExplanatory: self_explanatory,
+      description,
+      transportRequest: transport_request,
+    });
+
+    logger?.info(
+      `✅ UpdateMessageClassMessage completed: ${className}/${msgno}`,
+    );
+
+    return return_response({
+      data: JSON.stringify({
+        success: true,
+        message_class_name: className,
+        msgno,
+        transport_request,
+        status: state.updateResult?.status,
+        message: `Message ${msgno} updated in message class ${className}`,
+      }),
+    } as AxiosResponse);
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/readonly/handleReadMessageClass.ts
+++ b/src/handlers/message_class/readonly/handleReadMessageClass.ts
@@ -1,0 +1,59 @@
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'ReadMessageClass',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Operation: Read. Subject: Message Class (MSAG). Will be useful for reading a message class and its messages. [read-only] Read an ABAP message class (T100) with all of its messages. Answers: "show message class X", "list messages of message class", "display message text 001 of class". Returns name, description, package, master language and the array of messages (msgno, msgtext, self-explanatory, description).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Message class name (e.g., ZMY_MSGS).',
+      },
+    },
+    required: ['message_class_name'],
+  },
+} as const;
+
+export async function handleReadMessageClass(
+  context: HandlerContext,
+  args: { message_class_name: string },
+) {
+  const { connection, logger } = context;
+  try {
+    const { message_class_name } = args;
+    if (!message_class_name) {
+      return return_error(new Error('message_class_name is required'));
+    }
+
+    const client = createAdtClient(connection, logger);
+    const name = message_class_name.toUpperCase();
+
+    const state = await client.getMessageClass().read({ name });
+    if (!state) {
+      return return_error(new Error(`Message class ${name} not found.`));
+    }
+
+    return return_response({
+      data: JSON.stringify(
+        {
+          success: true,
+          message_class_name: name,
+          message_class: state.messageClass ?? null,
+        },
+        null,
+        2,
+      ),
+    } as AxiosResponse);
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/handlers/message_class/readonly/handleReadMessageClassMessage.ts
+++ b/src/handlers/message_class/readonly/handleReadMessageClassMessage.ts
@@ -1,0 +1,69 @@
+import { createAdtClient } from '../../../lib/clients';
+import type { HandlerContext } from '../../../lib/handlers/interfaces';
+import {
+  type AxiosResponse,
+  return_error,
+  return_response,
+} from '../../../lib/utils';
+
+export const TOOL_DEFINITION = {
+  name: 'ReadMessageClassMessage',
+  available_in: ['onprem', 'cloud'] as const,
+  description:
+    'Operation: Read. Subject: a single message inside a Message Class (MSAG). [read-only] Read one message (by number) from an ABAP message class. Answers: "show message 001 of class ZMY_MSGS", "get text of message". Returns msgno, msgtext, self-explanatory flag and description.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message_class_name: {
+        type: 'string',
+        description: 'Parent message class name (e.g., ZMY_MSGS).',
+      },
+      msgno: {
+        type: 'string',
+        description: 'Message number (e.g., "001").',
+      },
+    },
+    required: ['message_class_name', 'msgno'],
+  },
+} as const;
+
+export async function handleReadMessageClassMessage(
+  context: HandlerContext,
+  args: { message_class_name: string; msgno: string },
+) {
+  const { connection, logger } = context;
+  try {
+    const { message_class_name, msgno } = args;
+    if (!message_class_name) {
+      return return_error(new Error('message_class_name is required'));
+    }
+    if (!msgno) {
+      return return_error(new Error('msgno is required'));
+    }
+
+    const client = createAdtClient(connection, logger);
+    const className = message_class_name.toUpperCase();
+
+    const state = await client
+      .getMessageClassMessage()
+      .read({ className, msgno });
+    if (!state) {
+      return return_error(new Error(`Message class ${className} not found.`));
+    }
+
+    return return_response({
+      data: JSON.stringify(
+        {
+          success: true,
+          message_class_name: className,
+          msgno,
+          message: state.message ?? null,
+        },
+        null,
+        2,
+      ),
+    } as AxiosResponse);
+  } catch (error: any) {
+    return return_error(error);
+  }
+}

--- a/src/lib/handlers/groups/HighLevelHandlersGroup.ts
+++ b/src/lib/handlers/groups/HighLevelHandlersGroup.ts
@@ -289,6 +289,38 @@ import {
   handleActivateInterface,
 } from '../../../handlers/interface/low/handleActivateInterface';
 import {
+  TOOL_DEFINITION as CreateMessageClass_Tool,
+  handleCreateMessageClass,
+} from '../../../handlers/message_class/high/handleCreateMessageClass';
+import {
+  TOOL_DEFINITION as CreateMessageClassMessage_Tool,
+  handleCreateMessageClassMessage,
+} from '../../../handlers/message_class/high/handleCreateMessageClassMessage';
+import {
+  TOOL_DEFINITION as DeleteMessageClass_Tool,
+  handleDeleteMessageClass,
+} from '../../../handlers/message_class/high/handleDeleteMessageClass';
+import {
+  TOOL_DEFINITION as DeleteMessageClassMessage_Tool,
+  handleDeleteMessageClassMessage,
+} from '../../../handlers/message_class/high/handleDeleteMessageClassMessage';
+import {
+  TOOL_DEFINITION as GetMessageClass_Tool,
+  handleGetMessageClass,
+} from '../../../handlers/message_class/high/handleGetMessageClass';
+import {
+  TOOL_DEFINITION as GetMessageClassMessage_Tool,
+  handleGetMessageClassMessage,
+} from '../../../handlers/message_class/high/handleGetMessageClassMessage';
+import {
+  handleUpdateMessageClass,
+  TOOL_DEFINITION as UpdateMessageClass_Tool,
+} from '../../../handlers/message_class/high/handleUpdateMessageClass';
+import {
+  handleUpdateMessageClassMessage,
+  TOOL_DEFINITION as UpdateMessageClassMessage_Tool,
+} from '../../../handlers/message_class/high/handleUpdateMessageClassMessage';
+import {
   TOOL_DEFINITION as DeleteMetadataExtension_Tool,
   handleDeleteMetadataExtension,
 } from '../../../handlers/metadata_extension/high/handleDeleteMetadataExtension';
@@ -662,6 +694,38 @@ export class HighLevelHandlersGroup extends BaseHandlerGroup {
       {
         toolDefinition: DeleteDomain_Tool,
         handler: withContext(handleDeleteDomain),
+      },
+      {
+        toolDefinition: GetMessageClass_Tool,
+        handler: withContext(handleGetMessageClass),
+      },
+      {
+        toolDefinition: CreateMessageClass_Tool,
+        handler: withContext(handleCreateMessageClass),
+      },
+      {
+        toolDefinition: UpdateMessageClass_Tool,
+        handler: withContext(handleUpdateMessageClass),
+      },
+      {
+        toolDefinition: DeleteMessageClass_Tool,
+        handler: withContext(handleDeleteMessageClass),
+      },
+      {
+        toolDefinition: GetMessageClassMessage_Tool,
+        handler: withContext(handleGetMessageClassMessage),
+      },
+      {
+        toolDefinition: CreateMessageClassMessage_Tool,
+        handler: withContext(handleCreateMessageClassMessage),
+      },
+      {
+        toolDefinition: UpdateMessageClassMessage_Tool,
+        handler: withContext(handleUpdateMessageClassMessage),
+      },
+      {
+        toolDefinition: DeleteMessageClassMessage_Tool,
+        handler: withContext(handleDeleteMessageClassMessage),
       },
       {
         toolDefinition: CreateDataElement_Tool,

--- a/src/lib/handlers/groups/ReadOnlyHandlersGroup.ts
+++ b/src/lib/handlers/groups/ReadOnlyHandlersGroup.ts
@@ -79,6 +79,14 @@ import {
   TOOL_DEFINITION as ReadInterface_Tool,
 } from '../../../handlers/interface/readonly/handleReadInterface';
 import {
+  handleReadMessageClass,
+  TOOL_DEFINITION as ReadMessageClass_Tool,
+} from '../../../handlers/message_class/readonly/handleReadMessageClass';
+import {
+  handleReadMessageClassMessage,
+  TOOL_DEFINITION as ReadMessageClassMessage_Tool,
+} from '../../../handlers/message_class/readonly/handleReadMessageClassMessage';
+import {
   handleReadMetadataExtension,
   TOOL_DEFINITION as ReadMetadataExtension_Tool,
 } from '../../../handlers/metadata_extension/readonly/handleReadMetadataExtension';
@@ -251,6 +259,15 @@ export class ReadOnlyHandlersGroup extends BaseHandlerGroup {
       {
         toolDefinition: ReadDomain_Tool,
         handler: (args: any) => handleReadDomain(this.context, args),
+      },
+      {
+        toolDefinition: ReadMessageClass_Tool,
+        handler: (args: any) => handleReadMessageClass(this.context, args),
+      },
+      {
+        toolDefinition: ReadMessageClassMessage_Tool,
+        handler: (args: any) =>
+          handleReadMessageClassMessage(this.context, args),
       },
       {
         toolDefinition: ReadDataElement_Tool,


### PR DESCRIPTION
## Summary
Exposes the new **Message Class (MSAG / T100)** client from `@mcp-abap-adt/adt-clients` 7.3.x as MCP tools, and migrates the deps.

### New tools (10)
**ReadOnly group** (analytics):
- `ReadMessageClass` — class header + all messages
- `ReadMessageClassMessage` — one message by number

**HighLevel group** (dev CRUD):
- `GetMessageClass`, `CreateMessageClass`, `UpdateMessageClass`, `DeleteMessageClass`
- `GetMessageClassMessage`, `CreateMessageClassMessage`, `UpdateMessageClassMessage`, `DeleteMessageClassMessage`

Message classes are **not activatable/versioned**, so there are deliberately no Check/Activate/Versions tools for them. Transport handling mirrors the other CRUD objects (`transport_request` → `corrNr`, required for transportable packages). `available_in: ['onprem', 'cloud']`.

### Dependency migration
- `@mcp-abap-adt/adt-clients` `^7.2.1 → ^7.3.1` (7.3.0 adds `getMessageClass()` / `getMessageClassMessage()`; 7.3.1 wires `corrNr` transport)
- `@mcp-abap-adt/interfaces` `^9.1.0 → ^9.2.0`

Also carries the 8.5.2 `yaml` install fix (#143), since this is built on top of it — so publishing 8.6.0 ships both.

## Verification
- Registered in `ReadOnlyHandlersGroup` + `HighLevelHandlersGroup`; docs regenerated (`docs:tools`) — 10 tools appear across HIGH/READONLY/combined docs
- Added `handleMessageClass` unit tests (7) — dispatch + camelCase config mapping, SAP-free via mocked AdtClient
- `npm run build` ✅ · `test:check` ✅ · **360 unit tests** (18 suites) ✅ · `npm audit` **0**
- Versions **8.6.0** consistent across `package.json` / `package-lock.json` / `server.json`; no `link:`/`file:` in lock

### Follow-up (not in this PR)
- Integration tests against a real SAP system need a shared MSAG object (`shared:setup` collaboration) — deferred; the client is already covered by adt-clients' own integration tests, and E2E can be verified via cloud-llm-hub after publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)