### PR TITLE
chore(deps): migrate to @mcp-abap-adt/adt-clients ^7.4.2 — 8.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.8.1] - 2026-07-16
+
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^7.4.2`** (from `^7.4.0`). Two correctness fixes to `update()`'s read-back: the post-update readiness poll and the final returned read now target the **inactive** version — the one the write just produced — instead of `'active'` (which 404s for a never-activated object and returns stale content for an existing one). So reading back the result of an `update()` (including the `CreateServiceDefinition` `create → update → activate` flow) now returns the freshly written source. `@mcp-abap-adt/interfaces` stays `^9.2.0`. Non-breaking; no tool contract changed.
+
 ## [8.8.0] - 2026-07-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.8.0",
+      "version": "8.8.1",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^7.4.0",
+        "@mcp-abap-adt/adt-clients": "^7.4.2",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.4.0.tgz",
-      "integrity": "sha512-m/7kel+aGmW0paA8Sqou6a8eSSUaLdylWdXoaCYQY9ZPEkr43NjDBk/F1iE45KfFaZ0Sad7RdII4cxgxUTwZxA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.4.2.tgz",
+      "integrity": "sha512-XzlzBHtlduY1p4uTgfwbr/fAVzWVvGK89XdtKzBBKVpb5Fc7xaDwK5TQjyyG3zPRrmaSYbVXI8iWfYPspUOzAQ==",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -137,7 +137,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^7.4.0",
+    "@mcp-abap-adt/adt-clients": "^7.4.2",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.8.0",
+  "version": "8.8.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.8.0",
+      "version": "8.8.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
Migrate `@mcp-abap-adt/adt-clients` `^7.4.0 → ^7.4.2` — two correctness fixes to `update()`'s read-back.

7.4.1 (#70) and 7.4.2 (#72): after `update()` writes source under a lock, the object exists only as the **inactive** version. The post-update readiness poll and the final returned read used to target `'active'` — which 404s for a never-activated object and returns stale pre-update content for an existing one. Both now read `'inactive'`, so reading back an `update()` result returns the freshly written source (relevant to the `CreateServiceDefinition` `create → update → activate` flow from 8.7.1).

`@mcp-abap-adt/interfaces` stays `^9.2.0`.

## Verification
- `npm run build` ✅ · `test:check` ✅ · **368 unit** (20 suites) ✅ · `npm audit` **0**
- Versions **8.8.1** consistent (package/lock/server); adt-clients resolved 7.4.2, interfaces 9.2.0; no `link:`/`file:`.

Non-breaking — no API/tool contract change, purely a read-back correctness fix in adt-clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)