### PR TITLE
chore(registry): declare SAP env vars in server.json (#142 follow-up) — 8.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.6.1] - 2026-07-05
+
+### Changed
+- **Declared the SAP connection environment variables in `server.json` (#142 follow-up).** The MCP Registry entry carried no `environmentVariables`, so registry-based installers (e.g. FLUJO) launched the server with no configuration — it then ran in tool-inspection-only mode and the client timed out waiting for a usable connection. `server.json` now declares the connection variables (`SAP_URL` required; `SAP_AUTH_TYPE`, `SAP_SYSTEM_TYPE` with choices/defaults; `SAP_CLIENT`, `SAP_JWT_TOKEN` (secret), `SAP_USERNAME`, `SAP_PASSWORD` (secret), `SAP_LANGUAGE`, `SAP_MASTER_SYSTEM`, `SAP_RESPONSIBLE`), so registry clients can prompt for and inject them. No code change — the server already completes the MCP handshake without env vars (verified); this only surfaces the required configuration to installers. Republished to the MCP Registry via `mcp-publisher`.
+
 ## [8.6.0] - 2026-07-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,15 +6,77 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.6.0",
+  "version": "8.6.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "environmentVariables": [
+        {
+          "name": "SAP_URL",
+          "description": "Base URL of the ABAP system (e.g. https://my-system.example.com or a BTP ABAP service URL). Required to connect; without it the server starts in tool-inspection-only mode.",
+          "isRequired": true,
+          "format": "string",
+          "placeholder": "https://your-abap-system.example.com"
+        },
+        {
+          "name": "SAP_AUTH_TYPE",
+          "description": "Authentication method: 'xsuaa' for JWT/OAuth2 (BTP ABAP Cloud) or 'basic' for username/password (on-prem).",
+          "format": "string",
+          "choices": ["xsuaa", "basic"],
+          "default": "xsuaa"
+        },
+        {
+          "name": "SAP_SYSTEM_TYPE",
+          "description": "System type, controls which tools are available (e.g. Programs are onprem-only).",
+          "format": "string",
+          "choices": ["cloud", "onprem", "legacy"],
+          "default": "cloud"
+        },
+        {
+          "name": "SAP_CLIENT",
+          "description": "ABAP client/mandant number (e.g. 100). Optional for BTP ABAP Cloud.",
+          "format": "string",
+          "placeholder": "100"
+        },
+        {
+          "name": "SAP_JWT_TOKEN",
+          "description": "JWT bearer token for SAP_AUTH_TYPE=xsuaa. Provide this (or the SAP_UAA_* refresh-token set) for JWT auth.",
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "SAP_USERNAME",
+          "description": "Username for SAP_AUTH_TYPE=basic (on-prem).",
+          "format": "string"
+        },
+        {
+          "name": "SAP_PASSWORD",
+          "description": "Password for SAP_AUTH_TYPE=basic (on-prem).",
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "SAP_LANGUAGE",
+          "description": "Logon language (ISO code, e.g. 'en', 'de').",
+          "format": "string",
+          "default": "en"
+        },
+        {
+          "name": "SAP_MASTER_SYSTEM",
+          "description": "System context for on-prem create/update operations (e.g. DEV).",
+          "format": "string"
+        },
+        {
+          "name": "SAP_RESPONSIBLE",
+          "description": "Responsible user for on-prem create/update operations.",
+          "format": "string"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Why
Follow-up to #142. After the registry entry was refreshed to a working version, @mario-andreschak reported that a registry-based install (FLUJO) still isn't 1-click: `server.json` declared **no** environment variables, so the installer launched the server with no config → it ran in tool-inspection-only mode → the client timed out waiting for a usable connection.

## What
Declared the SAP connection variables in `server.json` → `packages[].environmentVariables`, so registry clients can prompt for / inject them:
- `SAP_URL` (**required**)
- `SAP_AUTH_TYPE` (`xsuaa` | `basic`, default `xsuaa`), `SAP_SYSTEM_TYPE` (`cloud` | `onprem` | `legacy`, default `cloud`)
- `SAP_CLIENT`, `SAP_JWT_TOKEN` (secret), `SAP_USERNAME`, `SAP_PASSWORD` (secret), `SAP_LANGUAGE`, `SAP_MASTER_SYSTEM`, `SAP_RESPONSIBLE`

**No code change.** Verified the server already completes the MCP handshake without env vars (sent `initialize` over stdio with no env → valid response, no hang), so this is purely surfacing the required config to installers. `server.json` validated against the `2025-12-11` schema.

## Release
Metadata-only patch **8.6.1** (server.json is not in the npm tarball → identical code). After merge: publish npm `8.6.1`, then `mcp-publisher publish` to push the new `server.json` to the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)