### PR TITLE
fix(ddlx): check the active version by default in CheckMetadataExtension

### DIFF
--- a/src/__tests__/integration/high/check/CheckHighHandlers.test.ts
+++ b/src/__tests__/integration/high/check/CheckHighHandlers.test.ts
@@ -858,7 +858,15 @@ describe('Check High-Level Handlers Integration', () => {
           assertNormalizedCheckResponse(data, objectName);
           expect(data.name).toBe(objectName.toUpperCase());
 
+          // Regression: default check must target the ACTIVE version.
+          // An activated DDLX has no genuine inactive version; checking
+          // 'inactive' returns notProcessed / "Error while reading the object
+          // ... from the database". Default 'active' must come back processed.
+          expect(data.version).toBe('active');
           const cr = data.check_result;
+          expect(cr.status).not.toBe('notProcessed');
+          expect(cr.status).toBe('processed');
+
           logger?.success(
             `✅ check: ${objectName} — ${cr.errors.length} error(s), ${cr.warnings.length} warning(s)`,
           );

--- a/src/__tests__/unit/checkMetadataExtensionVersion.test.ts
+++ b/src/__tests__/unit/checkMetadataExtensionVersion.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for CheckMetadataExtension version handling.
+ *
+ * Regression for the "notProcessed / Error while reading the object ... from the
+ * database" bug: an active-only DDLX must be checked against the *active* version.
+ * The DDLX checkruns endpoint does NOT fall back to active when there is no genuine
+ * inactive version, so checking version=inactive on an activated object errors.
+ *
+ * The low handler must:
+ *  - default to checking the 'active' version
+ *  - thread an explicit version through to client.getMetadataExtension().check(cfg, version)
+ */
+
+const checkMock = jest.fn();
+
+jest.mock('../../lib/clients', () => ({
+  createAdtClient: () => ({
+    getMetadataExtension: () => ({
+      check: checkMock,
+    }),
+  }),
+}));
+
+import { handleCheckMetadataExtension as handleLow } from '../../handlers/ddlx/low/handleCheckMetadataExtension';
+
+const PROCESSED_XML = `<?xml version="1.0" encoding="utf-8"?><chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun"><chkrun:checkReport chkrun:reporter="abapCheckRun" chkrun:triggeringUri="/sap/bc/adt/ddic/ddlx/sources/zc_ddlx" chkrun:status="processed" chkrun:statusText="Object ZC_DDLX has been checked"/></chkrun:checkRunReports>`;
+
+function makeContext() {
+  return {
+    connection: {} as any,
+    logger: undefined,
+  } as any;
+}
+
+describe('CheckMetadataExtension version threading', () => {
+  beforeEach(() => {
+    checkMock.mockReset();
+    checkMock.mockResolvedValue({ checkResult: { data: PROCESSED_XML } });
+  });
+
+  it("defaults to checking the 'active' version", async () => {
+    await handleLow(makeContext(), { name: 'ZC_DDLX' });
+
+    expect(checkMock).toHaveBeenCalledTimes(1);
+    const [config, version] = checkMock.mock.calls[0];
+    expect(config).toEqual({ name: 'ZC_DDLX' });
+    expect(version).toBe('active');
+  });
+
+  it("threads an explicit version='inactive' through to the client", async () => {
+    await handleLow(makeContext(), { name: 'ZC_DDLX', version: 'inactive' });
+
+    const [, version] = checkMock.mock.calls[0];
+    expect(version).toBe('inactive');
+  });
+
+  it("threads an explicit version='active' through to the client", async () => {
+    await handleLow(makeContext(), { name: 'ZC_DDLX', version: 'active' });
+
+    const [, version] = checkMock.mock.calls[0];
+    expect(version).toBe('active');
+  });
+});

--- a/src/handlers/ddlx/high/handleCheckMetadataExtension.ts
+++ b/src/handlers/ddlx/high/handleCheckMetadataExtension.ts
@@ -14,6 +14,12 @@ export const TOOL_DEFINITION = {
         type: 'string',
         description: 'Metadata extension name (e.g., ZC_MY_DDLX).',
       },
+      version: {
+        type: 'string',
+        description:
+          "Version to check: 'active' (last activated) or 'inactive' (current unsaved). Default: active.",
+        enum: ['active', 'inactive'],
+      },
     },
     required: ['name'],
   },
@@ -21,7 +27,7 @@ export const TOOL_DEFINITION = {
 
 export async function handleCheckMetadataExtension(
   context: HandlerContext,
-  args: { name: string },
+  args: { name: string; version?: string },
 ) {
   const result = await handleCheckMetadataExtensionLow(context, args);
   return normalizeCheckResponse(result, args.name?.toUpperCase());

--- a/src/handlers/ddlx/low/handleCheckMetadataExtension.ts
+++ b/src/handlers/ddlx/low/handleCheckMetadataExtension.ts
@@ -27,6 +27,12 @@ export const TOOL_DEFINITION = {
         type: 'string',
         description: 'MetadataExtension name (e.g., ZI_MY_DDLX).',
       },
+      version: {
+        type: 'string',
+        description:
+          "Version to check: 'active' (last activated) or 'inactive' (current unsaved). Default: active. Note: checking 'inactive' on an activated DDLX with no genuine inactive version errors with 'Error while reading the object ... from the database'.",
+        enum: ['active', 'inactive'],
+      },
       session_id: {
         type: 'string',
         description:
@@ -49,6 +55,7 @@ export const TOOL_DEFINITION = {
 
 interface CheckMetadataExtensionArgs {
   name: string;
+  version?: string;
   session_id?: string;
   session_state?: {
     cookies?: string;
@@ -68,13 +75,23 @@ export async function handleCheckMetadataExtension(
 ) {
   const { connection, logger } = context;
   try {
-    const { name, session_id, session_state } =
+    const { name, version, session_id, session_state } =
       args as CheckMetadataExtensionArgs;
 
     // Validation
     if (!name) {
       return return_error(new Error('name is required'));
     }
+
+    // Version to check. Default 'active': an activated DDLX has no genuine
+    // inactive version, and the DDLX checkruns endpoint (unlike DDLS) does NOT
+    // fall back to active for version='inactive' — it returns notProcessed
+    // ("Error while reading the object ... from the database").
+    const validVersions = ['active', 'inactive'];
+    const checkVersion =
+      version && validVersions.includes(version.toLowerCase())
+        ? (version.toLowerCase() as 'active' | 'inactive')
+        : 'active';
 
     const client = createAdtClient(connection, logger);
 
@@ -87,13 +104,16 @@ export async function handleCheckMetadataExtension(
 
     const ddlxName = name.toUpperCase();
 
-    logger?.info(`Starting metadata extension check: ${ddlxName}`);
+    logger?.info(
+      `Starting metadata extension check: ${ddlxName} (version: ${checkVersion})`,
+    );
 
     try {
-      // Check metadata extension
+      // Check metadata extension. The second arg maps to chkrun:version inside
+      // the adt-clients check() method (status === 'active' ? 'active' : 'inactive').
       const checkState = await client
         .getMetadataExtension()
-        .check({ name: ddlxName });
+        .check({ name: ddlxName }, checkVersion);
       const response = checkState.checkResult;
 
       if (!response) {
@@ -117,6 +137,7 @@ export async function handleCheckMetadataExtension(
           {
             success: checkResult.success,
             name: ddlxName,
+            version: checkVersion,
             check_result: checkResult,
             session_id: session_id || null,
             session_state: null, // Session state management is now handled by auth-broker,


### PR DESCRIPTION
## Problem

`CheckMetadataExtension` always checks the **inactive** version. The low handler
calls `client.getMetadataExtension().check({ name })` with no status, which
adt-clients maps to `chkrun:version="inactive"`.

For an activated DDLX that has no genuine inactive version, the DDLX checkruns
endpoint does **not** fall back to active (unlike the DDLS endpoint) and returns
`status="notProcessed"` with `"Error while reading the object ... from the
database"`. So checking a perfectly valid, activated metadata extension reports
a failure.

## Fix

Expose a `version` param (`active` | `inactive`, default `active`) on both the
high and low handlers, mirroring the existing `CheckView` handler, and thread it
through to the adt-clients `check()` call.

Default is `active` so an activated object checks cleanly; callers that want the
old behaviour can still pass `inactive` explicitly.

## Tests

- `src/__tests__/unit/checkMetadataExtensionVersion.test.ts` — asserts the
  version is threaded through and defaults to `active`.
- `CheckHighHandlers.test.ts` — integration assertion for the default.

Build clean, 521 unit tests green against `main` (adt-clients 10.1.0).
