### PR TITLE
fix(locks): uninterruptible critical section for mutating tools — 8.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [8.7.0] - 2026-07-16
+
+### Fixed
+- **Timeouts no longer leave objects locked and inactive.** A mutating tool (Create/Update/Delete) runs a stateful lock → modify → unlock chain as several separate ADT requests. On a slow system a short per-request timeout would abort one of them mid-flight; aborting the socket drops the stateful ADT session and orphans the lock handle, so the follow-up unlock has nothing to release — the object was left **locked and inactive** (whereas a normal error keeps the session alive, so unlock worked). Every high-level Create/Update/Delete handler (70 tools) is now wrapped in an **uninterruptible critical section**: `beginCriticalSection()` before it runs and `endCriticalSection()` in a `finally`, via `@mcp-abap-adt/connection` 1.10.0. While active, the connection raises the request timeout to a large ceiling (`SAP_TIMEOUT_CRITICAL`, default 600000 ms) so slow write requests run to completion instead of being interrupted. Feature-detected, so it degrades to a no-op on older connections.
+
+### Changed
+- **Migrated to `@mcp-abap-adt/connection@^1.10.0`** (from `^1.9.1`), which adds the reference-counted `beginCriticalSection()` / `endCriticalSection()` primitives used above. Non-breaking.
+
 ## [8.6.1] - 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.6.1",
+  "version": "8.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.6.1",
+      "version": "8.7.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^7.3.1",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
-        "@mcp-abap-adt/connection": "^1.9.1",
+        "@mcp-abap-adt/connection": "^1.10.0",
         "@mcp-abap-adt/header-validator": "^0.1.8",
         "@mcp-abap-adt/interfaces": "^9.2.0",
         "@mcp-abap-adt/logger": "^0.1.4",
@@ -321,13 +321,13 @@
       }
     },
     "node_modules/@mcp-abap-adt/connection": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/connection/-/connection-1.9.1.tgz",
-      "integrity": "sha512-AyrE3CoZyTR5t0JBm/W0g4HOksrRwA3qJvNnU+9vuCdsm6hq14eXjx4PC3wTSUPLPdCIITxJi6gjYhfhMpdIDA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/connection/-/connection-1.10.0.tgz",
+      "integrity": "sha512-+ROM2T0mpes2YaNFZLJY/xSYatgrrBdde7ixxKht1Fa9c+Pn/5cNUIN1soC65cqYRc7g5Fduk0iR804qCJcaYw==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.2.0",
-        "axios": "^1.13.5",
+        "axios": "^1.16.0",
         "commander": "^14.0.3",
         "express": "^5.1.0",
         "open": "^11.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.6.1",
+  "version": "8.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -141,7 +141,7 @@
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",
-    "@mcp-abap-adt/connection": "^1.9.1",
+    "@mcp-abap-adt/connection": "^1.10.0",
     "@mcp-abap-adt/header-validator": "^0.1.8",
     "@mcp-abap-adt/interfaces": "^9.2.0",
     "@mcp-abap-adt/logger": "^0.1.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.6.1",
+  "version": "8.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.6.1",
+      "version": "8.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/unit/criticalSection.test.ts
+++ b/src/__tests__/unit/criticalSection.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests: withCriticalSection / isMutatingToolName.
+ * The wrapper must bracket a mutating handler with the connection's
+ * begin/endCriticalSection() — including on throw — so a lock → modify →
+ * unlock chain runs uninterruptibly. Feature-detected: a connection without
+ * the methods is a no-op.
+ */
+import {
+  isMutatingToolName,
+  withCriticalSection,
+} from '../../lib/criticalSection';
+
+describe('isMutatingToolName', () => {
+  it('matches Create/Update/Delete tools', () => {
+    for (const n of [
+      'CreateDomain',
+      'UpdateMessageClass',
+      'DeleteMessageClassMessage',
+    ]) {
+      expect(isMutatingToolName(n)).toBe(true);
+    }
+  });
+  it('does not match read/activate tools', () => {
+    for (const n of ['GetDomain', 'ReadTable', 'ActivateClass', 'GetSession']) {
+      expect(isMutatingToolName(n)).toBe(false);
+    }
+  });
+});
+
+describe('withCriticalSection', () => {
+  it('calls begin before and end after the handler (success path)', async () => {
+    const calls: string[] = [];
+    const conn = {
+      beginCriticalSection: () => calls.push('begin'),
+      endCriticalSection: () => calls.push('end'),
+    };
+    const handler = async (_ctx: unknown, _args: unknown) => {
+      calls.push('handler');
+      return { ok: true };
+    };
+
+    const wrapped = withCriticalSection(handler, () => conn);
+    const res = await wrapped({} as any, {});
+
+    expect(res).toEqual({ ok: true });
+    expect(calls).toEqual(['begin', 'handler', 'end']);
+  });
+
+  it('still calls end when the handler throws', async () => {
+    const calls: string[] = [];
+    const conn = {
+      beginCriticalSection: () => calls.push('begin'),
+      endCriticalSection: () => calls.push('end'),
+    };
+    const handler = async (_ctx: unknown, _args: unknown) => {
+      calls.push('handler');
+      throw new Error('boom');
+    };
+
+    const wrapped = withCriticalSection(handler, () => conn);
+    await expect(wrapped({} as any, {})).rejects.toThrow('boom');
+    expect(calls).toEqual(['begin', 'handler', 'end']);
+  });
+
+  it('is a no-op on a connection lacking the methods (older connection)', async () => {
+    const handler = async () => 'ok';
+    const wrapped = withCriticalSection(handler, () => ({}) as unknown);
+    await expect(wrapped()).resolves.toBe('ok');
+  });
+
+  it('tolerates a null/undefined connection', async () => {
+    const handler = async () => 'ok';
+    const wrapped = withCriticalSection(handler, () => undefined);
+    await expect(wrapped()).resolves.toBe('ok');
+  });
+});

--- a/src/lib/criticalSection.ts
+++ b/src/lib/criticalSection.ts
@@ -1,0 +1,53 @@
+/**
+ * Uninterruptible critical section wrapper for mutating handlers.
+ *
+ * A mutating operation (Create/Update/Delete) runs a stateful
+ * lock → modify → unlock chain. If a short per-request timeout aborts one of
+ * those requests mid-flight, tearing down the socket drops the stateful ADT
+ * session and orphans the lock handle — the object is left locked and inactive.
+ * (A normal error keeps the session alive, so the finally-unlock works; only a
+ * timeout leaves it locked — see @mcp-abap-adt/connection 1.10.0.)
+ *
+ * `@mcp-abap-adt/connection` (>= 1.10.0) exposes reference-counted
+ * `beginCriticalSection()` / `endCriticalSection()`: while active, the request
+ * timeout is raised to a large ceiling (SAP_TIMEOUT_CRITICAL) so slow
+ * write requests run to completion instead of being aborted. We bracket the
+ * whole mutating handler with it — begin before it runs, end in a `finally`.
+ *
+ * The methods are feature-detected via a structural cast, so this degrades to a
+ * no-op against an older connection that lacks them (no hard dependency on the
+ * IAbapConnection interface shape).
+ */
+
+interface CriticalSectionCapable {
+  beginCriticalSection?: () => void;
+  endCriticalSection?: () => void;
+}
+
+/**
+ * Wrap a handler so the connection is held in an uninterruptible critical
+ * section for the whole call. `getConnection` is a thunk because the connection
+ * lives on the per-request handler context, resolved when the handler runs.
+ *
+ * Generic over the handler's own signature so the wrapped function keeps the
+ * exact arity/return type (and stays assignable to `ToolHandler`).
+ */
+export function withCriticalSection<H extends (...args: any[]) => any>(
+  handler: H,
+  getConnection: () => unknown,
+): (...args: Parameters<H>) => Promise<Awaited<ReturnType<H>>> {
+  return async (...args: Parameters<H>) => {
+    const conn = getConnection() as CriticalSectionCapable | null | undefined;
+    conn?.beginCriticalSection?.();
+    try {
+      return await handler(...args);
+    } finally {
+      conn?.endCriticalSection?.();
+    }
+  };
+}
+
+/** Tool names that run a lock → modify → unlock chain and must not be interrupted. */
+export function isMutatingToolName(name: string): boolean {
+  return /^(Create|Update|Delete)/.test(name);
+}

--- a/src/lib/handlers/groups/HighLevelHandlersGroup.ts
+++ b/src/lib/handlers/groups/HighLevelHandlersGroup.ts
@@ -518,6 +518,10 @@ import {
   handleUpdateUnitTest,
   TOOL_DEFINITION as UpdateUnitTest_Tool,
 } from '../../../handlers/unit_test/high/handleUpdateUnitTest';
+import {
+  isMutatingToolName,
+  withCriticalSection,
+} from '../../criticalSection.js';
 import { BaseHandlerGroup } from '../base/BaseHandlerGroup.js';
 import type { HandlerEntry } from '../interfaces.js';
 
@@ -538,7 +542,7 @@ export class HighLevelHandlersGroup extends BaseHandlerGroup {
       return (args: unknown) => handler(this.context, args as TArgs);
     };
 
-    return [
+    const entries: HandlerEntry[] = [
       // Common — group activation
       {
         toolDefinition: ActivateObjects_Tool,
@@ -1136,5 +1140,22 @@ export class HighLevelHandlersGroup extends BaseHandlerGroup {
         handler: withContext(entry.handler),
       })),
     ];
+
+    // Mutating tools (Create/Update/Delete) run a stateful lock → modify →
+    // unlock chain in a single call. Wrap them in an uninterruptible critical
+    // section so a slow request is not aborted mid-flight, which would drop the
+    // stateful session and orphan the lock (leaving the object locked/inactive).
+    // No-op on connections older than @mcp-abap-adt/connection 1.10.0.
+    return entries.map((entry) =>
+      isMutatingToolName(entry.toolDefinition.name)
+        ? {
+            ...entry,
+            handler: withCriticalSection(
+              entry.handler,
+              () => this.context.connection,
+            ),
+          }
+        : entry,
+    );
   }
 }


### PR DESCRIPTION
## Problem
A mutating tool (Create/Update/Delete) runs a stateful **lock → modify → unlock** chain as several separate ADT requests. On a slow system, a short per-request timeout aborts one of them mid-flight. Tearing down the socket **drops the stateful ADT session and orphans the lock handle**, so the follow-up `unlock` has nothing to release — the object is left **locked and inactive**. (A normal error keeps the session alive, so the `finally`-unlock works — which is why only *timeouts* left objects stuck.)

## Fix (consumer side of the connection change)
Builds on `@mcp-abap-adt/connection` **1.10.0** (`beginCriticalSection()` / `endCriticalSection()`), which raises the request timeout to a large ceiling (`SAP_TIMEOUT_CRITICAL`, default 600000 ms) while active.

- **Migrate** `@mcp-abap-adt/connection` `^1.9.1 → ^1.10.0`.
- New helper `withCriticalSection(handler, () => ctx.connection)` + `isMutatingToolName()` (`src/lib/criticalSection.ts`).
- In `HighLevelHandlersGroup.getHandlers()`, a single `.map()` wraps **every** Create/Update/Delete entry (**70 tools**) so the whole mutating call runs uninterruptibly — `begin` before, `end` in a `finally`.
- **Feature-detected** via a structural cast → no-op on a connection older than 1.10.0 (no `IAbapConnection` interface change needed).

## Verification
- New `criticalSection.test.ts` (6): begin/end order, end-on-throw, no-op on missing methods / null connection, `isMutatingToolName`.
- Runtime check: `HighLevelHandlersGroup` wraps 70 mutating tools; invoking one fires begin=1/end=1.
- `npm run build` ✅ · `test:check` ✅ · **366 unit** (19 suites) ✅
- Versions **8.7.0** consistent (package/lock/server); connection resolved 1.10.0.

Low-level lock/unlock (separate tool calls) are out of scope — a critical section can't span two MCP calls; this covers the self-contained high-level CRUD where the orphan happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)