### PR TITLE
fix(srvd): CreateServiceDefinition wrote an empty body — 8.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.7.1] - 2026-07-16
+
+### Fixed
+- **`CreateServiceDefinition` created the object with an empty body.** The service-definition `create()` POST only registers the shell (metadata: name/description/package) — it does **not** persist the `define service … { … }` source, and the handler had no follow-up write step (a regression in the underlying `@mcp-abap-adt/adt-clients` create flow, which used to run create → lock → update → unlock). The handler now runs an explicit high-level `update()` (lock → write source → unlock) right after create whenever `source_code` is provided, then activates — so the service definition is created with its real body. (Root cause is in adt-clients' `AdtServiceDefinition.create()`; this handler-side fix restores correct behavior immediately.)
+
 ## [8.7.0] - 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.7.0",
+  "version": "8.7.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/unit/handleCreateServiceDefinition.test.ts
+++ b/src/__tests__/unit/handleCreateServiceDefinition.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit test: CreateServiceDefinition writes the source body.
+ * Regression guard — the create() POST only registers the shell (metadata),
+ * so the handler must run a follow-up update() to persist the
+ * `define service … { … }` source; otherwise the object is created empty.
+ * SAP-free via a mocked AdtClient.
+ */
+
+const mockValidate = jest.fn();
+const mockCreate = jest.fn();
+const mockUpdate = jest.fn();
+const mockActivate = jest.fn();
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getServiceDefinition: () => ({
+      validate: mockValidate,
+      create: mockCreate,
+      update: mockUpdate,
+      activate: mockActivate,
+    }),
+  }),
+}));
+
+import { handleCreateServiceDefinition } from '../../handlers/service_definition/high/handleCreateServiceDefinition';
+
+const ctx = { connection: {}, logger: undefined } as any;
+
+describe('CreateServiceDefinition — source body is written (regression)', () => {
+  beforeEach(() => {
+    for (const m of [mockValidate, mockCreate, mockUpdate, mockActivate]) {
+      m.mockReset();
+    }
+    mockValidate.mockResolvedValue({});
+    mockCreate.mockResolvedValue({ createResult: { status: 201 } });
+    mockUpdate.mockResolvedValue({ updateResult: { status: 200 } });
+    mockActivate.mockResolvedValue({ activateResult: { data: '' } });
+  });
+
+  it('calls update() with the source_code after create()', async () => {
+    const src = 'define service ZSD provider contracts { expose zi_x; }';
+    const result = await handleCreateServiceDefinition(ctx, {
+      service_definition_name: 'zsd',
+      package_name: '$TMP',
+      source_code: src,
+      activate: false,
+    } as any);
+
+    expect((result as any).isError).toBe(false);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      serviceDefinitionName: 'ZSD',
+      sourceCode: src,
+      transportRequest: undefined,
+    });
+  });
+
+  it('does not call update() when no source_code is given', async () => {
+    await handleCreateServiceDefinition(ctx, {
+      service_definition_name: 'zsd',
+      package_name: '$TMP',
+      activate: false,
+    } as any);
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/handlers/service_definition/high/handleCreateServiceDefinition.ts
+++ b/src/handlers/service_definition/high/handleCreateServiceDefinition.ts
@@ -148,6 +148,18 @@ export async function handleCreateServiceDefinition(
         );
       }
 
+      // Write the source body. The create() POST only registers the shell
+      // (metadata) and does NOT persist the `define service … { … }` source,
+      // so without this the object is created with an empty body. Run a full
+      // lock → update → unlock via the high-level update() to write it.
+      if (typedArgs.source_code) {
+        await client.getServiceDefinition().update({
+          serviceDefinitionName,
+          sourceCode: typedArgs.source_code,
+          transportRequest: typedArgs.transport_request,
+        });
+      }
+
       // Activate if requested
       if (shouldActivate) {
         const activateState = await client


### PR DESCRIPTION
## Bug (urgent)
`CreateServiceDefinition` created the service definition with an **empty body** — the `define service … { … }` source was not persisted.

## Root cause
The SD `create()` POST (`@mcp-abap-adt/adt-clients`) only registers the **shell** (metadata: name/description/package/language); its XML body never includes the source. `AdtServiceDefinition.create()` returns right after the shell POST — it no longer runs the `lock → update(source) → unlock` step (a regression: git history shows `create()` used to call `updateServiceDefinition`). The mcp-abap-adt handler had no separate write step either (workflow was validate → create → activate), so the body was always empty.

## Fix (handler side — immediate)
After `create()`, when `source_code` is provided, the handler now runs an explicit high-level `update()` (lock → write source → unlock) to persist the body, then activates:
```
validate → create (shell) → update (write source) → activate
```
Uses the existing `client.getServiceDefinition().update(...)`. No adt-clients bump required to ship the fix.

## Verification
- New `handleCreateServiceDefinition.test.ts` (2): `update()` dispatched with `{ serviceDefinitionName, sourceCode, transportRequest }` when `source_code` is given; not called otherwise.
- `npm run build` ✅ · `test:check` ✅ · **368 unit** (20 suites) ✅ · versions **8.7.1** consistent.

## Follow-up (proper root fix)
Restore the source-write in adt-clients' `AdtServiceDefinition.create()` (create → lock → update → unlock) so direct adt-clients consumers are fixed too. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)