### PR TITLE
fix(read): read handlers surface failures instead of masking as success:true (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [8.11.0] - 2026-07-22
+
+### Fixed
+- **Read handlers no longer mask a failed read as `success:true` + null (#159).** 17 readonly handlers (`ReadDomain`, `ReadClass`, `ReadInterface`, `ReadProgram`, `ReadTable`, `ReadStructure`, `ReadDdl`, `ReadDataElement`, `ReadFunctionGroup`, `ReadFunctionModule`, `ReadFunctionInclude`, `ReadPackage`, `ReadServiceDefinition`, `ReadServiceBinding`, `ReadMetadataExtension`, `ReadBehaviorDefinition`, `ReadBehaviorImplementation`) wrapped their `read`/`readMetadata` calls in inner `try/catch` blocks that only logged a `warn` and swallowed the error, then returned `success:true` with `source_code:null`/`metadata:null` regardless. A hard failure — expired token, network error, HTTP 5xx — or a genuinely non-existent object was thus delivered to the caller as a successful (but empty) read. The inner swallows are removed; read errors now propagate to the existing outer `catch → return_error`, so a failed read returns a structured failure (tool result `isError:true`). This is the READ-path sibling of the activation/deletion masking fixes. `GetStructuresList` was not affected — it already surfaces a root read failure via `return_error` and flags partial append issues explicitly.
+
 ## [8.10.0] - 2026-07-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/core",
-  "version": "8.10.0",
+  "version": "8.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/core",
-      "version": "8.10.0",
+      "version": "8.11.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/adt-clients": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcp-abap-adt/core",
   "mcpName": "io.github.fr0ster/mcp-abap-adt",
-  "version": "8.10.0",
+  "version": "8.11.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/fr0ster/mcp-abap-adt",
     "source": "github"
   },
-  "version": "8.10.0",
+  "version": "8.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mcp-abap-adt/core",
-      "version": "8.10.0",
+      "version": "8.11.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/unit/readHandlersSurfaceErrors.test.ts
+++ b/src/__tests__/unit/readHandlersSurfaceErrors.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit test (#159): readonly handlers must NOT mask a failed read as
+ * `success:true` + null. When the underlying read throws (auth/network/404/5xx),
+ * the handler must return a structured failure (isError:true).
+ *
+ * SAP-free via a mocked AdtClient. Domain and Class stand in for the whole
+ * family of 18 handlers that share the identical read+readMetadata structure.
+ */
+
+const mockDomainRead = jest.fn();
+const mockDomainReadMeta = jest.fn();
+const mockClassRead = jest.fn();
+const mockClassReadMeta = jest.fn();
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getDomain: () => ({
+      read: mockDomainRead,
+      readMetadata: mockDomainReadMeta,
+    }),
+    getClass: () => ({
+      read: mockClassRead,
+      readMetadata: mockClassReadMeta,
+    }),
+  }),
+}));
+
+import { handleReadClass } from '../../handlers/class/readonly/handleReadClass';
+import { handleReadDomain } from '../../handlers/domain/readonly/handleReadDomain';
+
+const ctx = { connection: {}, logger: undefined } as any;
+
+function payload(result: any) {
+  const text =
+    (result.content.find((c: any) => c.type === 'text') as any)?.text || '';
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+describe('readonly handlers surface read failures as isError (#159)', () => {
+  beforeEach(() => {
+    mockDomainRead.mockReset();
+    mockDomainReadMeta.mockReset();
+    mockClassRead.mockReset();
+    mockClassReadMeta.mockReset();
+  });
+
+  it('ReadDomain: happy path returns success with data', async () => {
+    mockDomainRead.mockResolvedValue({ readResult: { data: '<domain/>' } });
+    mockDomainReadMeta.mockResolvedValue({
+      metadataResult: { data: '<meta/>' },
+    });
+
+    const result = await handleReadDomain(ctx, { domain_name: 'ZD_OK' });
+
+    expect(result.isError).toBe(false);
+    const p = payload(result);
+    expect(p.success).toBe(true);
+    expect(p.source_code).toBe('<domain/>');
+  });
+
+  it('ReadDomain: a thrown read (e.g. expired token) → isError, NOT false success', async () => {
+    const err: any = new Error('JWT token has expired');
+    err.response = { status: 401 };
+    mockDomainRead.mockRejectedValue(err);
+    mockDomainReadMeta.mockRejectedValue(err);
+
+    const result = await handleReadDomain(ctx, { domain_name: 'ZD_LOCKED' });
+
+    expect(result.isError).toBe(true);
+    expect(payload(result).success).not.toBe(true);
+  });
+
+  it('ReadDomain: a not-found (404) read → isError, NOT false success:true+null', async () => {
+    const err: any = new Error("Domain 'ZD_NOPE' not found");
+    err.response = { status: 404 };
+    mockDomainRead.mockRejectedValue(err);
+    mockDomainReadMeta.mockRejectedValue(err);
+
+    const result = await handleReadDomain(ctx, { domain_name: 'ZD_NOPE' });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('ReadClass: a thrown read → isError, NOT false success', async () => {
+    const err: any = new Error('Request failed with status code 500');
+    err.response = { status: 500 };
+    mockClassRead.mockRejectedValue(err);
+    mockClassReadMeta.mockRejectedValue(err);
+
+    const result = await handleReadClass(ctx, { class_name: 'ZCL_BOOM' });
+
+    expect(result.isError).toBe(true);
+    expect(payload(result).success).not.toBe(true);
+  });
+});

--- a/src/__tests__/unit/readHandlersSurfaceErrors.test.ts
+++ b/src/__tests__/unit/readHandlersSurfaceErrors.test.ts
@@ -4,7 +4,7 @@
  * the handler must return a structured failure (isError:true).
  *
  * SAP-free via a mocked AdtClient. Domain and Class stand in for the whole
- * family of 18 handlers that share the identical read+readMetadata structure.
+ * family of 17 handlers that share the identical read+readMetadata structure.
  */
 
 const mockDomainRead = jest.fn();

--- a/src/handlers/behavior_definition/readonly/handleReadBehaviorDefinition.ts
+++ b/src/handlers/behavior_definition/readonly/handleReadBehaviorDefinition.ts
@@ -47,38 +47,26 @@ export async function handleReadBehaviorDefinition(
     const obj = client.getBehaviorDefinition();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { name: behaviorDefinitionName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read source for ${behaviorDefinitionName}: ${e?.message}`,
-      );
+    const readResult = await obj.read(
+      { name: behaviorDefinitionName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({
-        name: behaviorDefinitionName,
-      });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${behaviorDefinitionName}: ${e?.message}`,
-      );
+    const metaResult = await obj.readMetadata({
+      name: behaviorDefinitionName,
+    });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/behavior_implementation/readonly/handleReadBehaviorImplementation.ts
+++ b/src/handlers/behavior_implementation/readonly/handleReadBehaviorImplementation.ts
@@ -50,38 +50,26 @@ export async function handleReadBehaviorImplementation(
     const obj = client.getBehaviorImplementation();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { className: behaviorImplementationName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read source for ${behaviorImplementationName}: ${e?.message}`,
-      );
+    const readResult = await obj.read(
+      { className: behaviorImplementationName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({
-        className: behaviorImplementationName,
-      });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${behaviorImplementationName}: ${e?.message}`,
-      );
+    const metaResult = await obj.readMetadata({
+      className: behaviorImplementationName,
+    });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/class/readonly/handleReadClass.ts
+++ b/src/handlers/class/readonly/handleReadClass.ts
@@ -43,32 +43,24 @@ export async function handleReadClass(
     const obj = client.getClass();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { className },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${className}: ${e?.message}`);
+    const readResult = await obj.read(
+      { className },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ className });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read metadata for ${className}: ${e?.message}`);
+    const metaResult = await obj.readMetadata({ className });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/data_element/readonly/handleReadDataElement.ts
+++ b/src/handlers/data_element/readonly/handleReadDataElement.ts
@@ -44,36 +44,24 @@ export async function handleReadDataElement(
     const obj = client.getDataElement();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { dataElementName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read source for ${dataElementName}: ${e?.message}`,
-      );
+    const readResult = await obj.read(
+      { dataElementName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ dataElementName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${dataElementName}: ${e?.message}`,
-      );
+    const metaResult = await obj.readMetadata({ dataElementName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/ddl/readonly/handleReadDdl.ts
+++ b/src/handlers/ddl/readonly/handleReadDdl.ts
@@ -43,32 +43,24 @@ export async function handleReadDdl(
     const obj = client.getDdl();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { ddlName: ddlName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${ddlName}: ${e?.message}`);
+    const readResult = await obj.read(
+      { ddlName: ddlName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ ddlName: ddlName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read metadata for ${ddlName}: ${e?.message}`);
+    const metaResult = await obj.readMetadata({ ddlName: ddlName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/domain/readonly/handleReadDomain.ts
+++ b/src/handlers/domain/readonly/handleReadDomain.ts
@@ -43,32 +43,24 @@ export async function handleReadDomain(
     const obj = client.getDomain();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { domainName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${domainName}: ${e?.message}`);
+    const readResult = await obj.read(
+      { domainName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ domainName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read metadata for ${domainName}: ${e?.message}`);
+    const metaResult = await obj.readMetadata({ domainName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/function_group/readonly/handleReadFunctionGroup.ts
+++ b/src/handlers/function_group/readonly/handleReadFunctionGroup.ts
@@ -44,36 +44,24 @@ export async function handleReadFunctionGroup(
     const obj = client.getFunctionGroup();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { functionGroupName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read source for ${functionGroupName}: ${e?.message}`,
-      );
+    const readResult = await obj.read(
+      { functionGroupName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ functionGroupName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${functionGroupName}: ${e?.message}`,
-      );
+    const metaResult = await obj.readMetadata({ functionGroupName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/function_include/readonly/handleReadFunctionInclude.ts
+++ b/src/handlers/function_include/readonly/handleReadFunctionInclude.ts
@@ -56,35 +56,27 @@ export async function handleReadFunctionInclude(
     const obj = client.getFunctionInclude();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { functionGroupName, includeName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${includeName}: ${e?.message}`);
+    const readResult = await obj.read(
+      { functionGroupName, includeName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({
-        functionGroupName,
-        includeName,
-      });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read metadata for ${includeName}: ${e?.message}`);
+    const metaResult = await obj.readMetadata({
+      functionGroupName,
+      includeName,
+    });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/function_module/readonly/handleReadFunctionModule.ts
+++ b/src/handlers/function_module/readonly/handleReadFunctionModule.ts
@@ -64,23 +64,15 @@ export async function handleReadFunctionModule(
     // the group segment in the URL, so we must verify ownership from metadata
     // (<adtcore:containerRef/>) before trusting any source payload.
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({
-        functionModuleName,
-        functionGroupName,
-      });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      return return_error(
-        new Error(
-          `Could not read metadata for ${functionModuleName} in group ${functionGroupName}: ${e?.message ?? e}`,
-        ),
-      );
+    const metaResult = await obj.readMetadata({
+      functionModuleName,
+      functionGroupName,
+    });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     const realGroup = assertFunctionGroupMatches(
@@ -90,21 +82,15 @@ export async function handleReadFunctionModule(
     );
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { functionModuleName, functionGroupName: realGroup },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read source for ${functionModuleName}: ${e?.message}`,
-      );
+    const readResult = await obj.read(
+      { functionModuleName, functionGroupName: realGroup },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     return return_response({

--- a/src/handlers/interface/readonly/handleReadInterface.ts
+++ b/src/handlers/interface/readonly/handleReadInterface.ts
@@ -44,34 +44,24 @@ export async function handleReadInterface(
     const obj = client.getInterface();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { interfaceName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${interfaceName}: ${e?.message}`);
+    const readResult = await obj.read(
+      { interfaceName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ interfaceName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${interfaceName}: ${e?.message}`,
-      );
+    const metaResult = await obj.readMetadata({ interfaceName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/metadata_extension/readonly/handleReadMetadataExtension.ts
+++ b/src/handlers/metadata_extension/readonly/handleReadMetadataExtension.ts
@@ -47,38 +47,26 @@ export async function handleReadMetadataExtension(
     const obj = client.getMetadataExtension();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { name: metadataExtensionName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read source for ${metadataExtensionName}: ${e?.message}`,
-      );
+    const readResult = await obj.read(
+      { name: metadataExtensionName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({
-        name: metadataExtensionName,
-      });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${metadataExtensionName}: ${e?.message}`,
-      );
+    const metaResult = await obj.readMetadata({
+      name: metadataExtensionName,
+    });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/package/readonly/handleReadPackage.ts
+++ b/src/handlers/package/readonly/handleReadPackage.ts
@@ -44,32 +44,24 @@ export async function handleReadPackage(
     const obj = client.getPackage();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { packageName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${packageName}: ${e?.message}`);
+    const readResult = await obj.read(
+      { packageName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ packageName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read metadata for ${packageName}: ${e?.message}`);
+    const metaResult = await obj.readMetadata({ packageName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/program/readonly/handleReadProgram.ts
+++ b/src/handlers/program/readonly/handleReadProgram.ts
@@ -44,32 +44,24 @@ export async function handleReadProgram(
     const obj = client.getProgram();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { programName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${programName}: ${e?.message}`);
+    const readResult = await obj.read(
+      { programName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ programName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read metadata for ${programName}: ${e?.message}`);
+    const metaResult = await obj.readMetadata({ programName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     // ReadProgram only reads main programs (PROG/P). Detect the actual object

--- a/src/handlers/service_binding/readonly/handleReadServiceBinding.ts
+++ b/src/handlers/service_binding/readonly/handleReadServiceBinding.ts
@@ -38,29 +38,21 @@ export async function handleReadServiceBinding(
     const obj = client.getServiceBinding();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read({ bindingName });
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${bindingName}: ${e?.message}`);
+    const readResult = await obj.read({ bindingName });
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ bindingName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read metadata for ${bindingName}: ${e?.message}`);
+    const metaResult = await obj.readMetadata({ bindingName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/service_definition/readonly/handleReadServiceDefinition.ts
+++ b/src/handlers/service_definition/readonly/handleReadServiceDefinition.ts
@@ -47,36 +47,24 @@ export async function handleReadServiceDefinition(
     const obj = client.getServiceDefinition();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { serviceDefinitionName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read source for ${serviceDefinitionName}: ${e?.message}`,
-      );
+    const readResult = await obj.read(
+      { serviceDefinitionName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ serviceDefinitionName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${serviceDefinitionName}: ${e?.message}`,
-      );
+    const metaResult = await obj.readMetadata({ serviceDefinitionName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/structure/readonly/handleReadStructure.ts
+++ b/src/handlers/structure/readonly/handleReadStructure.ts
@@ -44,34 +44,24 @@ export async function handleReadStructure(
     const obj = client.getStructure();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { structureName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${structureName}: ${e?.message}`);
+    const readResult = await obj.read(
+      { structureName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ structureName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(
-        `Could not read metadata for ${structureName}: ${e?.message}`,
-      );
+    const metaResult = await obj.readMetadata({ structureName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({

--- a/src/handlers/table/readonly/handleReadTable.ts
+++ b/src/handlers/table/readonly/handleReadTable.ts
@@ -43,32 +43,24 @@ export async function handleReadTable(
     const obj = client.getTable();
 
     let source_code: string | null = null;
-    try {
-      const readResult = await obj.read(
-        { tableName },
-        version as 'active' | 'inactive',
-      );
-      if (readResult?.readResult?.data) {
-        source_code =
-          typeof readResult.readResult.data === 'string'
-            ? readResult.readResult.data
-            : safeStringify(readResult.readResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read source for ${tableName}: ${e?.message}`);
+    const readResult = await obj.read(
+      { tableName },
+      version as 'active' | 'inactive',
+    );
+    if (readResult?.readResult?.data) {
+      source_code =
+        typeof readResult.readResult.data === 'string'
+          ? readResult.readResult.data
+          : safeStringify(readResult.readResult.data);
     }
 
     let metadata: string | null = null;
-    try {
-      const metaResult = await obj.readMetadata({ tableName });
-      if (metaResult?.metadataResult?.data) {
-        metadata =
-          typeof metaResult.metadataResult.data === 'string'
-            ? metaResult.metadataResult.data
-            : safeStringify(metaResult.metadataResult.data);
-      }
-    } catch (e: any) {
-      logger?.warn(`Could not read metadata for ${tableName}: ${e?.message}`);
+    const metaResult = await obj.readMetadata({ tableName });
+    if (metaResult?.metadataResult?.data) {
+      metadata =
+        typeof metaResult.metadataResult.data === 'string'
+          ? metaResult.metadataResult.data
+          : safeStringify(metaResult.metadataResult.data);
     }
 
     return return_response({


### PR DESCRIPTION
Closes #159. READ-path sibling of the #154 activation-masking fix.

## Problem

17 readonly handlers wrapped their `read`/`readMetadata` calls in inner `try/catch` blocks that only `logger?.warn`ed and swallowed the error, then returned `success:true` with `source_code:null`/`metadata:null` **unconditionally**:

```ts
let source_code = null;
try { source_code = await obj.read(...) }
catch (e) { logger?.warn(`Could not read source ...`) }   // swallows
let metadata = null;
try { metadata = await obj.readMetadata(...) }
catch (e) { logger?.warn(`Could not read metadata ...`) } // swallows
return return_response({ success: true, source_code, metadata }); // always success
```

The outer `catch → return_error` (which sets `isError:true`) was unreachable. A hard failure (expired token, network, HTTP 5xx) or a genuinely non-existent object was delivered to the caller as a **successful but empty** read. Observed live during #154 verification: with an expired token, `ReadDomain` returned `success:true` + null; a non-existent domain likewise.

## Fix

Remove the inner swallow blocks; read errors propagate to the existing outer `catch → return_error`, so a failed read returns a structured failure (`isError:true`).

Rationale (contract: **any throw → isError**): adt-clients `read()` re-throws the original AxiosError (carries `response.status`/`code`), and the low-level read throws **only** on HTTP/network failure — a legitimately empty object returns HTTP 200 with an empty body (no throw). So a throw always means a real failure and must not be masked.

## Scope — 17 handlers

domain, class, interface, program, table, structure, ddl, data_element, function_group, function_module, function_include, package, service_definition, service_binding, metadata_extension, behavior_definition, behavior_implementation.

`GetStructuresList` was **not** touched (initial audit false positive): it already surfaces a root read failure via `return_error` and flags partial append issues explicitly (`appends_unavailable`, per-node `error`).

## Tests

New `src/__tests__/unit/readHandlersSurfaceErrors.test.ts` (SAP-free, mocked client): a throwing read → `isError` for domain (401, 404) and class (500); the happy path still returns `success` with data.

- `npm run build` — clean (biome error-level + tsc)
- `jest --testPathIgnorePatterns=integration` — 38 suites, 500 tests pass (incl. the 4 new)

## Note

Single-repo change (handler layer). Behaviour is consumer-visible (previously `success:true`+null, now `isError:true` on failed reads) → minor bump **8.11.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)