### PR TITLE
fix(test-config): ZMCP_VIEW_TBL02 value char(10), not dec(10,2)

### DIFF
--- a/tests/test-config.yaml.template
+++ b/tests/test-config.yaml.template
@@ -214,7 +214,7 @@ shared_dependencies:
           key client : abap.clnt not null;
           key id     : abap.char(10) not null;
           name       : abap.char(50);
-          value      : abap.dec(10,2);
+          value      : abap.char(10);
           created_at : abap.dats;
         }
 


### PR DESCRIPTION
Change the shared View-builder test table `ZMCP_VIEW_TBL02` field `value` from `abap.dec(10,2)` to `abap.char(10)` in `tests/test-config.yaml.template`.

Category stays `#NOT_EXTENSIBLE` (no append structures on this table — left untouched per design). Test-fixture template only — not shipped in the npm tarball, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)