### PR TITLE
fix(paths): split AUTH_BROKER_PATH per platform

### DIFF
--- a/src/__tests__/lib/platformPaths.test.ts
+++ b/src/__tests__/lib/platformPaths.test.ts
@@ -1,0 +1,71 @@
+/**
+ * AUTH_BROKER_PATH is split into a list of base paths. The separator has to
+ * depend on the platform: a Windows absolute path carries a colon after its
+ * drive letter, so splitting on ':' there tears every path in two.
+ *
+ * The assertions count the paths produced rather than comparing them, because
+ * `path.resolve` normalises differently on each platform and the test would
+ * otherwise pass or fail depending on where CI happens to run.
+ */
+
+import { getPlatformPaths } from '../../lib/stores/platformPaths';
+
+describe('getPlatformPaths with AUTH_BROKER_PATH', () => {
+  const realPlatform = process.platform;
+  const realEnv = process.env.AUTH_BROKER_PATH;
+
+  const pretendPlatform = (value: NodeJS.Platform) => {
+    Object.defineProperty(process, 'platform', {
+      value,
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    pretendPlatform(realPlatform);
+    if (realEnv === undefined) {
+      delete process.env.AUTH_BROKER_PATH;
+    } else {
+      process.env.AUTH_BROKER_PATH = realEnv;
+    }
+  });
+
+  it('keeps a Windows absolute path whole', () => {
+    pretendPlatform('win32');
+    process.env.AUTH_BROKER_PATH = 'D:\\Users\\dev\\mcp-abap-adt';
+
+    // One path from the variable, plus the cwd fallback. Splitting on ':' as
+    // well would yield "D" and "\Users\dev\mcp-abap-adt" — two entries, the
+    // second resolving against whatever drive the process happens to be on.
+    expect(getPlatformPaths(undefined, 'sessions')).toHaveLength(2);
+  });
+
+  it('still separates several Windows paths on the semicolon', () => {
+    pretendPlatform('win32');
+    process.env.AUTH_BROKER_PATH = 'D:\\one;E:\\two';
+
+    expect(getPlatformPaths(undefined, 'sessions')).toHaveLength(3);
+  });
+
+  it('separates Unix paths on the colon', () => {
+    pretendPlatform('linux');
+    process.env.AUTH_BROKER_PATH = '/opt/one:/opt/two';
+
+    expect(getPlatformPaths(undefined, 'sessions')).toHaveLength(3);
+  });
+
+  it('still accepts a semicolon on Unix', () => {
+    // Kept working so an existing configuration does not break.
+    pretendPlatform('linux');
+    process.env.AUTH_BROKER_PATH = '/opt/one;/opt/two';
+
+    expect(getPlatformPaths(undefined, 'sessions')).toHaveLength(3);
+  });
+
+  it('ignores empty entries left by a trailing separator', () => {
+    pretendPlatform('win32');
+    process.env.AUTH_BROKER_PATH = 'D:\\one;;';
+
+    expect(getPlatformPaths(undefined, 'sessions')).toHaveLength(2);
+  });
+});

--- a/src/lib/stores/platformPaths.ts
+++ b/src/lib/stores/platformPaths.ts
@@ -62,9 +62,13 @@ export function getPlatformPaths(
   // AUTH_BROKER_PATH is ALWAYS a base path - we add subfolder to it
   const envPath = process.env.AUTH_BROKER_PATH;
   if (envPath) {
-    // Support both colon (Unix) and semicolon (Windows) separators
+    // Only semicolon separates paths on Windows. Splitting on ':' as well
+    // tears an absolute path in two at its drive letter: "D:\tools\project"
+    // becomes "D" and "\tools\project", the second resolving against
+    // whatever drive the process is on — a bogus directory added beside the
+    // real one, or no match at all when run from another drive.
     const envPaths = envPath
-      .split(/[:;]/)
+      .split(isWindows ? /;/ : /[:;]/)
       .map((p) => p.trim())
       .filter((p) => p.length > 0);
     paths.push(


### PR DESCRIPTION
## The problem

A Windows absolute path carries a colon after its drive letter, so splitting `AUTH_BROKER_PATH` on both `:` and `;` tears every path in two.

`D:\tools\project` becomes `D` and `\tools\project`. The second resolves against whatever drive the process happens to be on.

On that same drive it is quiet rather than fatal — the real directory is still found, with a bogus one reported beside it — which is why it can sit unnoticed. Run from another drive, the directory is simply not found and any named system definitions under it are invisible, with no error to explain why.

## The fix

The comment above the split already described the intended behaviour:

```
// Support both colon (Unix) and semicolon (Windows) separators
```

but the code applied both separators everywhere. `isWindows` is already computed at the top of the same function, so the change is to use it:

```ts
.split(isWindows ? /;/ : /[:;]/)
```

Unix keeps accepting both separators, so an existing configuration that used `;` there does not break.

## Tests

Adds the first tests for `getPlatformPaths`. They count the paths produced rather than comparing them: `path.resolve` normalises differently per platform, and a comparison would pass or fail depending on where CI runs.

Three of the five cases fail against the unfixed code.

## How it turned up

Setting `AUTH_BROKER_PATH` to a project directory on Windows so that the server and its named system definitions live together. `ListSystems` reported two `sessions` directories where one was expected — the real one, and one assembled from the fragment after the drive letter.
