### PR TITLE
chore(security): override @hono/node-server ^2.0.5 — clear remaining moderate advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6786,12 +6786,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -217,5 +217,8 @@
       "biome check --write"
     ]
   },
-  "private": false
+  "private": false,
+  "overrides": {
+    "@hono/node-server": "^2.0.5"
+  }
 }


### PR DESCRIPTION
## What

Pin `@hono/node-server` to `^2.0.5` via npm `overrides`, taking `npm audit` to **0 vulnerabilities**. Follow-up to #164 (which cleared the two *high* advisories); this clears the two remaining *moderate* ones.

## The advisory

`@hono/node-server` (< 2.0.5) — GHSA-frvp-7c67-39w9, path traversal in `serve-static` on Windows via encoded backslash (`%5C`). Moderate.

It reaches us only as a **transitive** dep of `@modelcontextprotocol/sdk` (the Streamable HTTP transport). It is below the CI `high+` gate, so CI is already green — this PR is about reaching a clean `audit 0`, not unblocking CI.

## Why an override (and not a version bump)

There is **no in-range fix**:

- The latest `@modelcontextprotocol/sdk` (1.29.0, what we already use) still pins `@hono/node-server ^1.19.9`.
- `npm audit fix --force` would *downgrade* the SDK to **1.24.3** — a regression, not a fix.

So an `override` is the only way to clear it without downgrading the SDK.

## Why it's safe

- The SDK's `streamableHttp` transport imports exactly **one** symbol from the package — `getRequestListener` — which is present and unchanged in 2.0.11 (verified by resolving it from the SDK's own module context).
- The vulnerable `serve-static` sub-path is **never imported** by the SDK.
- Our own `StreamableHttpServer` uses **express**, not hono, directly.
- This deliberately reintroduces a single override (all were removed in #141). Justified: in-range resolution is impossible until the SDK bumps its own hono dep. Worth revisiting/removing once it does.

## Verification

- `npm audit` → **0 vulnerabilities** (`--omit=dev --audit-level=high` also exit 0)
- `@hono/node-server` resolves to **2.0.11**, `package-lock.json` has 0 `"link": true`
- `npm run build:fast` → exit 0
- `npm run test:check` → exit 0
- SAP-free server/transport unit tests (`tlsServer`, `dnsRebindingProtection`, `serverConfigDnsRebinding`) → 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)