### PR TITLE
chore(deps): consume @mcp-abap-adt/adt-clients 8.0.0 (honest capability types)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Removed
+- **Version-history tools are no longer advertised for non-versioned object types.** `function_group`, `domain`, `data_element` and `package` were exposed by the version tools but their adt-clients handlers' `getVersions`/`getVersionSource` have always thrown "not supported" — the calls were dead on arrival. Removed from:
+  - the `object_type` enum of the generic `GetObjectVersions` / `GetObjectVersionSource` / `GetObjectVersionDiff` (they now accept only the 9 genuinely versioned types: class, program, interface, function_module, table, structure, ddl, behavior_definition, metadata_extension);
+  - the per-type high-level surface — the 12 tools `Get{FunctionGroup,Domain,DataElement,Package}{Versions,VersionSource,VersionDiff}` are gone (39 → 27 per-type version tools, total tool count 365 → 353).
+
+  Those object types remain fully supported by `LockObject` and every other tool — they are lockable, just not versioned. This surfaced from the adt-clients 8.0.0 migration below: the honest capability types turned an always-failing runtime call into a compile error. **Breaking to the tool surface** (removed enum values + removed tools) — a client that requested version history for these types received a runtime error before and now gets a schema/`Unsupported object_type` error instead.
+
+### Changed
+- **Migrated to `@mcp-abap-adt/adt-clients@^8.0.0` and `@mcp-abap-adt/interfaces@^11.3.0`** (from `^7.6.0` / `^11.2.0`). adt-clients 8.0.0 is a breaking major that narrows every `AdtClient.getXxx()` return type from the fat `IAdtObject` to the honest capability composite each handler actually implements (`IAdtSourceObject`, `IAdtNonVersionedObject`, or an inline intersection); interfaces 11.3.0 adds those composites. Calling a capability a handler does not implement is now a compile error instead of a silent runtime throw — which is exactly what caught the version-tools defect above. Our direct interfaces range is bumped to `^11.3.0` to keep a single top-level interfaces version aligned with the client and re-export the current type surface.
+
 ## [8.11.0] - 2026-07-22
 
 ### Fixed

--- a/docs/user-guide/AVAILABLE_TOOLS.md
+++ b/docs/user-guide/AVAILABLE_TOOLS.md
@@ -4,9 +4,9 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ## Summary
 
-- Total tools: 365
+- Total tools: 353
 - Read-only tools: 64
-- High-level tools: 177
+- High-level tools: 165
 - Low-level tools: 124
 
 - Compact tools: 22 (included in High-level group)
@@ -148,18 +148,9 @@ Generated from code in `src/handlers/**` (not from docs).
     - [GetClassVersionDiff](#getclassversiondiff-high-level-common)
     - [GetClassVersions](#getclassversions-high-level-common)
     - [GetClassVersionSource](#getclassversionsource-high-level-common)
-    - [GetDataElementVersionDiff](#getdataelementversiondiff-high-level-common)
-    - [GetDataElementVersions](#getdataelementversions-high-level-common)
-    - [GetDataElementVersionSource](#getdataelementversionsource-high-level-common)
     - [GetDdlVersionDiff](#getddlversiondiff-high-level-common)
     - [GetDdlVersions](#getddlversions-high-level-common)
     - [GetDdlVersionSource](#getddlversionsource-high-level-common)
-    - [GetDomainVersionDiff](#getdomainversiondiff-high-level-common)
-    - [GetDomainVersions](#getdomainversions-high-level-common)
-    - [GetDomainVersionSource](#getdomainversionsource-high-level-common)
-    - [GetFunctionGroupVersionDiff](#getfunctiongroupversiondiff-high-level-common)
-    - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
-    - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
     - [GetFunctionModuleVersionDiff](#getfunctionmoduleversiondiff-high-level-common)
     - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
     - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
@@ -169,9 +160,6 @@ Generated from code in `src/handlers/**` (not from docs).
     - [GetMetadataExtensionVersionDiff](#getmetadataextensionversiondiff-high-level-common)
     - [GetMetadataExtensionVersions](#getmetadataextensionversions-high-level-common)
     - [GetMetadataExtensionVersionSource](#getmetadataextensionversionsource-high-level-common)
-    - [GetPackageVersionDiff](#getpackageversiondiff-high-level-common)
-    - [GetPackageVersions](#getpackageversions-high-level-common)
-    - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
     - [GetProgramVersionDiff](#getprogramversiondiff-high-level-common)
     - [GetProgramVersions](#getprogramversions-high-level-common)
     - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
@@ -1836,40 +1824,6 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-<a id="getdataelementversiondiff-high-level-common"></a>
-#### GetDataElementVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP data element versions, by their content_uris (taken from GetDataElementVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDataElementVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDataElementVersions entry).
-
----
-
-<a id="getdataelementversions-high-level-common"></a>
-#### GetDataElementVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `data_element_name` (string, required) - ABAP data element name.
-
----
-
-<a id="getdataelementversionsource-high-level-common"></a>
-#### GetDataElementVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP data element version by its content_uri (taken from a GetDataElementVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetDataElementVersions entry.
-
----
-
 <a id="getddlversiondiff-high-level-common"></a>
 #### GetDdlVersionDiff (High-Level / Common)
 **Description:** [read-only] Compute a unified diff between two CDS view (DDL source) versions, by their content_uris (taken from GetDdlVersions entries).
@@ -1901,74 +1855,6 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetDdlVersions entry.
-
----
-
-<a id="getdomainversiondiff-high-level-common"></a>
-#### GetDomainVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP domain versions, by their content_uris (taken from GetDomainVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDomainVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDomainVersions entry).
-
----
-
-<a id="getdomainversions-high-level-common"></a>
-#### GetDomainVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `domain_name` (string, required) - ABAP domain name.
-
----
-
-<a id="getdomainversionsource-high-level-common"></a>
-#### GetDomainVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP domain version by its content_uri (taken from a GetDomainVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetDomainVersions entry.
-
----
-
-<a id="getfunctiongroupversiondiff-high-level-common"></a>
-#### GetFunctionGroupVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP function group versions, by their content_uris (taken from GetFunctionGroupVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionGroupVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionGroupVersions entry).
-
----
-
-<a id="getfunctiongroupversions-high-level-common"></a>
-#### GetFunctionGroupVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `function_group_name` (string, required) - ABAP function group name.
-
----
-
-<a id="getfunctiongroupversionsource-high-level-common"></a>
-#### GetFunctionGroupVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP function group version by its content_uri (taken from a GetFunctionGroupVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
 
 ---
 
@@ -2072,40 +1958,6 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetMetadataExtensionVersions entry.
-
----
-
-<a id="getpackageversiondiff-high-level-common"></a>
-#### GetPackageVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP package versions, by their content_uris (taken from GetPackageVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetPackageVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetPackageVersions entry).
-
----
-
-<a id="getpackageversions-high-level-common"></a>
-#### GetPackageVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `package_name` (string, required) - ABAP package name.
-
----
-
-<a id="getpackageversionsource-high-level-common"></a>
-#### GetPackageVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP package version by its content_uri (taken from a GetPackageVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
 
 ---
 
@@ -5777,4 +5629,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-07-05*
+*Last updated: 2026-07-22*

--- a/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_COMPACT.md
@@ -596,4 +596,4 @@ Preferred dedicated compact tools and minimal payloads:
 
 ---
 
-*Last updated: 2026-07-05*
+*Last updated: 2026-07-22*

--- a/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_HIGH.md
@@ -3,7 +3,7 @@
 Generated from code in `src/handlers/**` (not from docs).
 
 - Level: High-Level
-- Total tools: 177
+- Total tools: 165
 
 ## Navigation
 
@@ -45,18 +45,9 @@ Generated from code in `src/handlers/**` (not from docs).
     - [GetClassVersionDiff](#getclassversiondiff-high-level-common)
     - [GetClassVersions](#getclassversions-high-level-common)
     - [GetClassVersionSource](#getclassversionsource-high-level-common)
-    - [GetDataElementVersionDiff](#getdataelementversiondiff-high-level-common)
-    - [GetDataElementVersions](#getdataelementversions-high-level-common)
-    - [GetDataElementVersionSource](#getdataelementversionsource-high-level-common)
     - [GetDdlVersionDiff](#getddlversiondiff-high-level-common)
     - [GetDdlVersions](#getddlversions-high-level-common)
     - [GetDdlVersionSource](#getddlversionsource-high-level-common)
-    - [GetDomainVersionDiff](#getdomainversiondiff-high-level-common)
-    - [GetDomainVersions](#getdomainversions-high-level-common)
-    - [GetDomainVersionSource](#getdomainversionsource-high-level-common)
-    - [GetFunctionGroupVersionDiff](#getfunctiongroupversiondiff-high-level-common)
-    - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
-    - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
     - [GetFunctionModuleVersionDiff](#getfunctionmoduleversiondiff-high-level-common)
     - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
     - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
@@ -66,9 +57,6 @@ Generated from code in `src/handlers/**` (not from docs).
     - [GetMetadataExtensionVersionDiff](#getmetadataextensionversiondiff-high-level-common)
     - [GetMetadataExtensionVersions](#getmetadataextensionversions-high-level-common)
     - [GetMetadataExtensionVersionSource](#getmetadataextensionversionsource-high-level-common)
-    - [GetPackageVersionDiff](#getpackageversiondiff-high-level-common)
-    - [GetPackageVersions](#getpackageversions-high-level-common)
-    - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
     - [GetProgramVersionDiff](#getprogramversiondiff-high-level-common)
     - [GetProgramVersions](#getprogramversions-high-level-common)
     - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
@@ -656,40 +644,6 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-<a id="getdataelementversiondiff-high-level-common"></a>
-#### GetDataElementVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP data element versions, by their content_uris (taken from GetDataElementVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDataElementVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDataElementVersions entry).
-
----
-
-<a id="getdataelementversions-high-level-common"></a>
-#### GetDataElementVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP data element. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDataElementVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `data_element_name` (string, required) - ABAP data element name.
-
----
-
-<a id="getdataelementversionsource-high-level-common"></a>
-#### GetDataElementVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP data element version by its content_uri (taken from a GetDataElementVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetDataElementVersions entry.
-
----
-
 <a id="getddlversiondiff-high-level-common"></a>
 #### GetDdlVersionDiff (High-Level / Common)
 **Description:** [read-only] Compute a unified diff between two CDS view (DDL source) versions, by their content_uris (taken from GetDdlVersions entries).
@@ -721,74 +675,6 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetDdlVersions entry.
-
----
-
-<a id="getdomainversiondiff-high-level-common"></a>
-#### GetDomainVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP domain versions, by their content_uris (taken from GetDomainVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetDomainVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetDomainVersions entry).
-
----
-
-<a id="getdomainversions-high-level-common"></a>
-#### GetDomainVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP domain. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetDomainVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `domain_name` (string, required) - ABAP domain name.
-
----
-
-<a id="getdomainversionsource-high-level-common"></a>
-#### GetDomainVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP domain version by its content_uri (taken from a GetDomainVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetDomainVersions entry.
-
----
-
-<a id="getfunctiongroupversiondiff-high-level-common"></a>
-#### GetFunctionGroupVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP function group versions, by their content_uris (taken from GetFunctionGroupVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionGroupVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionGroupVersions entry).
-
----
-
-<a id="getfunctiongroupversions-high-level-common"></a>
-#### GetFunctionGroupVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `function_group_name` (string, required) - ABAP function group name.
-
----
-
-<a id="getfunctiongroupversionsource-high-level-common"></a>
-#### GetFunctionGroupVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP function group version by its content_uri (taken from a GetFunctionGroupVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
 
 ---
 
@@ -892,40 +778,6 @@ Generated from code in `src/handlers/**` (not from docs).
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetMetadataExtensionVersions entry.
-
----
-
-<a id="getpackageversiondiff-high-level-common"></a>
-#### GetPackageVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP package versions, by their content_uris (taken from GetPackageVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetPackageVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetPackageVersions entry).
-
----
-
-<a id="getpackageversions-high-level-common"></a>
-#### GetPackageVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `package_name` (string, required) - ABAP package name.
-
----
-
-<a id="getpackageversionsource-high-level-common"></a>
-#### GetPackageVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP package version by its content_uri (taken from a GetPackageVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
 
 ---
 
@@ -2759,4 +2611,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-07-05*
+*Last updated: 2026-07-22*

--- a/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LEGACY.md
@@ -5,9 +5,9 @@ Generated from code in `src/handlers/**` (not from docs).
 Tools available on legacy SAP systems (BASIS < 7.50).
 Legacy systems support a subset of tools — primarily Class, Interface, View, Program, Function Group/Module, Package (read/update/delete), Include, Unit Test, and common utilities.
 
-- Total tools: 165
+- Total tools: 159
 - Read-Only: 18
-- High-Level: 86
+- High-Level: 80
 - Low-Level: 61
 
 ## Navigation
@@ -70,18 +70,12 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
     - [GetDdlVersionDiff](#getddlversiondiff-high-level-common)
     - [GetDdlVersions](#getddlversions-high-level-common)
     - [GetDdlVersionSource](#getddlversionsource-high-level-common)
-    - [GetFunctionGroupVersionDiff](#getfunctiongroupversiondiff-high-level-common)
-    - [GetFunctionGroupVersions](#getfunctiongroupversions-high-level-common)
-    - [GetFunctionGroupVersionSource](#getfunctiongroupversionsource-high-level-common)
     - [GetFunctionModuleVersionDiff](#getfunctionmoduleversiondiff-high-level-common)
     - [GetFunctionModuleVersions](#getfunctionmoduleversions-high-level-common)
     - [GetFunctionModuleVersionSource](#getfunctionmoduleversionsource-high-level-common)
     - [GetInterfaceVersionDiff](#getinterfaceversiondiff-high-level-common)
     - [GetInterfaceVersions](#getinterfaceversions-high-level-common)
     - [GetInterfaceVersionSource](#getinterfaceversionsource-high-level-common)
-    - [GetPackageVersionDiff](#getpackageversiondiff-high-level-common)
-    - [GetPackageVersions](#getpackageversions-high-level-common)
-    - [GetPackageVersionSource](#getpackageversionsource-high-level-common)
     - [GetProgramVersionDiff](#getprogramversiondiff-high-level-common)
     - [GetProgramVersions](#getprogramversions-high-level-common)
     - [GetProgramVersionSource](#getprogramversionsource-high-level-common)
@@ -871,46 +865,6 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
-<a id="getfunctiongroupversiondiff-high-level-common"></a>
-#### GetFunctionGroupVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP function group versions, by their content_uris (taken from GetFunctionGroupVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Available in:** `onprem`, `cloud`, `legacy`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetFunctionGroupVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetFunctionGroupVersions entry).
-
----
-
-<a id="getfunctiongroupversions-high-level-common"></a>
-#### GetFunctionGroupVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP function group. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetFunctionGroupVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Available in:** `onprem`, `cloud`, `legacy`
-
-**Parameters:**
-- `function_group_name` (string, required) - ABAP function group name.
-
----
-
-<a id="getfunctiongroupversionsource-high-level-common"></a>
-#### GetFunctionGroupVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP function group version by its content_uri (taken from a GetFunctionGroupVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Available in:** `onprem`, `cloud`, `legacy`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetFunctionGroupVersions entry.
-
----
-
 <a id="getfunctionmoduleversiondiff-high-level-common"></a>
 #### GetFunctionModuleVersionDiff (High-Level / Common)
 **Description:** [read-only] Compute a unified diff between two ABAP function module versions, by their content_uris (taken from GetFunctionModuleVersions entries).
@@ -989,46 +943,6 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 **Parameters:**
 - `content_uri` (string, required) - Opaque content_uri taken from a GetInterfaceVersions entry.
-
----
-
-<a id="getpackageversiondiff-high-level-common"></a>
-#### GetPackageVersionDiff (High-Level / Common)
-**Description:** [read-only] Compute a unified diff between two ABAP package versions, by their content_uris (taken from GetPackageVersions entries).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Available in:** `onprem`, `cloud`, `legacy`
-
-**Parameters:**
-- `content_uri_from` (string, required) - Opaque content_uri of the OLD/base version (from a GetPackageVersions entry).
-- `content_uri_to` (string, required) - Opaque content_uri of the NEW/compare version (from a GetPackageVersions entry).
-
----
-
-<a id="getpackageversions-high-level-common"></a>
-#### GetPackageVersions (High-Level / Common)
-**Description:** [read-only] List the SAP version history of a ABAP package. Returns each version with its versionId, author, updatedAt, title, the transportRequest (and transportDescription) that produced it when available, and an opaque content_uri to fetch that version's source via GetPackageVersionSource.
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Available in:** `onprem`, `cloud`, `legacy`
-
-**Parameters:**
-- `package_name` (string, required) - ABAP package name.
-
----
-
-<a id="getpackageversionsource-high-level-common"></a>
-#### GetPackageVersionSource (High-Level / Common)
-**Description:** [read-only] Fetch the source of a specific ABAP package version by its content_uri (taken from a GetPackageVersions entry).
-
-**Source:** `src/handlers/common/high/objectVersionTools.ts`
-
-**Available in:** `onprem`, `cloud`, `legacy`
-
-**Parameters:**
-- `content_uri` (string, required) - Opaque content_uri taken from a GetPackageVersions entry.
 
 ---
 
@@ -2922,4 +2836,4 @@ Legacy systems support a subset of tools — primarily Class, Interface, View, P
 
 ---
 
-*Last updated: 2026-07-05*
+*Last updated: 2026-07-22*

--- a/docs/user-guide/AVAILABLE_TOOLS_LOW.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_LOW.md
@@ -1991,4 +1991,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-07-05*
+*Last updated: 2026-07-22*

--- a/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
+++ b/docs/user-guide/AVAILABLE_TOOLS_READONLY.md
@@ -1033,4 +1033,4 @@ Generated from code in `src/handlers/**` (not from docs).
 
 ---
 
-*Last updated: 2026-07-05*
+*Last updated: 2026-07-22*

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mcp-abap-adt/auth-stores": "^1.0.4",
         "@mcp-abap-adt/connection": "^1.10.0",
         "@mcp-abap-adt/header-validator": "^0.1.8",
-        "@mcp-abap-adt/interfaces": "^11.2.0",
+        "@mcp-abap-adt/interfaces": "^11.3.0",
         "@mcp-abap-adt/logger": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.18.1",
@@ -236,15 +236,6 @@
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
       },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@mcp-abap-adt/adt-clients/node_modules/@mcp-abap-adt/interfaces": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.3.0.tgz",
-      "integrity": "sha512-4KFONd3n1JE+NdXZkuGw7XdXgj5vwHQPtGmQCNE2fwlbb5zMKmThuKFn/fGikBhk2CKiLYtaNOuad3u3pYQKLA==",
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -928,9 +919,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.2.0.tgz",
-      "integrity": "sha512-/ZQ1XwYnheefhe8FNZwLPjeyP7yjLG+tqB3Tv6pWH90zNovhgwB1mxEO59tzvCB0m43xM416Tech7Tfov0CyUA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.3.0.tgz",
+      "integrity": "sha512-4KFONd3n1JE+NdXZkuGw7XdXgj5vwHQPtGmQCNE2fwlbb5zMKmThuKFn/fGikBhk2CKiLYtaNOuad3u3pYQKLA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.11.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/adt-clients": "^7.6.0",
+        "@mcp-abap-adt/adt-clients": "^8.0.0",
         "@mcp-abap-adt/auth-broker": "^1.0.5",
         "@mcp-abap-adt/auth-providers": "^1.0.5",
         "@mcp-abap-adt/auth-stores": "^1.0.4",
@@ -226,16 +226,25 @@
       }
     },
     "node_modules/@mcp-abap-adt/adt-clients": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-7.6.0.tgz",
-      "integrity": "sha512-W8d8spv7jHtTwoUH/itO7vA0rOr31QQX2BpJXpJ+iDpqeoGfML4EwL9hGziPvbve1iQJRQDtDZERLwJIt1GdsQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/adt-clients/-/adt-clients-8.0.0.tgz",
+      "integrity": "sha512-NyAyEf99VqdkP3Jc84cqbFBbgXDs1Ja1pqH86w56/1nmxnaOQvAZBx765kCUAQDQoc4hWZNXSWjYhTbi7/sLPw==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^11.2.0",
+        "@mcp-abap-adt/interfaces": "^11.3.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/adt-clients/node_modules/@mcp-abap-adt/interfaces": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.3.0.tgz",
+      "integrity": "sha512-4KFONd3n1JE+NdXZkuGw7XdXgj5vwHQPtGmQCNE2fwlbb5zMKmThuKFn/fGikBhk2CKiLYtaNOuad3u3pYQKLA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@mcp-abap-adt/adt-clients": "^7.6.0",
+    "@mcp-abap-adt/adt-clients": "^8.0.0",
     "@mcp-abap-adt/auth-broker": "^1.0.5",
     "@mcp-abap-adt/auth-providers": "^1.0.5",
     "@mcp-abap-adt/auth-stores": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@mcp-abap-adt/auth-stores": "^1.0.4",
     "@mcp-abap-adt/connection": "^1.10.0",
     "@mcp-abap-adt/header-validator": "^0.1.8",
-    "@mcp-abap-adt/interfaces": "^11.2.0",
+    "@mcp-abap-adt/interfaces": "^11.3.0",
     "@mcp-abap-adt/logger": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.18.1",

--- a/src/__tests__/unit/objectVersionDiff.test.ts
+++ b/src/__tests__/unit/objectVersionDiff.test.ts
@@ -173,11 +173,11 @@ describe('version diff tools (#30)', () => {
     expect(errText).not.toContain('ADT_UNSUPPORTED_OPERATION');
   });
 
-  it('the factory builds 13 VersionDiff tools (39 total) and they register in High', () => {
+  it('the factory builds 9 VersionDiff tools (27 total) and they register in High', () => {
     const names = buildObjectVersionTools().map((e) => e.toolDefinition.name);
     const diffNames = names.filter((n) => n.endsWith('VersionDiff'));
-    expect(diffNames.length).toBe(13);
-    expect(names.length).toBe(39);
+    expect(diffNames.length).toBe(9);
+    expect(names.length).toBe(27);
 
     const group = new HighLevelHandlersGroup({
       connection: {},

--- a/src/__tests__/unit/objectVersionToolsHigh.test.ts
+++ b/src/__tests__/unit/objectVersionToolsHigh.test.ts
@@ -3,8 +3,11 @@
  *  - Get<Display>Versions dispatches to the right client accessor per type and
  *    forwards the natural name param as the resolver config;
  *  - Get<Display>VersionSource forwards content_uri to getVersionSource;
- *  - the factory registers all 26 expected tool names with the per-type
- *    available_in copied from each high-level Get<X> (program is onprem/legacy).
+ *  - the factory registers all 27 expected tool names (9 versioned types ×
+ *    {Versions, VersionSource, VersionDiff}) with the per-type available_in
+ *    copied from each high-level Get<X> (program is onprem/legacy);
+ *  - non-versioned types (function_group, domain, data_element, package) get
+ *    no version tools.
  * SAP-free via a mocked AdtClient.
  */
 
@@ -120,20 +123,16 @@ describe('per-object high-level version tools (#30)', () => {
     expect(data.source).toBe('DEFINE TABLE zmy_table.');
   });
 
-  it('registers all 39 expected tool names', () => {
+  it('registers all 27 expected tool names', () => {
     const names = buildObjectVersionTools().map((e) => e.toolDefinition.name);
     const displays = [
       'Class',
       'Program',
       'Interface',
-      'FunctionGroup',
       'FunctionModule',
       'Table',
       'Structure',
       'Ddl',
-      'Domain',
-      'DataElement',
-      'Package',
       'BehaviorDefinition',
       'MetadataExtension',
     ];
@@ -143,10 +142,21 @@ describe('per-object high-level version tools (#30)', () => {
       `Get${d}VersionDiff`,
     ]);
     expect(names.sort()).toEqual(expected.sort());
-    expect(new Set(names).size).toBe(39);
+    expect(new Set(names).size).toBe(27);
   });
 
-  it('the registered HighLevel group contains all 39 version tools (no dups)', () => {
+  it('does not register version tools for non-versioned types', () => {
+    const names = new Set(
+      buildObjectVersionTools().map((e) => e.toolDefinition.name),
+    );
+    for (const d of ['FunctionGroup', 'Domain', 'DataElement', 'Package']) {
+      expect(names.has(`Get${d}Versions`)).toBe(false);
+      expect(names.has(`Get${d}VersionSource`)).toBe(false);
+      expect(names.has(`Get${d}VersionDiff`)).toBe(false);
+    }
+  });
+
+  it('the registered HighLevel group contains all 27 version tools (no dups)', () => {
     const group = new HighLevelHandlersGroup({
       connection: {},
       logger: undefined,

--- a/src/handlers/common/high/objectVersionTools.ts
+++ b/src/handlers/common/high/objectVersionTools.ts
@@ -54,6 +54,13 @@ interface VersionedTypeRow {
 /**
  * One row per versioned object_type. `available_in` is copied from each type's
  * existing high-level Get<X> handler (src/handlers/<type>/high/handleGet<X>.ts).
+ *
+ * Only object types whose adt-clients handler implements version history
+ * (IAdtSourceObject) appear here — same supported set as VERSIONED_OBJECT_TYPES
+ * in resolveVersionedObject. Non-versioned lockable types (function_group,
+ * domain, data_element, package) are deliberately excluded: their
+ * getVersions/getVersionSource throw "not supported", so per-type version tools
+ * for them would always error.
  */
 export const VERSIONED_TYPES: VersionedTypeRow[] = [
   {
@@ -75,13 +82,6 @@ export const VERSIONED_TYPES: VersionedTypeRow[] = [
     display: 'Interface',
     nameParam: 'interface_name',
     label: 'ABAP interface',
-    available_in: ['onprem', 'cloud', 'legacy'],
-  },
-  {
-    object_type: 'function_group',
-    display: 'FunctionGroup',
-    nameParam: 'function_group_name',
-    label: 'ABAP function group',
     available_in: ['onprem', 'cloud', 'legacy'],
   },
   {
@@ -110,27 +110,6 @@ export const VERSIONED_TYPES: VersionedTypeRow[] = [
     display: 'Ddl',
     nameParam: 'ddl_name',
     label: 'CDS view (DDL source)',
-    available_in: ['onprem', 'cloud', 'legacy'],
-  },
-  {
-    object_type: 'domain',
-    display: 'Domain',
-    nameParam: 'domain_name',
-    label: 'ABAP domain',
-    available_in: ['onprem', 'cloud'],
-  },
-  {
-    object_type: 'data_element',
-    display: 'DataElement',
-    nameParam: 'data_element_name',
-    label: 'ABAP data element',
-    available_in: ['onprem', 'cloud'],
-  },
-  {
-    object_type: 'package',
-    display: 'Package',
-    nameParam: 'package_name',
-    label: 'ABAP package',
     available_in: ['onprem', 'cloud', 'legacy'],
   },
   {
@@ -395,7 +374,7 @@ function buildVersionDiffTool(row: VersionedTypeRow): ObjectVersionToolEntry {
 }
 
 /**
- * Build all 39 high-level per-object version tools (13 types ×
+ * Build all 27 high-level per-object version tools (9 versioned types ×
  * {Versions, VersionSource, VersionDiff}). The handlers take (context, args);
  * the registering group wraps each with withContext.
  */

--- a/src/handlers/common/readonly/resolveVersionedObject.ts
+++ b/src/handlers/common/readonly/resolveVersionedObject.ts
@@ -2,28 +2,31 @@
  * Shared object_type → IAdtObject resolver for the read-only version-history
  * handlers (GetObjectVersions / GetObjectVersionSource).
  *
- * Mirrors the switch in handleLockObject EXACTLY: the SAME object_type values,
- * the SAME client.getX() accessors, and the SAME config name keys. Instead of
- * calling .lock(...), callers use the returned IAdtObject to call
- * .getVersions(config) / .getVersionSource(contentUri).
+ * Uses the SAME client.getX() accessors and config name keys as handleLockObject,
+ * but only for the object types that actually support version history
+ * (IAdtSourceObject). Callers use the returned handler to call
+ * .getVersions(config) / .getVersionSource(contentUri). Non-versioned lockable
+ * types (function_group, domain, data_element, package) are deliberately absent.
  */
 
 import type { AdtClient } from '@mcp-abap-adt/adt-clients';
 import type { IAdtObject } from '@mcp-abap-adt/interfaces';
 
 /** object_type values supported for version history (same set as LockObject). */
+// Only object types whose adt-clients handler actually implements version
+// history (IAdtSourceObject) belong here. function_group, domain, data_element
+// and package are IAdtNonVersionedObject — their getVersions/getVersionSource
+// throw "not supported", so exposing them here advertised a capability that
+// never worked. The lock switch (handleLockObject) is intentionally wider:
+// those types ARE lockable, just not versioned.
 export const VERSIONED_OBJECT_TYPES = [
   'class',
   'program',
   'interface',
-  'function_group',
   'function_module',
   'table',
   'structure',
   'ddl',
-  'domain',
-  'data_element',
-  'package',
   'behavior_definition',
   'metadata_extension',
 ] as const;
@@ -55,11 +58,6 @@ export function resolveVersionedObject(
       return { obj: client.getProgram(), config: { programName: name } };
     case 'interface':
       return { obj: client.getInterface(), config: { interfaceName: name } };
-    case 'function_group':
-      return {
-        obj: client.getFunctionGroup(),
-        config: { functionGroupName: name },
-      };
     case 'function_module': {
       // Identity is the FM name + its owning function group. The group can be
       // passed explicitly (function_group_name) or via GROUP|FM_NAME, as the
@@ -87,19 +85,10 @@ export function resolveVersionedObject(
       return { obj: client.getStructure(), config: { structureName: name } };
     case 'ddl':
       return { obj: client.getDdl(), config: { ddlName: name } };
-    case 'domain':
-      return { obj: client.getDomain(), config: { domainName: name } };
-    case 'data_element':
-      return {
-        obj: client.getDataElement(),
-        config: { dataElementName: name },
-      };
     case 'behavior_definition':
       return { obj: client.getBehaviorDefinition(), config: { name } };
     case 'metadata_extension':
       return { obj: client.getMetadataExtension(), config: { name } };
-    case 'package':
-      return { obj: client.getPackage(), config: { packageName: name } };
     default:
       return null;
   }


### PR DESCRIPTION
## What

Bump `@mcp-abap-adt/adt-clients` `^7.6.0` → `^8.0.0` (from the npm registry) and fix the one latent bug the new types surfaced.

## Why 8.0.0 is a breaking major

adt-clients 8.0.0 narrows every `AdtClient.getXxx()` return type from the fat `IAdtObject` to the **honest capability composite** each handler actually implements (`IAdtSourceObject`, `IAdtNonVersionedObject`, or an inline `&`-intersection). Calling a capability a handler doesn't support is now a **compile error** instead of a silent runtime throw.

## Latent bug this caught

The version-history tools (`GetObjectVersions` / `GetObjectVersionSource` / `GetObjectVersionDiff`) advertised four object types as versioned that **never were**:

| object_type | 8.0.0 contract | `getVersions()` in adt-clients |
|---|---|---|
| `function_group` | `IAdtNonVersionedObject` | `throwUnsupportedVersions('function group')` |
| `domain` | `IAdtNonVersionedObject` | `throwUnsupportedVersions('domain')` |
| `data_element` | `IAdtNonVersionedObject` | `throwUnsupportedVersions('data element')` |
| `package` | narrower (no `activate` either) | `throwUnsupportedVersions('package')` |

Requesting versions for any of these was **dead on arrival** — the server exposed a capability that always threw at runtime. Before 8.0.0 this compiled silently; the honest types turn it into `TS2739: missing getVersions, getVersionSource`.

Root cause: `resolveVersionedObject.ts` was copied from the wider `handleLockObject` switch (its header even said "Mirrors handleLockObject EXACTLY"). Lock is a wider capability than versions — those four types are lockable, just not versioned.

## Change

- Drop `function_group`, `domain`, `data_element`, `package` from `VERSIONED_OBJECT_TYPES` and the resolver switch — the tool enum now matches what the client can actually do.
- Correct the misleading header comment that caused the copy.
- They remain valid for `LockObject`.

## Verification

- `npx tsc -p tsconfig.json --noEmit` → exit 0
- `npm run build` → clean
- 20/20 version-tool unit tests pass (`objectVersionToolsHigh`, `handleObjectVersions`, `objectVersionDiff`)
- `package-lock.json`: 0 `"link": true` entries (all from npm registry)

## Note

Removing four values from the version tools' `object_type` enum is a visible MCP schema change (removing broken functionality) — suggest a **minor** bump for the server. Version + CHANGELOG entry to be decided by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)