### PR TITLE
chore(deps): migrate to adt-clients ^7.4.4 + interfaces ^10.0.0 — 8.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [8.9.0] - 2026-07-17
+
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^7.4.4` and `@mcp-abap-adt/interfaces@^10.0.0`** (from `^7.4.2` / `^9.2.0`). interfaces 10.0.0 is a major bump whose only breaking change is removing the no-op `source_code` field from the low-level create-params (`ICreateAccessControl/ServiceDefinition/EnhancementParams`) — source is written via the update flow. This does **not** affect us: our handlers use the high-level config types (`IServiceDefinitionConfig.sourceCode`, unchanged), not the low-level create-params. adt-clients 7.4.3 dropped the matching dead create() pass-through.
+- **`CreateServiceDefinition`:** removed the now-dead `sourceCode` from the `create()` config (create makes the shell only; the body is still written by the follow-up `update()` from 8.7.1). No behavior change.
+
 ## [8.8.1] - 2026-07-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.8.1",
+  "version": "8.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.8.1",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^7.4.2",
+        "@mcp-abap-adt/adt-clients": "^7.4.4",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
         "@mcp-abap-adt/connection": "^1.10.0",
         "@mcp-abap-adt/header-validator": "^0.1.8",
-        "@mcp-abap-adt/interfaces": "^9.2.0",
+        "@mcp-abap-adt/interfaces": "^10.0.0",
         "@mcp-abap-adt/logger": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.18.1",
@@ -226,12 +226,12 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.4.2.tgz",
-      "integrity": "sha512-XzlzBHtlduY1p4uTgfwbr/fAVzWVvGK89XdtKzBBKVpb5Fc7xaDwK5TQjyyG3zPRrmaSYbVXI8iWfYPspUOzAQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.4.4.tgz",
+      "integrity": "sha512-EXPASLM3sKvUOceZCfDNDNFh+rCJwsbumfG+2qjhHM2yNJEz+8lnkoEKUeyF8yChzwqwnVjGbQhhEyqAV3C9sQ==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^9.2.0",
+        "@mcp-abap-adt/interfaces": "^10.0.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.2.0.tgz",
-      "integrity": "sha512-iMb3OOjMsMxAf8dSXz763uq+Q4CV32fuSjc6GSL4Uu8cCxjJs3AWjNgbQFyhmzIhw0LlSlYWChCkrZBOUJI7GA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-10.0.0.tgz",
+      "integrity": "sha512-fnXWmqMQHUulKQtSZH1a7L3uhgutGgSCpyWMCQHQNu4VMR5oguLtMsX2cBU90wxj3CJup0/n/HRdDMj05liwAw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.8.1",
+  "version": "8.9.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -137,13 +137,13 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^7.4.2",
+    "@mcp-abap-adt/adt-clients": "^7.4.4",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",
     "@mcp-abap-adt/connection": "^1.10.0",
     "@mcp-abap-adt/header-validator": "^0.1.8",
-    "@mcp-abap-adt/interfaces": "^9.2.0",
+    "@mcp-abap-adt/interfaces": "^10.0.0",
     "@mcp-abap-adt/logger": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.18.1",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.8.1",
+  "version": "8.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.8.1",
+      "version": "8.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/handlers/service_definition/high/handleCreateServiceDefinition.ts
+++ b/src/handlers/service_definition/high/handleCreateServiceDefinition.ts
@@ -134,7 +134,9 @@ export async function handleCreateServiceDefinition(
         packageName: typedArgs.package_name.toUpperCase(),
         transportRequest: typedArgs.transport_request,
         masterLanguage: typedArgs.master_language,
-        ...(typedArgs.source_code && { sourceCode: typedArgs.source_code }),
+        // NB: source is NOT passed to create() — create() only makes the shell
+        // (adt-clients 7.4.3 dropped the no-op create source pass-through). The
+        // body is written by the update() call below when source_code is given.
       };
 
       const createState = await client


### PR DESCRIPTION
## Summary
Migrate `@mcp-abap-adt/adt-clients` `^7.4.2 → ^7.4.4` and `@mcp-abap-adt/interfaces` `^9.2.0 → ^10.0.0`.

**interfaces 10.0.0** is a major bump, but its only breaking change is removing the **no-op `source_code`** from the low-level create-params (`ICreateAccessControl/ServiceDefinition/EnhancementParams`) — source is written via the update flow (`IUpdate*Params.source_code`, untouched). No runtime change.

**Impact on us: none at the type level.** Our handlers use the high-level config types (`IServiceDefinitionConfig.sourceCode`, camelCase, unchanged), not the low-level create-params. adt-clients 7.4.3 already dropped the matching dead `create()` source pass-through; 7.4.4 aligns the interfaces floor.

Small cleanup: `CreateServiceDefinition` no longer passes the now-dead `sourceCode` to `create()` (create = shell only; the body is still written by the follow-up `update()` from 8.7.1). No behavior change.

## Verification
- `npm run build` ✅ · `test:check` ✅ · **368 unit** (20 suites, incl. the SD regression test) ✅ · `npm audit` **0**
- Versions **8.9.0** consistent (package/lock/server); adt-clients 7.4.4, interfaces 10.0.0; no `link:`/`file:`.

Note: this does **not** unblock the ATC PR (#147) — the ATC client (`getAtc()`/`getUnitTestRunner()`) is not in adt-clients yet; that's a separate adt-clients release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)