### PR TITLE
chore(deps): migrate to @mcp-abap-adt/adt-clients ^7.4.0 — 8.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.8.0] - 2026-07-16
+
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^7.4.0`** (from `^7.3.1`). 7.4.0 adds a session-scoped lock registry with an `unlockAll()` safety net, which complements the uninterruptible critical sections from 8.7.0 by making orphaned locks recoverable. `@mcp-abap-adt/interfaces` stays `^9.2.0`. Non-breaking; no tool contract changed.
+
 ## [8.7.1] - 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.7.1",
+  "version": "8.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.7.1",
+      "version": "8.8.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^7.3.1",
+        "@mcp-abap-adt/adt-clients": "^7.4.0",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.3.1.tgz",
-      "integrity": "sha512-sq9sj68fUhZgF9082vUpS8lb6a42RQEnhcKYQFB3lAcCeOkfvVdHmZgdK1oeiysphSMhGUIT3u17oNnyaumBng==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.4.0.tgz",
+      "integrity": "sha512-m/7kel+aGmW0paA8Sqou6a8eSSUaLdylWdXoaCYQY9ZPEkr43NjDBk/F1iE45KfFaZ0Sad7RdII4cxgxUTwZxA==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.7.1",
+  "version": "8.8.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -137,7 +137,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^7.3.1",
+    "@mcp-abap-adt/adt-clients": "^7.4.0",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.7.1",
+  "version": "8.8.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.7.1",
+      "version": "8.8.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
Migrate `@mcp-abap-adt/adt-clients` `^7.3.1 → ^7.4.0`.

7.4.0 adds a **session-scoped lock registry with an `unlockAll()` safety net** — it complements the uninterruptible critical sections from 8.7.0 by making orphaned locks recoverable. `@mcp-abap-adt/interfaces` stays `^9.2.0`.

Built on top of 8.7.1 (so this release also carries the `CreateServiceDefinition` empty-body fix).

## Verification
- `npm run build` ✅ · `test:check` ✅ · **368 unit** (20 suites) ✅ · `npm audit` **0**
- Versions **8.8.0** consistent (package/lock/server); adt-clients resolved 7.4.0, interfaces 9.2.0; no `link:`/`file:` in lock.

Non-breaking — no tool contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)