### PR TITLE
fix(#168): collect transport requests from the whole CTS tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`ListTransports` no longer reports an empty list while the user owns transport requests.** The tool returned `{"success": true, "count": 0, "transports": []}` for every input — any user, any `modifiable_only` — on a system where the queried user owned 55 modifiable requests, while `GetSqlQuery` against `E070` and `GetTransport` on the same connection both returned the data. The endpoint negotiates `application/vnd.sap.adt.transportorganizertree.v1+xml`, a *tree*: requests sit under status containers one level below the category (`tm:root > tm:workbench > tm:modifiable > tm:request`), `tm:workbench` repeats once per transport target, and there is a parallel `tm:customizing` branch. The parser looked for `tm:request` only directly under the root or directly under `tm:workbench`, so every lookup missed and the list came back empty — silently, with `success: true`. Requests are now collected from anywhere in the tree (the flatter shapes keep working), deduplicated by request number, and a request with no `tm:status` inherits the status of its container. `modifiable_only` is additionally enforced client-side, because the tree carries released requests too and it is not established that the endpoint honours the `status` query parameter. Unit-tested against a reconstructed tree payload; `scripts/probe-transport-list.ts` dumps the raw payload from a real system so the fixture can be replaced with a capture. ([#168](https://github.com/fr0ster/mcp-abap-adt/issues/168))
+
+### Added
+- **Diagnostic script `scripts/probe-transport-list.ts`** — dumps the raw `/sap/bc/adt/cts/transportrequests` payload for a given user and env file, so the transport-list parser can be checked against the shape a system actually returns.
+
 ## [8.13.0] - 2026-07-24
 
 ### Fixed

--- a/scripts/probe-transport-list.ts
+++ b/scripts/probe-transport-list.ts
@@ -1,0 +1,66 @@
+/**
+ * Dump the raw CTS transport-list payload (issue #168).
+ *
+ * `ListTransports` reports count 0 on systems where the user owns requests.
+ * The endpoint negotiates `application/vnd.sap.adt.transportorganizertree.v1+xml`,
+ * a *tree* representation, so the requests are expected to sit under status
+ * containers rather than directly under the root. This script prints the raw
+ * XML so the parser can be written against the real shape instead of a guess.
+ *
+ * Usage:
+ *   npx tsx scripts/probe-transport-list.ts --env trial.env [--user <SAPUSER>] [--status D]
+ *
+ * With no --user the SAP_USERNAME from the env file is used.
+ */
+import * as path from 'node:path';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import * as dotenv from 'dotenv';
+import { getSapConfigFromEnv } from '../src/__tests__/integration/helpers/configHelpers';
+
+const ACCEPT_TRANSPORT_LIST =
+  'application/vnd.sap.adt.transportorganizertree.v1+xml';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const get = (flag: string): string | undefined => {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+
+  const envFile = path.resolve(
+    get('--env') || path.join(__dirname, '..', 'trial.env'),
+  );
+  dotenv.config({ path: envFile, override: true });
+
+  const user = get('--user') || process.env.SAP_USERNAME || '';
+  const status = get('--status');
+  console.log(`env:  ${envFile}`);
+  console.log(`user: ${user || '(empty)'}`);
+
+  const query = new URLSearchParams({ user });
+  if (status) query.append('status', status);
+  const url = `/sap/bc/adt/cts/transportrequests?${query.toString()}`;
+  console.log(`url:  ${url}\n`);
+
+  const conn = createAbapConnection(getSapConfigFromEnv()) as any;
+  try {
+    const response = await conn.makeAdtRequest({
+      url,
+      method: 'GET',
+      headers: { Accept: ACCEPT_TRANSPORT_LIST },
+    });
+    console.log(`--- HTTP ${response.status} ---`);
+    console.log(String(response.data ?? ''));
+  } catch (error) {
+    const e = error as any;
+    console.log(`--- FAILED HTTP ${e?.response?.status ?? '?'} ---`);
+    console.log(e?.message);
+    console.log(String(e?.response?.data ?? '').slice(0, 2000));
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error('Fatal:', error);
+  process.exit(1);
+});

--- a/src/__tests__/unit/parseTransportListXml.test.ts
+++ b/src/__tests__/unit/parseTransportListXml.test.ts
@@ -1,0 +1,141 @@
+import {
+  isModifiableStatus,
+  parseTransportListXml,
+} from '../../handlers/transport/readonly/handleListTransports';
+
+/**
+ * Guard for #168: `ListTransports` reported `count: 0` on a system where the
+ * queried user owned 55 requests, because the parser looked for `tm:request`
+ * only directly under the root or directly under `tm:workbench`.
+ *
+ * The endpoint negotiates `application/vnd.sap.adt.transportorganizertree.v1+xml`,
+ * where requests sit under status containers one level deeper and `tm:workbench`
+ * repeats per transport target.
+ *
+ * NOTE: the tree fixture below is RECONSTRUCTED from that representation, not
+ * captured from a live system — the reporter could not dump the payload and no
+ * on-premise system was reachable here. `scripts/probe-transport-list.ts` dumps
+ * the real thing; replace this fixture with a capture once one is available.
+ */
+const TREE_PAYLOAD = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:useraction="">
+  <tm:workbench tm:parent_name="">
+    <tm:modifiable tm:parent_name="">
+      <tm:request tm:number="SIDK905635" tm:desc="Feature work" tm:type="K" tm:status="D" tm:owner="DEVELOPER" tm:target="/SIDTOQAS/">
+        <tm:task tm:number="SIDK905636" tm:desc="Task of 905635" tm:type="S" tm:status="D" tm:owner="DEVELOPER"/>
+      </tm:request>
+      <tm:request tm:number="SIDK905640" tm:desc="Protected request" tm:type="K" tm:status="L" tm:owner="DEVELOPER" tm:target="/SIDTOQAS/"/>
+    </tm:modifiable>
+    <tm:released tm:parent_name="">
+      <tm:request tm:number="SIDK905600" tm:desc="Shipped last week" tm:type="K" tm:status="R" tm:owner="DEVELOPER" tm:target="/SIDTOQAS/"/>
+    </tm:released>
+  </tm:workbench>
+  <tm:workbench tm:parent_name="">
+    <tm:modifiable tm:parent_name="">
+      <tm:request tm:number="SIDK905700" tm:desc="Second target" tm:type="K" tm:owner="DEVELOPER" tm:target="/SIDTODEV/"/>
+    </tm:modifiable>
+  </tm:workbench>
+  <tm:customizing tm:parent_name="">
+    <tm:modifiable tm:parent_name="">
+      <tm:request tm:number="SIDK905800" tm:desc="Customizing" tm:type="W" tm:status="D" tm:owner="DEVELOPER" tm:target="/SIDTOQAS/"/>
+    </tm:modifiable>
+  </tm:customizing>
+</tm:root>`;
+
+/** The shape the previous parser expected. It must keep working. */
+const FLAT_PAYLOAD = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm">
+  <tm:request tm:number="SIDK900001" tm:desc="Flat one" tm:type="K" tm:status="D" tm:owner="DEVELOPER" tm:target="/SIDTOQAS/"/>
+</tm:root>`;
+
+const EMPTY_PAYLOAD = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:useraction="">
+  <tm:workbench tm:parent_name=""/>
+</tm:root>`;
+
+describe('parseTransportListXml — transportorganizertree shape (#168)', () => {
+  it('finds requests nested under status containers, in every branch', () => {
+    const numbers = parseTransportListXml(TREE_PAYLOAD).map((t) => t.number);
+
+    expect(numbers).toEqual([
+      'SIDK905635',
+      'SIDK905640',
+      'SIDK905600',
+      'SIDK905700',
+      'SIDK905800',
+    ]);
+  });
+
+  it('maps the request attributes', () => {
+    const first = parseTransportListXml(TREE_PAYLOAD)[0];
+
+    expect(first).toEqual({
+      number: 'SIDK905635',
+      description: 'Feature work',
+      type: 'K',
+      status: 'D',
+      owner: 'DEVELOPER',
+      target: '/SIDTOQAS/',
+    });
+  });
+
+  it('does not report tasks as requests', () => {
+    const numbers = parseTransportListXml(TREE_PAYLOAD).map((t) => t.number);
+
+    expect(numbers).not.toContain('SIDK905636');
+  });
+
+  it('falls back to the container status when the request has none', () => {
+    const entry = parseTransportListXml(TREE_PAYLOAD).find(
+      (t) => t.number === 'SIDK905700',
+    );
+
+    expect(entry?.status).toBe('D');
+  });
+
+  it('still parses the flat shape', () => {
+    expect(parseTransportListXml(FLAT_PAYLOAD).map((t) => t.number)).toEqual([
+      'SIDK900001',
+    ]);
+  });
+
+  it('returns an empty list for an empty tree and for empty input', () => {
+    expect(parseTransportListXml(EMPTY_PAYLOAD)).toEqual([]);
+    expect(parseTransportListXml('')).toEqual([]);
+  });
+
+  it('collapses a request reachable through more than one branch', () => {
+    const duplicated = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm">
+  <tm:workbench><tm:modifiable>
+    <tm:request tm:number="SIDK900002" tm:desc="Once" tm:status="D"/>
+  </tm:modifiable></tm:workbench>
+  <tm:workbench><tm:modifiable>
+    <tm:request tm:number="SIDK900002" tm:desc="Twice" tm:status="D"/>
+  </tm:modifiable></tm:workbench>
+</tm:root>`;
+
+    const parsed = parseTransportListXml(duplicated);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].description).toBe('Once');
+  });
+});
+
+describe('isModifiableStatus', () => {
+  it('treats D and L as modifiable', () => {
+    expect(isModifiableStatus('D')).toBe(true);
+    expect(isModifiableStatus('L')).toBe(true);
+  });
+
+  it('treats released statuses as not modifiable', () => {
+    expect(isModifiableStatus('R')).toBe(false);
+    expect(isModifiableStatus('N')).toBe(false);
+    expect(isModifiableStatus('O')).toBe(false);
+  });
+
+  it('keeps a request whose status could not be determined', () => {
+    expect(isModifiableStatus('')).toBe(true);
+    expect(isModifiableStatus(undefined)).toBe(true);
+  });
+});

--- a/src/__tests__/unit/parseTransportListXml.test.ts
+++ b/src/__tests__/unit/parseTransportListXml.test.ts
@@ -53,6 +53,14 @@ const EMPTY_PAYLOAD = `<?xml version="1.0" encoding="utf-8"?>
   <tm:workbench tm:parent_name=""/>
 </tm:root>`;
 
+/**
+ * CAPTURED, not reconstructed: the verbatim response of
+ * `GET /sap/bc/adt/cts/transportrequests?user=` from an SAP BTP ABAP
+ * environment (us10 trial) that owns no transport requests, 2026-07-28.
+ * An empty result is a bare self-closing root with no status containers at all.
+ */
+const CAPTURED_NO_TRANSPORTS = `<?xml version="1.0" encoding="utf-8"?><tm:root adtcore:name="CB9980008038" adtcore:changedAt="2026-07-28T13:53:59Z" adtcore:createdAt="2026-07-28T13:53:59Z" adtcore:changedBy="CB9980008038" adtcore:createdBy="CB9980008038" xmlns:tm="http://www.sap.com/cts/adt/tm" xmlns:adtcore="http://www.sap.com/adt/core"/>`;
+
 describe('parseTransportListXml — transportorganizertree shape (#168)', () => {
   it('finds requests nested under status containers, in every branch', () => {
     const numbers = parseTransportListXml(TREE_PAYLOAD).map((t) => t.number);
@@ -102,6 +110,12 @@ describe('parseTransportListXml — transportorganizertree shape (#168)', () => 
   it('returns an empty list for an empty tree and for empty input', () => {
     expect(parseTransportListXml(EMPTY_PAYLOAD)).toEqual([]);
     expect(parseTransportListXml('')).toEqual([]);
+  });
+
+  it('reports nothing for a captured response from a system with no requests', () => {
+    // Guards the honest-empty case: `count: 0` must stay 0 when it is true,
+    // not become noise once the parser walks the whole tree.
+    expect(parseTransportListXml(CAPTURED_NO_TRANSPORTS)).toEqual([]);
   });
 
   it('collapses a request reachable through more than one branch', () => {

--- a/src/handlers/transport/readonly/handleListTransports.ts
+++ b/src/handlers/transport/readonly/handleListTransports.ts
@@ -48,7 +48,67 @@ interface TransportEntry {
   target?: string;
 }
 
-function parseTransportListXml(xmlData: string): TransportEntry[] {
+/**
+ * Status implied by the container a request sits in, used only when the request
+ * node itself carries no `tm:status` attribute.
+ */
+const STATUS_BY_CONTAINER: Record<string, string> = {
+  'tm:modifiable': 'D',
+  'tm:released': 'R',
+};
+
+/** Modifiable request statuses: D = modifiable, L = modifiable/protected. */
+const MODIFIABLE_STATUSES = new Set(['D', 'L']);
+
+function collectRequestNodes(
+  node: unknown,
+  containerStatus: string,
+  found: { req: Record<string, unknown>; containerStatus: string }[],
+): void {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectRequestNodes(item, containerStatus, found);
+    }
+    return;
+  }
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (key === 'tm:request') {
+      const requests = Array.isArray(value) ? value : [value];
+      for (const req of requests) {
+        if (req && typeof req === 'object') {
+          found.push({ req: req as Record<string, unknown>, containerStatus });
+        }
+      }
+      // Do not descend into a request: its children are tasks, not requests.
+      continue;
+    }
+    collectRequestNodes(
+      value,
+      STATUS_BY_CONTAINER[key] ?? containerStatus,
+      found,
+    );
+  }
+}
+
+/**
+ * Parse the CTS transport list payload.
+ *
+ * The endpoint negotiates `application/vnd.sap.adt.transportorganizertree.v1+xml`,
+ * a *tree*: requests sit under status containers, one level below the category —
+ * `tm:root > tm:workbench > tm:modifiable > tm:request` — and `tm:workbench` may
+ * repeat, once per transport target. The previous implementation looked for
+ * `tm:request` only directly under the root or directly under `tm:workbench`,
+ * so on a real system every lookup missed and the tool reported an empty list
+ * while the user owned requests (#168).
+ *
+ * Requests are therefore collected from anywhere in the tree, which keeps the
+ * flatter shapes working too. Duplicates (same request number reached through
+ * more than one branch) are collapsed, first occurrence winning.
+ */
+export function parseTransportListXml(xmlData: string): TransportEntry[] {
   const parser = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: '',
@@ -59,27 +119,36 @@ function parseTransportListXml(xmlData: string): TransportEntry[] {
 
   const result = parser.parse(xmlData);
 
-  // Response can be under different roots depending on SAP version
-  const root = result['tm:root'] || result['tm:roots'] || result;
+  const found: { req: Record<string, unknown>; containerStatus: string }[] = [];
+  collectRequestNodes(result, '', found);
 
-  // Extract requests
-  const requests =
-    root?.['tm:request'] || root?.['tm:workbench']?.['tm:request'] || [];
-  const requestList = Array.isArray(requests) ? requests : [requests];
+  const seen = new Set<string>();
+  const entries: TransportEntry[] = [];
 
-  return requestList
-    .filter((req: Record<string, unknown>) => req)
-    .map((req: Record<string, unknown>) => ({
-      number:
-        (req['tm:number'] as string) || (req['adtcore:name'] as string) || '',
+  for (const { req, containerStatus } of found) {
+    const number =
+      (req['tm:number'] as string) || (req['adtcore:name'] as string) || '';
+    if (!number || seen.has(number)) {
+      continue;
+    }
+    seen.add(number);
+    entries.push({
+      number,
       description:
         (req['tm:desc'] as string) || (req['tm:description'] as string) || '',
       type: (req['tm:type'] as string) || '',
-      status: (req['tm:status'] as string) || '',
+      status: (req['tm:status'] as string) || containerStatus || '',
       owner: (req['tm:owner'] as string) || '',
       target: (req['tm:target'] as string) || '',
-    }))
-    .filter((t: TransportEntry) => t.number);
+    });
+  }
+
+  return entries;
+}
+
+/** Unknown status is kept: never hide a request because it was not classified. */
+export function isModifiableStatus(status: string | undefined): boolean {
+  return !status || MODIFIABLE_STATUSES.has(status);
 }
 
 export async function handleListTransports(
@@ -105,7 +174,14 @@ export async function handleListTransports(
       status: modifiableOnly ? 'D' : undefined,
     });
 
-    const transports = parseTransportListXml(state.listResult?.data || '');
+    const parsed = parseTransportListXml(state.listResult?.data || '');
+
+    // The tree representation returns both modifiable and released branches, and
+    // it is not established that the endpoint honours the `status` query param
+    // (#168). Filter here so `modifiable_only` holds regardless.
+    const transports = modifiableOnly
+      ? parsed.filter((t) => isModifiableStatus(t.status))
+      : parsed;
 
     logger?.info(`ListTransports: found ${transports.length} transport(s)`);
 


### PR DESCRIPTION
Fixes #168.

## The defect

`ListTransports` returned `{"success": true, "count": 0, "transports": []}` for every input — any user, any `modifiable_only` — on a system where the queried user owned 55 modifiable requests. `GetSqlQuery` against `E070` and `GetTransport` on the same connection both returned the data, so the endpoint, credentials and authorizations were fine; only the list path was broken. It failed silently with `success: true`, which is a worse failure mode than #23.

## Root cause

The endpoint negotiates `application/vnd.sap.adt.transportorganizertree.v1+xml` (`adt-clients/dist/constants/contentTypes.js:37`) — a **tree**:

```
tm:root
  tm:workbench            (repeats: one per transport target)
    tm:modifiable
      tm:request
    tm:released
      tm:request
  tm:customizing
    tm:modifiable
      tm:request
```

The parser expected `tm:request` either directly under the root or directly under `tm:workbench`:

```js
const requests = root?.['tm:request'] || root?.['tm:workbench']?.['tm:request'] || [];
```

Both lookups miss at that depth — and when `tm:workbench` repeats it is an array, so the second lookup cannot match either. Result: `[]` for every input, exactly as observed.

Confirmed by running the old expression against the fixture in this PR: **0 requests found where 5 exist.**

## The fix

- `parseTransportListXml` collects `tm:request` from anywhere in the tree, so every status container and both the workbench and customizing branches are covered. The flatter shapes keep working.
- Results are deduplicated by request number (first occurrence wins) in case a request is reachable through more than one branch.
- A request carrying no `tm:status` inherits its container's status (`tm:modifiable` → `D`, `tm:released` → `R`).
- Tasks are not descended into, so `tm:task` nodes are never reported as requests.
- `modifiable_only` is now enforced client-side as well (`D`/`L` modifiable; an undetermined status is kept, never hidden). The tree carries released requests, and it is not established that the endpoint honours the `status` query parameter — the reporter saw `count: 0` with and without it, so the two cases cannot be told apart from the evidence.

## Verification

- `npm run build`, `npm run test:check` — clean.
- Full non-integration suite: 43 suites / 524 tests pass, including 10 new ones.

**Not verified on a live system.** The unit fixture is reconstructed from the `transportorganizertree` representation, not captured: the reporter could not dump the payload, and no on-premise system was reachable here (all local env JWTs are expired). `scripts/probe-transport-list.ts` is added for exactly this — it dumps the raw payload for a user and env file, so the fixture can be replaced with a real capture and the fix confirmed against the shape a system actually returns.

## Side note from the issue

The reported `handleRuntimeGetDumpByUri` defect does not reproduce on 8.13.0: there is no such handler. `src/handlers/system/readonly/handleRuntimeGetDumpById.ts:120` calls `runtimeClient.getDumps().getById(...)` — the factory pattern — and `AdtRuntimeClient.prototype` does expose `getDumps` (checked at runtime). Nothing to fix there; it looks like the observation was made against an older build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)