### PR TITLE
chore(deps): migrate to adt-clients ^7.6.0 + interfaces ^11.2.0 — 8.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [8.10.0] - 2026-07-21
+
+### Fixed
+- **Locked/failed activations no longer report a false `success:true`.** Migrated to `@mcp-abap-adt/adt-clients@^7.6.0`, which fixes the activation-masking bug (adt-clients #79): ADT's `/sap/bc/adt/activation` returns HTTP 200 even when activation fails (object locked in another session, syntax errors), and the shared `activateObjectInSession` helper previously returned that response unchecked. Every high-level `Update*`/`Activate*` tool built on it (`UpdateDomain`, and the whole family across domain, program, table, structure, class, interface, ddl, tabletype, functionModule, functionInclude, metadataExtension, behaviorDefinition, enhancement, unitTest) therefore returned `{"success":true,"...":"updated and activated successfully"}` on a locked object. With 7.6.0 the client now throws on an explicit activation-failure signal; the handler's catch maps it to a structured `McpError` (tool result `isError:true`), so consumers can finally tell the operation failed. Fixes #154.
+
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^7.6.0` and `@mcp-abap-adt/interfaces@^11.2.0`** (from `^7.4.4` / `^10.0.0`). adt-clients 7.6.0 sources its public types from interfaces `^11.2.0`; bumping our direct interfaces range keeps a single top-level interfaces version aligned with the client. No handler API change.
+
 ## [8.9.0] - 2026-07-17
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.9.0",
+  "version": "8.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.9.0",
+      "version": "8.10.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^7.4.4",
+        "@mcp-abap-adt/adt-clients": "^7.6.0",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
         "@mcp-abap-adt/connection": "^1.10.0",
         "@mcp-abap-adt/header-validator": "^0.1.8",
-        "@mcp-abap-adt/interfaces": "^10.0.0",
+        "@mcp-abap-adt/interfaces": "^11.2.0",
         "@mcp-abap-adt/logger": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.18.1",
@@ -226,12 +226,12 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.4.4.tgz",
-      "integrity": "sha512-EXPASLM3sKvUOceZCfDNDNFh+rCJwsbumfG+2qjhHM2yNJEz+8lnkoEKUeyF8yChzwqwnVjGbQhhEyqAV3C9sQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.6.0.tgz",
+      "integrity": "sha512-W8d8spv7jHtTwoUH/itO7vA0rOr31QQX2BpJXpJ+iDpqeoGfML4EwL9hGziPvbve1iQJRQDtDZERLwJIt1GdsQ==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^10.0.0",
+        "@mcp-abap-adt/interfaces": "^11.2.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-10.0.0.tgz",
-      "integrity": "sha512-fnXWmqMQHUulKQtSZH1a7L3uhgutGgSCpyWMCQHQNu4VMR5oguLtMsX2cBU90wxj3CJup0/n/HRdDMj05liwAw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.2.0.tgz",
+      "integrity": "sha512-/ZQ1XwYnheefhe8FNZwLPjeyP7yjLG+tqB3Tv6pWH90zNovhgwB1mxEO59tzvCB0m43xM416Tech7Tfov0CyUA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.9.0",
+  "version": "8.10.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -137,13 +137,13 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^7.4.4",
+    "@mcp-abap-adt/adt-clients": "^7.6.0",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",
     "@mcp-abap-adt/connection": "^1.10.0",
     "@mcp-abap-adt/header-validator": "^0.1.8",
-    "@mcp-abap-adt/interfaces": "^10.0.0",
+    "@mcp-abap-adt/interfaces": "^11.2.0",
     "@mcp-abap-adt/logger": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.18.1",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.9.0",
+  "version": "8.10.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.9.0",
+      "version": "8.10.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Realigns the server onto `@mcp-abap-adt/adt-clients@^7.6.0`, which carries the activation-masking fix. **Fixes #154.**

## What this fixes

ADT's `/sap/bc/adt/activation` returns **HTTP 200 even when activation fails**
(object locked in another session, syntax errors). adt-clients' shared
`activateObjectInSession` previously returned that response unchecked, so every
high-level `Update*`/`Activate*` tool built on it reported a **false
`success:true`** on a locked object — the exact symptom in #154:

```json
{"success":true,"status":"active","message":"Domain ZD_... updated and activated successfully"}
```

for a domain locked in another session (confirmed in SM12).

adt-clients 7.6.0 (fix landed in adt-clients #79) now throws on an explicit
activation-failure signal (`activationExecuted="false"` / error-severity
`<msg>`). `handleUpdateDomain`'s catch already maps a thrown activation error to
a structured `McpError` → tool result `isError:true`, so consumers can finally
detect the failure. **No handler code change was required.**

## Changes

- `@mcp-abap-adt/adt-clients` `^7.4.4` → `^7.6.0`
- `@mcp-abap-adt/interfaces` `^10.0.0` → `^11.2.0` (adt-clients 7.6.0 sources its
  public types from interfaces `^11.2.0`; keeps a single top-level interfaces version)
- version `8.9.0` → `8.10.0` (`package.json`, `server.json` ×2, `CHANGELOG.md`)
- `package-lock.json` re-synced

## Verification

- `npm run build` — clean (biome error-level + tsc) against interfaces 11.2.0;
  the major interfaces bump did not break any handler types
- `jest --testPathIgnorePatterns=integration` — 37 suites, 496 tests pass

## Not yet done (flagging honestly)

- The failed-activation XML shape was reconstructed from the ADT contract in the
  adt-clients unit test. A **live locked-object activation** (integration suite /
  cloud-llm-hub) should confirm the client throws end-to-end before #154 is
  closed. Happy to run it once the SAP env is ready.
- The second half of #154 ("`-32603` text without `isError`") is already
  `isError:true` on the current MCP SDK (SDK wraps a thrown `McpError` into a
  tool result with `isError:true`); the remaining gap is consumer-side
  (fr0ster/llm-agent#231).

🤖 Generated with [Claude Code](https://claude.com/claude-code)