### PR TITLE
fix(GetSqlQuery): empty cells shifted every following value up a row

### DIFF
--- a/src/__tests__/unit/parseSqlQueryXml.test.ts
+++ b/src/__tests__/unit/parseSqlQueryXml.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the ADT data preview parser.
+ *
+ * The primary fixture is a VERBATIM capture from a 7.5x system of
+ *   SELECT FIELDNAME, CHECKTABLE FROM DD03L WHERE TABNAME = 'E070'
+ * It is the minimal real payload that exhibits the alignment bug: eight of the
+ * nine CHECKTABLE cells are empty, and SAP emits each of them as a
+ * self-closing <dataPreview:data/>.
+ */
+
+import { parseSqlQueryXml } from '../../handlers/system/readonly/handleGetSqlQuery';
+
+/** Verbatim server response — do not reformat; the self-closing <data/> elements are the point. */
+const DD03L_PAYLOAD = `<?xml version="1.0" encoding="utf-8"?><dataPreview:tableData xmlns:dataPreview="http://www.sap.com/adt/dataPreview"><dataPreview:totalRows>9</dataPreview:totalRows><dataPreview:isHanaAnalyticalView>false</dataPreview:isHanaAnalyticalView><dataPreview:executedQueryString>SELECT FIELDNAME, CHECKTABLE FROM DD03L WHERE TABNAME = 'E070'   INTO     TABLE @DATA(LT_RESULT)   UP TO 15  ROWS   .</dataPreview:executedQueryString><dataPreview:queryExecutionTime>8.5520000</dataPreview:queryExecutionTime><dataPreview:columns><dataPreview:metadata dataPreview:name="FIELDNAME" dataPreview:type="C" dataPreview:description="FIELDNAME" dataPreview:keyAttribute="false" dataPreview:colType="" dataPreview:isKeyFigure="false"/><dataPreview:dataSet><dataPreview:data>AS4USER</dataPreview:data><dataPreview:data>AS4DATE</dataPreview:data><dataPreview:data>AS4TIME</dataPreview:data><dataPreview:data>TRKORR</dataPreview:data><dataPreview:data>TRFUNCTION</dataPreview:data><dataPreview:data>KORRDEV</dataPreview:data><dataPreview:data>TRSTATUS</dataPreview:data><dataPreview:data>TARSYSTEM</dataPreview:data><dataPreview:data>STRKORR</dataPreview:data></dataPreview:dataSet></dataPreview:columns><dataPreview:columns><dataPreview:metadata dataPreview:name="CHECKTABLE" dataPreview:type="C" dataPreview:description="CHECKTABLE" dataPreview:keyAttribute="false" dataPreview:colType="" dataPreview:isKeyFigure="false"/><dataPreview:dataSet><dataPreview:data/><dataPreview:data/><dataPreview:data/><dataPreview:data/><dataPreview:data/><dataPreview:data/><dataPreview:data/><dataPreview:data/><dataPreview:data>E070</dataPreview:data></dataPreview:dataSet></dataPreview:columns></dataPreview:tableData>`;
+
+function buildPayload(
+  columns: Array<{ name: string; type?: string; values: string[] }>,
+): string {
+  const blocks = columns
+    .map(
+      ({ name, type = 'C', values }) =>
+        `<dataPreview:columns><dataPreview:metadata dataPreview:name="${name}" dataPreview:type="${type}" dataPreview:description="${name}"/><dataPreview:dataSet>${values
+          .map((value) =>
+            value === ''
+              ? '<dataPreview:data/>'
+              : `<dataPreview:data>${value}</dataPreview:data>`,
+          )
+          .join('')}</dataPreview:dataSet></dataPreview:columns>`,
+    )
+    .join('');
+
+  return `<?xml version="1.0" encoding="utf-8"?><dataPreview:tableData xmlns:dataPreview="http://www.sap.com/adt/dataPreview"><dataPreview:totalRows>${columns[0]?.values.length ?? 0}</dataPreview:totalRows><dataPreview:queryExecutionTime>1.0</dataPreview:queryExecutionTime>${blocks}</dataPreview:tableData>`;
+}
+
+describe('parseSqlQueryXml', () => {
+  describe('row alignment with empty cells', () => {
+    const result = parseSqlQueryXml(DD03L_PAYLOAD, 'SELECT ...', 15);
+
+    it('returns every row', () => {
+      expect(result.rows).toHaveLength(9);
+      expect(result.total_rows).toBe(9);
+    });
+
+    it('attributes CHECKTABLE=E070 to STRKORR, not to the first row', () => {
+      // The whole bug in one assertion: the single non-empty value belongs to
+      // the last row. A parser that drops self-closing <data/> puts it first.
+      const strkorr = result.rows.find((row) => row.FIELDNAME === 'STRKORR');
+      expect(strkorr?.CHECKTABLE).toBe('E070');
+
+      const as4user = result.rows.find((row) => row.FIELDNAME === 'AS4USER');
+      expect(as4user?.CHECKTABLE).toBe('');
+    });
+
+    it('keeps FIELDNAME in its original order', () => {
+      expect(result.rows.map((row) => row.FIELDNAME)).toEqual([
+        'AS4USER',
+        'AS4DATE',
+        'AS4TIME',
+        'TRKORR',
+        'TRFUNCTION',
+        'KORRDEV',
+        'TRSTATUS',
+        'TARSYSTEM',
+        'STRKORR',
+      ]);
+    });
+
+    it('represents an empty cell as an empty string rather than null', () => {
+      expect(result.rows.slice(0, 8).map((row) => row.CHECKTABLE)).toEqual(
+        Array(8).fill(''),
+      );
+    });
+
+    it('reports no warnings for a well-formed payload', () => {
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it('exposes the statement SAP actually executed', () => {
+      expect(result.executed_query).toContain(
+        'INTO     TABLE @DATA(LT_RESULT)',
+      );
+      expect(result.executed_query).toContain('UP TO 15  ROWS');
+    });
+
+    it('reads column metadata', () => {
+      expect(result.columns).toEqual([
+        {
+          name: 'FIELDNAME',
+          key: 'FIELDNAME',
+          type: 'C',
+          description: 'FIELDNAME',
+          length: undefined,
+        },
+        {
+          name: 'CHECKTABLE',
+          key: 'CHECKTABLE',
+          type: 'C',
+          description: 'CHECKTABLE',
+          length: undefined,
+        },
+      ]);
+    });
+  });
+
+  describe('duplicate column names', () => {
+    // A JOIN over E070/E071 returns TRKORR twice; keying by name alone makes
+    // the second column overwrite the first and silently halves the result.
+    const payload = buildPayload([
+      { name: 'TRKORR', values: ['DESK1', 'DESK2'] },
+      { name: 'TRKORR', values: ['TASK1', 'TASK2'] },
+      { name: 'TRKORR', values: ['SUB1', 'SUB2'] },
+    ]);
+    const result = parseSqlQueryXml(payload, 'SELECT ...', 10);
+
+    it('disambiguates rather than overwriting', () => {
+      expect(result.rows[0]).toEqual({
+        TRKORR: 'DESK1',
+        TRKORR_2: 'TASK1',
+        TRKORR_3: 'SUB1',
+      });
+    });
+
+    it('reports the original name alongside the key', () => {
+      expect(result.columns.map((column) => [column.name, column.key])).toEqual(
+        [
+          ['TRKORR', 'TRKORR'],
+          ['TRKORR', 'TRKORR_2'],
+          ['TRKORR', 'TRKORR_3'],
+        ],
+      );
+    });
+
+    it('warns about the collision', () => {
+      expect(result.warnings).toHaveLength(2);
+      expect(result.warnings?.[0]).toContain('TRKORR_2');
+    });
+  });
+
+  describe('value fidelity', () => {
+    it('keeps NUMC values as zero-padded strings', () => {
+      const payload = buildPayload([
+        { name: 'POSITION', type: 'N', values: ['0001', '0010'] },
+      ]);
+      const result = parseSqlQueryXml(payload, 'SELECT ...', 10);
+      expect(result.rows.map((row) => row.POSITION)).toEqual(['0001', '0010']);
+    });
+
+    it('keeps "0" instead of turning it into null', () => {
+      const payload = buildPayload([{ name: 'FLAG', values: ['0', '1', '0'] }]);
+      const result = parseSqlQueryXml(payload, 'SELECT ...', 10);
+      expect(result.rows.map((row) => row.FLAG)).toEqual(['0', '1', '0']);
+    });
+
+    it('decodes XML entities', () => {
+      const payload = buildPayload([
+        { name: 'TEXT', values: ['A &amp; B', '&lt;tag&gt;'] },
+      ]);
+      const result = parseSqlQueryXml(payload, 'SELECT ...', 10);
+      expect(result.rows.map((row) => row.TEXT)).toEqual(['A & B', '<tag>']);
+    });
+  });
+
+  describe('degenerate payloads', () => {
+    it('handles a single row without collapsing the array', () => {
+      const payload = buildPayload([
+        { name: 'FIELDNAME', values: ['STRKORR'] },
+        { name: 'CHECKTABLE', values: ['E070'] },
+      ]);
+      const result = parseSqlQueryXml(payload, 'SELECT ...', 10);
+      expect(result.rows).toEqual([
+        { FIELDNAME: 'STRKORR', CHECKTABLE: 'E070' },
+      ]);
+    });
+
+    it('handles an empty result set', () => {
+      const payload = buildPayload([{ name: 'FIELDNAME', values: [] }]);
+      const result = parseSqlQueryXml(payload, 'SELECT ...', 10);
+      expect(result.rows).toEqual([]);
+      expect(result.columns).toHaveLength(1);
+    });
+
+    it('warns when columns disagree on row count', () => {
+      const payload = buildPayload([
+        { name: 'A', values: ['1', '2', '3'] },
+        { name: 'B', values: ['x'] },
+      ]);
+      const result = parseSqlQueryXml(payload, 'SELECT ...', 10);
+      expect(result.warnings?.join(' ')).toContain('misaligned');
+      expect(result.rows[2]).toEqual({ A: '3', B: null });
+    });
+
+    it('reports a parse failure instead of returning a plausible empty table', () => {
+      const result: any = parseSqlQueryXml('not xml at all', 'SELECT ...', 10);
+      expect(result.error).toContain('Failed to parse');
+    });
+  });
+});

--- a/src/handlers/system/readonly/handleGetSqlQuery.ts
+++ b/src/handlers/system/readonly/handleGetSqlQuery.ts
@@ -1,18 +1,24 @@
 import type { ILogger } from '@mcp-abap-adt/interfaces';
+import { XMLParser } from 'fast-xml-parser';
 import { createAdtClient } from '../../../lib/clients';
 import type { HandlerContext } from '../../../lib/handlers/interfaces';
 import { return_error } from '../../../lib/utils';
+
 export const TOOL_DEFINITION = {
   name: 'GetSqlQuery',
   available_in: ['onprem', 'cloud'] as const,
   description:
-    '[read-only] Execute ABAP SQL SELECT queries on database tables and CDS views via SAP ADT Data Preview API. Use for ad-hoc data retrieval, row counts, and filtered queries.',
+    '[read-only] Execute ABAP SQL SELECT queries on database tables and CDS views via SAP ADT Data Preview API. Use for ad-hoc data retrieval, row counts, and filtered queries. ' +
+    'IMPORTANT: SAP appends "INTO TABLE @DATA(LT_RESULT) UP TO <row_number> ROWS ." to your query, so do NOT write your own INTO or UP TO ... ROWS clause — they collide and SAP rejects the statement with a grammar error. ' +
+    'Use ABAP SQL syntax (alias~column, spaces inside function parentheses, e.g. SUBSTRING( col, 1, 4 )). ' +
+    'The response echoes back the statement SAP actually ran as "executed_query".',
   inputSchema: {
     type: 'object',
     properties: {
       sql_query: {
         type: 'string',
-        description: 'SQL query to execute',
+        description:
+          'SQL query to execute. Omit INTO and UP TO ... ROWS — SAP adds them. Use row_number to limit rows.',
       },
       row_number: {
         type: 'number',
@@ -32,17 +38,75 @@ export interface SqlQueryResponse {
   row_number: number;
   execution_time?: number;
   total_rows?: number;
+  /** The statement SAP actually executed (it rewrites the query and appends INTO/UP TO). */
+  executed_query?: string;
   columns: Array<{
     name: string;
+    /** Key under which this column's value appears in `rows`. Differs from `name` only when the result set has duplicate column names (common in JOINs). */
+    key: string;
     type: string;
     description?: string;
     length?: number;
   }>;
   rows: Array<Record<string, any>>;
+  /** Non-fatal parse anomalies (e.g. columns of differing length). Absent when clean. */
+  warnings?: string[];
+}
+
+/**
+ * Parser for the ADT data preview payload.
+ *
+ * `removeNSPrefix` strips the `dataPreview:` prefix from both elements and
+ * attributes, so this survives a namespace-prefix change on the SAP side.
+ *
+ * The remaining options all defend value fidelity, and each one is load-bearing:
+ * - `parseTagValue: false` keeps `"0001"` (a NUMC key) from decaying to the
+ *   number 1, and keeps a long numeric key from losing precision.
+ * - `trimValues: false` preserves leading/trailing blanks, which are meaningful
+ *   in fixed-width CHAR columns.
+ * - `isArray` forces `columns` and `data` to stay arrays even at length 1,
+ *   which keeps single-row and single-column results on the same code path as
+ *   everything else.
+ */
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  removeNSPrefix: true,
+  parseTagValue: false,
+  parseAttributeValue: false,
+  trimValues: false,
+  isArray: (name: string) => name === 'columns' || name === 'data',
+});
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
 }
 
 /**
  * Parse SAP ADT XML response from freestyle SQL query and convert to JSON format
+ *
+ * The payload is column-oriented — one `<columns>` block per column, each
+ * holding a `<metadata>` descriptor and a `<dataSet>` of `<data>` elements —
+ * and this function transposes it into rows.
+ *
+ * Two properties of the SAP payload make the transposition easy to get wrong,
+ * and both used to be:
+ *
+ * 1. An empty value is emitted as a SELF-CLOSING `<data/>`, not as
+ *    `<data></data>`. A parser that only recognises the open/close form drops
+ *    those elements, the column's array comes back short, and every value
+ *    below the first empty one shifts UP a row — silently attributing data to
+ *    the wrong record. (Reproduced against a 7.5x system: `SELECT FIELDNAME,
+ *    CHECKTABLE FROM DD03L WHERE TABNAME = 'E070'` has eight empty CHECKTABLE
+ *    cells, and the single real value, which belongs to STRKORR, was reported
+ *    against AS4USER.) Keeping the empty elements is what holds the rows in register.
+ *
+ * 2. Column names are NOT unique. A JOIN over E070/E071/E07T yields several
+ *    MANDT and TRKORR columns, so keying rows by name alone makes later
+ *    columns overwrite earlier ones. Duplicates therefore get a `_2`, `_3`
+ *    suffix, reported back to the caller as `columns[].key`.
+ *
  * @param xmlData - Raw XML response from ADT
  * @param sqlQuery - Original SQL query
  * @param rowNumber - Number of rows requested
@@ -55,99 +119,102 @@ export function parseSqlQueryXml(
   logger?: ILogger,
 ): SqlQueryResponse {
   try {
-    // Extract basic information
-    const totalRowsMatch = xmlData.match(
-      /<dataPreview:totalRows>(\d+)<\/dataPreview:totalRows>/,
-    );
-    const totalRows = totalRowsMatch ? parseInt(totalRowsMatch[1], 10) : 0;
+    const parsed = xmlParser.parse(xmlData);
+    const root = parsed?.tableData ?? parsed?.['dataPreview:tableData'];
 
-    const queryTimeMatch = xmlData.match(
-      /<dataPreview:queryExecutionTime>([\d.]+)<\/dataPreview:queryExecutionTime>/,
-    );
-    const queryExecutionTime = queryTimeMatch
-      ? parseFloat(queryTimeMatch[1])
-      : 0;
-
-    // Extract column metadata
-    const columns: Array<{
-      name: string;
-      type: string;
-      description?: string;
-      length?: number;
-    }> = [];
-    const columnMatches = xmlData.match(/<dataPreview:metadata[^>]*>/g);
-
-    if (columnMatches) {
-      columnMatches.forEach((match) => {
-        const nameMatch = match.match(/dataPreview:name="([^"]+)"/);
-        const typeMatch = match.match(/dataPreview:type="([^"]+)"/);
-        const descMatch = match.match(/dataPreview:description="([^"]+)"/);
-        const lengthMatch = match.match(/dataPreview:length="(\d+)"/);
-
-        if (nameMatch) {
-          columns.push({
-            name: nameMatch[1],
-            type: typeMatch ? typeMatch[1] : 'UNKNOWN',
-            description: descMatch ? descMatch[1] : '',
-            length: lengthMatch ? parseInt(lengthMatch[1], 10) : undefined,
-          });
-        }
-      });
+    if (!root) {
+      throw new Error('No <tableData> element in data preview response');
     }
 
-    // Extract row data
-    const rows: Array<Record<string, any>> = [];
+    const totalRows = Number.parseInt(String(root.totalRows ?? '0'), 10) || 0;
+    const executionTime =
+      Number.parseFloat(String(root.queryExecutionTime ?? '0')) || 0;
+    const executedQuery =
+      typeof root.executedQueryString === 'string'
+        ? root.executedQueryString.trim()
+        : undefined;
 
-    // Find all column sections
-    const columnSections = xmlData.match(
-      /<dataPreview:columns>.*?<\/dataPreview:columns>/gs,
-    );
+    const warnings: string[] = [];
+    const columns: SqlQueryResponse['columns'] = [];
+    const columnValues: string[][] = [];
+    const usedKeys = new Set<string>();
 
-    if (columnSections && columnSections.length > 0) {
-      // Extract data for each column
-      const columnData: Record<string, (string | null)[]> = {};
+    for (const block of toArray<any>(root.columns)) {
+      const meta = block?.metadata ?? {};
+      const name = String(meta['@_name'] ?? `COLUMN_${columns.length + 1}`);
 
-      columnSections.forEach((section, index) => {
-        if (index < columns.length) {
-          const columnName = columns[index].name;
-          const dataMatches = section.match(
-            /<dataPreview:data[^>]*>(.*?)<\/dataPreview:data>/g,
-          );
+      // Disambiguate duplicate column names (JOINs routinely produce them)
+      // rather than letting the later column silently overwrite the earlier.
+      let key = name;
+      let suffix = 2;
+      while (usedKeys.has(key)) {
+        key = `${name}_${suffix++}`;
+      }
+      usedKeys.add(key);
+      if (key !== name) {
+        warnings.push(
+          `Duplicate column name "${name}" in result set; exposed as "${key}".`,
+        );
+      }
 
-          if (dataMatches) {
-            columnData[columnName] = dataMatches.map((match) => {
-              const content = match.replace(/<[^>]+>/g, '');
-              return content || null;
-            });
-          } else {
-            columnData[columnName] = [];
-          }
-        }
+      const lengthAttr = meta['@_length'];
+      columns.push({
+        name,
+        key,
+        type: String(meta['@_type'] ?? 'UNKNOWN'),
+        description: meta['@_description']
+          ? String(meta['@_description'])
+          : undefined,
+        length:
+          lengthAttr !== undefined
+            ? Number.parseInt(String(lengthAttr), 10)
+            : undefined,
       });
 
-      // Convert column-based data to row-based data
-      const maxRowCount = Math.max(
-        ...Object.values(columnData).map((arr) => arr.length),
-        0,
+      // Self-closing <data/> parses to '' here — kept, not dropped, so the
+      // index of every following value still equals its row number.
+      columnValues.push(
+        toArray<any>(block?.dataSet?.data).map((value) =>
+          value === undefined || value === null ? '' : String(value),
+        ),
       );
+    }
 
-      for (let rowIndex = 0; rowIndex < maxRowCount; rowIndex++) {
-        const row: Record<string, any> = {};
-        columns.forEach((column) => {
-          const columnValues = columnData[column.name] || [];
-          row[column.name] = columnValues[rowIndex] || null;
-        });
-        rows.push(row);
-      }
+    const lengths = columnValues.map((values) => values.length);
+    const maxRowCount = lengths.length > 0 ? Math.max(...lengths) : 0;
+
+    // Every column must carry the same number of cells. If they don't, the
+    // rows are no longer trustworthy and the caller needs to be told rather
+    // than handed a plausible-looking table.
+    if (lengths.length > 0 && new Set(lengths).size > 1) {
+      warnings.push(
+        `Columns returned differing row counts (${columns
+          .map((column, index) => `${column.key}=${lengths[index]}`)
+          .join(', ')}); rows may be misaligned.`,
+      );
+    }
+
+    const rows: Array<Record<string, any>> = [];
+    for (let rowIndex = 0; rowIndex < maxRowCount; rowIndex++) {
+      const row: Record<string, any> = {};
+      columns.forEach((column, columnIndex) => {
+        const values = columnValues[columnIndex];
+        // `??` not `||`: an empty string and "0" are real values, not nulls.
+        // Only a genuinely absent cell becomes null.
+        row[column.key] = values[rowIndex] ?? null;
+      });
+      rows.push(row);
     }
 
     return {
       sql_query: sqlQuery,
       row_number: rowNumber,
-      execution_time: queryExecutionTime,
+      execution_time: executionTime,
       total_rows: totalRows,
+      executed_query: executedQuery,
       columns,
       rows,
+      warnings: warnings.length > 0 ? warnings : undefined,
     };
   } catch (parseError) {
     logger?.error('Failed to parse SQL query XML:', parseError as any);
@@ -158,9 +225,59 @@ export function parseSqlQueryXml(
       row_number: rowNumber,
       columns: [],
       rows: [],
-      error: 'Failed to parse XML response',
+      error: `Failed to parse XML response: ${
+        parseError instanceof Error ? parseError.message : String(parseError)
+      }`,
     } as any;
   }
+}
+
+/**
+ * Pull the human-readable reason out of an ADT `<exc:exception>` body.
+ *
+ * The Data Preview endpoint answers a rejected statement with a precise
+ * diagnosis — `"UP" is invalid here (due to grammar).` — and losing it leaves
+ * the caller staring at a bare HTTP status with no way to tell a typo from an
+ * unsupported construct.
+ */
+function extractSapErrorMessage(error: any): string | undefined {
+  const data = error?.response?.data;
+  if (!data) return undefined;
+
+  const raw = typeof data === 'string' ? data : String(data);
+  if (!raw.includes('exception')) return undefined;
+
+  try {
+    const parsed = xmlParser.parse(raw);
+    const exception = parsed?.exception ?? parsed?.['exc:exception'];
+    const message = exception?.message ?? exception?.localizedMessage;
+    const text =
+      typeof message === 'object' ? message?.['#text'] : (message as string);
+    return typeof text === 'string' && text.trim() ? text.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * SAP rewrites the submitted statement, appending its own INTO and UP TO
+ * clauses. A caller-supplied clause of either kind therefore arrives as a
+ * duplicate, and SAP reports it as a grammar error that says nothing about the
+ * real cause. Recognise that shape and explain it.
+ */
+function hintForSapError(
+  message: string,
+  sqlQuery: string,
+): string | undefined {
+  if (!/invalid here|due to grammar/i.test(message)) return undefined;
+
+  if (/\bINTO\b/i.test(sqlQuery)) {
+    return 'Your query contains an INTO clause. SAP appends "INTO TABLE @DATA(LT_RESULT)" itself — remove yours.';
+  }
+  if (/\bUP\s+TO\b/i.test(sqlQuery)) {
+    return 'Your query contains an UP TO ... ROWS clause. SAP appends "UP TO <row_number> ROWS" itself — remove yours and use the row_number parameter.';
+  }
+  return 'SAP appends "INTO TABLE @DATA(LT_RESULT) UP TO <row_number> ROWS ." to the statement. Note that ABAP SQL requires alias~column and spaces inside function parentheses, e.g. SUBSTRING( col, 1, 4 ).';
 }
 
 /**
@@ -184,9 +301,22 @@ export async function handleGetSqlQuery(context: HandlerContext, args: any) {
     logger?.info(`Executing SQL query (rows=${rowNumber})`);
 
     const client = createAdtClient(connection, logger);
-    const response = await client
-      .getUtils()
-      .getSqlQuery({ sql_query: sqlQuery, row_number: rowNumber });
+
+    let response: any;
+    try {
+      response = await client
+        .getUtils()
+        .getSqlQuery({ sql_query: sqlQuery, row_number: rowNumber });
+    } catch (requestError: any) {
+      // SAP's own diagnosis is far more useful than the transport-level
+      // failure wrapping it, so surface that instead of discarding the body.
+      const sapMessage = extractSapErrorMessage(requestError);
+      if (!sapMessage) throw requestError;
+
+      const hint = hintForSapError(sapMessage, sqlQuery);
+      logger?.error(`SQL query rejected by SAP: ${sapMessage}`);
+      return return_error(hint ? `${sapMessage} ${hint}` : sapMessage);
+    }
 
     if (response.status === 200 && response.data) {
       logger?.info('SQL query request completed successfully');


### PR DESCRIPTION
## The bug

SAP emits an empty cell in the data preview payload as a **self-closing** `<dataPreview:data/>`, not as `<dataPreview:data></dataPreview:data>`.

The regex in `parseSqlQueryXml` does not match the self-closing form:

```
/<dataPreview:data[^>]*>(.*?)<\/dataPreview:data>/g
```

So those cells are dropped, the column's array comes back short, and **every value below the first empty one moves up a row** — silently attributing data to the wrong record. Nothing errors; the result just looks plausible and is wrong.

## Reproduction

On a 7.5x system:

```sql
SELECT FIELDNAME, CHECKTABLE FROM DD03L WHERE TABNAME = 'E070'
```

Eight of the nine `CHECKTABLE` cells are empty. The single real value belongs to `STRKORR` (row 9):

| FIELDNAME | CHECKTABLE (before) | CHECKTABLE (after) |
|---|---|---|
| AS4USER | **E070** ❌ | `""` |
| … | null | `""` |
| STRKORR | null ❌ | **E070** |

`GetTableContents` imports the same parser and was equally affected.

## The fix

Rewritten with `XMLParser`, already a dependency. Also included, each verified by a test:

- Empty strings and `"0"` are preserved instead of becoming `null` (`??`, not `||`).
- NUMC values keep their leading zeros (`parseTagValue: false`), so a key like `"0001"` no longer decays to the number `1`.
- XML entities are decoded.
- Duplicate column names get a `_2`/`_3` suffix instead of overwriting each other, reported back as `columns[].key`.
- Columns of differing length raise a warning rather than producing a misaligned table that looks fine.

## Error reporting

The handler discarded SAP's `<exc:exception>` body and reported only the HTTP status. It now surfaces SAP's own message.

Worth knowing: SAP appends `INTO TABLE @DATA(LT_RESULT) UP TO n ROWS .` to the submitted statement, so a caller-supplied `INTO` or `UP TO` arrives as a duplicate and is rejected with a grammar error that says nothing about the real cause. The response now echoes `executed_query`, and the hint explains the collision.

## Tests

17 unit tests in `src/__tests__/unit/parseSqlQueryXml.test.ts`. The first is built on a verbatim capture of the payload above, so the regression is pinned to real server output rather than a hand-written fixture.

`tsc` clean.
